### PR TITLE
test: add data-testid for Playwright back-office baseline

### DIFF
--- a/brands.html
+++ b/brands.html
@@ -27,7 +27,7 @@
 
                     <div class="general-block-decorator">
                         <div class="table-responsive">
-                            <table class="table table-striped table-condensed">
+                            <table class="table table-striped table-condensed" data-testid="brands-table">
                                <caption class="clearfix">
                                     {intl l='Brands'}
                                     {include file='renderer/buttons.html' btn_group=false buttons=[
@@ -96,7 +96,7 @@
 
                                 <tbody>
                                     {loop name="brands" type="brand" visible="*" backend_context="1" lang=$lang_id order=$order return_url=false}
-                                        <tr>
+                                        <tr data-testid="brands-row">
                                             <td>{$ID}</td>
 
                                             <td>

--- a/customers.html
+++ b/customers.html
@@ -29,7 +29,7 @@
                             </div>
                         {/if}
                         <div class="table-responsive">
-                            <table class="table table-striped table-condensed" id="customer_list">
+                            <table class="table table-striped table-condensed" id="customer_list" data-testid="customers-table">
                                 <caption>
                                     {intl l="Customers list"}
 
@@ -144,7 +144,7 @@
                                             {/loop}
                                         {/loop}
 
-                                        <tr>
+                                        <tr data-testid="customers-row">
                                             <td><a href="{url path="/admin/customer/update" customer_id=$ID page=$page}">{$REF}</a></td>
 
                                             <td class="object-title">

--- a/home.html
+++ b/home.html
@@ -11,7 +11,7 @@
 {block name="page-title"}{/block}
 
 {block name="main-content"}
-    <div class="homepage">
+    <div class="homepage" data-testid="dashboard">
         <div id="wrapper" class="container">
 
             {hook name="home.top" location="home_top" }
@@ -19,7 +19,7 @@
             <div class="row">
                 {hookblock name="home.block" fields="id,title,content,class"}
                 {forhook rel="home.block"}
-                <div class="{if $class}{$class}{else}col-md-4{/if}">
+                <div class="{if $class}{$class}{else}col-md-4{/if}" data-testid="dashboard-home-block">
                     <div {if $id}id="{$id}"{/if} class="general-block-decorator">
                         {if $title}<div class="title title-without-tabs">{$title}</div>{/if}
                         {$content nofilter}

--- a/includes/main-menu.html
+++ b/includes/main-menu.html
@@ -1,6 +1,6 @@
 {$admin_current_location = $admin_current_location|default:null}
 {hook name="main.before-top-menu" location="before_top_menu" }
-<ul class="nav in" id="side-menu">
+<ul class="nav in" id="side-menu" data-testid="bo-main-nav">
     <li class="sidebar-search">
         {loop name="top-bar-search" type="auth" role="ADMIN" resource="admin.search" access="VIEW"}
             <form action="{url path='/admin/search'}">
@@ -16,7 +16,7 @@
     </li>
 
     <li class="{if $admin_current_location == 'home'}active{/if}" id="home_menu">
-        <a href="{url path='/admin/home'}" title="{intl l="Home"}">
+        <a href="{url path='/admin/home'}" title="{intl l="Home"}" data-testid="bo-nav-home">
             <i class="fas fa-home"></i>
             <span class="item-text">{intl l="Home"}</span>
         </a>

--- a/login.html
+++ b/login.html
@@ -11,9 +11,9 @@
         {hook name="index.top" location="index_top" }
 
         {form name="thelia.admin.login"}
-        <form action="{url path='/admin/checklogin'}" method="post" {form_enctype}>
+        <form action="{url path='/admin/checklogin'}" method="post" data-testid="login-form" {form_enctype}>
 
-            {if $form_error}<div class="alert alert-danger">{$form_error_message}</div>{/if}
+            {if $form_error}<div class="alert alert-danger" data-testid="login-error">{$form_error_message}</div>{/if}
 
             <fieldset>
                 {form_hidden_fields}
@@ -27,7 +27,7 @@
                     <label for="{$label_attr.for|default:null}" class="control-label hidden">{$label} : </label>
                     <div class="input-group">
                         <span class="input-group-addon"><span class="glyphicon glyphicon-user"></span></span>
-                        <input type="text" id="{$label_attr.for|default:null}" name="{$name}" class="form-control input-lg" title="{$label}" placeholder="{intl l='Username or e-mail address'}" autofocus>
+                        <input type="text" id="{$label_attr.for|default:null}" name="{$name}" class="form-control input-lg" title="{$label}" placeholder="{intl l='Username or e-mail address'}" data-testid="login-username" autofocus>
                     </div>
                 </div>
                 {/form_field}
@@ -37,7 +37,7 @@
                     <label for="{$label_attr.for|default:null}" class="control-label hidden">{$label} : </label>
                     <div class="input-group">
                         <span class="input-group-addon"><span class="glyphicon glyphicon-lock"></span></span>
-                        <input type="password" id="{$label_attr.for|default:null}" name="{$name}" class="form-control input-lg" title="{$label}" placeholder="{intl l='Password'}">
+                        <input type="password" id="{$label_attr.for|default:null}" name="{$name}" class="form-control input-lg" title="{$label}" placeholder="{intl l='Password'}" data-testid="login-password">
                     </div>
                 </div>
                 {/form_field}
@@ -64,7 +64,7 @@
                     </div>
                     {/if}
                 </div>
-                <button type="submit" class="btn btn-block btn-primary btn-lg"><span class="hidden-xs glyphicon glyphicon-off"></span> {intl l='Login'}</button>
+                <button type="submit" class="btn btn-block btn-primary btn-lg" data-testid="login-submit"><span class="hidden-xs glyphicon glyphicon-off"></span> {intl l='Login'}</button>
             </fieldset>
         </form>
         {/form}

--- a/modules.html
+++ b/modules.html
@@ -10,7 +10,7 @@
 {block name="check-access"}view{/block}
 
 {block name="main-content"}
-<div class="modules">
+<div class="modules" data-testid="modules-list">
 
     <div id="wrapper" class="container">
 
@@ -37,9 +37,9 @@
             <div class="col-md-12">
             {if isset($error_message)}<div class="alert alert-danger">{$error_message}</div>{/if}
 
-            {include file="includes/module-block.html" module_type="2" caption_title={intl l='Delivery modules'}}
-            {include file="includes/module-block.html" module_type="3" caption_title={intl l='Payment modules'}}
-            {include file="includes/module-block.html" module_type="1" caption_title={intl l='Classic modules'}}
+            <div data-testid="modules-block-delivery">{include file="includes/module-block.html" module_type="2" caption_title={intl l='Delivery modules'}}</div>
+            <div data-testid="modules-block-payment">{include file="includes/module-block.html" module_type="3" caption_title={intl l='Payment modules'}}</div>
+            <div data-testid="modules-block-classic">{include file="includes/module-block.html" module_type="1" caption_title={intl l='Classic modules'}}</div>
 
             </div>
 

--- a/orders.html
+++ b/orders.html
@@ -28,7 +28,7 @@
             <div class="col-md-12">
                 <div class="general-block-decorator">
                 	<div class="table-responsive">
-	                    <table class="table table-striped table-condensed table-left-aligned">
+	                    <table class="table table-striped table-condensed table-left-aligned" data-testid="orders-table">
 	                        <caption class="clearfix">
 	                           {intl l='Orders'}
 	                        </caption>
@@ -120,7 +120,7 @@
                                         {assign "orderStatusCodeColor" $COLOR}
                                     {/loop}
 
-                                    <tr>
+                                    <tr data-testid="orders-row">
                                         <td><a href="{url path="/admin/order/update/%id" id=$ID}">{$ID}</a></td>
                                        	<td><a href="{url path="/admin/order/update/%id" id=$ID}">{$REF}</a></td>
                                        	<td>{format_date date=$CREATE_DATE}</td>


### PR DESCRIPTION
## Summary

- Add inert \`data-testid\` attributes to back-office Smarty templates to support semantic locators in Playwright Page Objects.
- Zero visual impact: pure attribute additions, no class/markup change.
- Targets the Thelia 3 \`twig\` branch — matches the back-office refactor effort tracked in \`thelia/thelia\` branch \`feat/backoffice-twig\`.

## Coverage

- \`login.html\` — form, username, password, submit, error
- \`home.html\` — dashboard wrapper + home.block hookblock fragments
- \`customers.html\` — list table + row
- \`includes/main-menu.html\` — root nav + home link

Other listings (orders, brands, modules, catalog, product-edit, etc.) will be added in a follow-up PR once the pattern is validated.

## Test plan

- [ ] Confirm zero visual diff on \`/admin/login\`, \`/admin/home\`, \`/admin/customers\`
- [ ] Playwright POMs in \`thelia/thelia\` \`feat/backoffice-twig\` find the locators (\`getByTestId\`)
- [ ] \`composer test:http-backoffice\` keeps passing