### PR TITLE
feat: import admin bundle (controllers, forms, routing, config)

### DIFF
--- a/BackOfficeDefaultBundle.php
+++ b/BackOfficeDefaultBundle.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackOfficeDefaultBundle;
+
+use BackOfficeDefaultBundle\DependencyInjection\Compiler\RegisterAdminFormsPass;
+use BackOfficeDefaultBundle\Routing\BackOfficeDefaultAttributeLoader;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
+use Symfony\Component\Routing\Loader\XmlFileLoader;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+final class BackOfficeDefaultBundle extends AbstractBundle
+{
+    public const ACTIVE_TEMPLATE_NAME = 'default';
+
+    public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
+    {
+        $services = $container->services();
+
+        $services
+            ->defaults()
+            ->autowire()
+            ->autoconfigure();
+
+        $services
+            ->load('Thelia\\Controller\\Admin\\', __DIR__.'/Controller/Admin/');
+
+        $services
+            ->load('Thelia\\Form\\', __DIR__.'/Form/');
+
+        $services
+            ->set('bo_default.routing.attribute_loader', BackOfficeDefaultAttributeLoader::class)
+            ->public()
+            ->tag('routing.loader', ['priority' => 254]);
+
+        $routingPath = $this->getRoutingPath();
+
+        $services
+            ->set('router.fileLocator', FileLocator::class)
+            ->args([$routingPath])
+            ->public();
+
+        $services
+            ->set('router.xmlLoader', XmlFileLoader::class)
+            ->args([service('router.fileLocator')]);
+
+        $services
+            ->set('router.admin', (string) $builder->getParameter('router.class'))
+            ->args([
+                service('router.xmlLoader'),
+                'admin.xml',
+                [
+                    'cache_dir' => '%kernel.cache_dir%',
+                    'debug' => '%kernel.debug%',
+                ],
+                service('request.context'),
+            ])
+            ->tag('router.register', ['priority' => 0])
+            ->public();
+    }
+
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new RegisterAdminFormsPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION);
+    }
+
+    private function getRoutingPath(): string
+    {
+        return __DIR__.'/Config/Resources/routing';
+    }
+}

--- a/Config/Resources/parameters/forms_admin.php
+++ b/Config/Resources/parameters/forms_admin.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+use Thelia\Form\AddressCreateForm;
+use Thelia\Form\AddressUpdateForm;
+use Thelia\Form\AdminCreatePassword;
+use Thelia\Form\AdministratorCreationForm;
+use Thelia\Form\AdministratorModificationForm;
+use Thelia\Form\AdminLogin;
+use Thelia\Form\AdminLostPassword;
+use Thelia\Form\Area\AreaCountryForm;
+use Thelia\Form\Area\AreaCreateForm;
+use Thelia\Form\Area\AreaDeleteCountryForm;
+use Thelia\Form\Area\AreaModificationForm;
+use Thelia\Form\Area\AreaPostageForm;
+use Thelia\Form\AttributeAvCreationForm;
+use Thelia\Form\AttributeCreationForm;
+use Thelia\Form\AttributeModificationForm;
+use Thelia\Form\Brand\BrandCreationForm;
+use Thelia\Form\Brand\BrandDocumentModification;
+use Thelia\Form\Brand\BrandImageModification;
+use Thelia\Form\Brand\BrandModificationForm;
+use Thelia\Form\Cache\AssetsFlushForm;
+use Thelia\Form\Cache\CacheFlushForm;
+use Thelia\Form\Cache\ImagesAndDocumentsCacheFlushForm;
+use Thelia\Form\CategoryCreationForm;
+use Thelia\Form\CategoryDocumentModification;
+use Thelia\Form\CategoryImageModification;
+use Thelia\Form\CategoryModificationForm;
+use Thelia\Form\ConfigCreationForm;
+use Thelia\Form\ConfigModificationForm;
+use Thelia\Form\ConfigStoreForm;
+use Thelia\Form\ContentCreationForm;
+use Thelia\Form\ContentDocumentModification;
+use Thelia\Form\ContentImageModification;
+use Thelia\Form\ContentModificationForm;
+use Thelia\Form\CountryCreationForm;
+use Thelia\Form\CountryModificationForm;
+use Thelia\Form\CouponCreationForm;
+use Thelia\Form\CurrencyCreationForm;
+use Thelia\Form\CurrencyModificationForm;
+use Thelia\Form\CustomerCreateForm;
+use Thelia\Form\CustomerUpdateForm;
+use Thelia\Form\ExportForm;
+use Thelia\Form\FeatureAvCreationForm;
+use Thelia\Form\FeatureCreationForm;
+use Thelia\Form\FeatureModificationForm;
+use Thelia\Form\FolderCreationForm;
+use Thelia\Form\FolderDocumentModification;
+use Thelia\Form\FolderImageModification;
+use Thelia\Form\FolderModificationForm;
+use Thelia\Form\HookCreationForm;
+use Thelia\Form\HookModificationForm;
+use Thelia\Form\ImportForm;
+use Thelia\Form\Lang\LangCreateForm;
+use Thelia\Form\Lang\LangDefaultBehaviorForm;
+use Thelia\Form\Lang\LangUpdateForm;
+use Thelia\Form\Lang\LangUrlForm;
+use Thelia\Form\MailingSystemModificationForm;
+use Thelia\Form\MessageCreationForm;
+use Thelia\Form\MessageModificationForm;
+use Thelia\Form\MessageSendSampleForm;
+use Thelia\Form\ModuleHookCreationForm;
+use Thelia\Form\ModuleHookModificationForm;
+use Thelia\Form\ModuleImageModification;
+use Thelia\Form\ModuleInstallForm;
+use Thelia\Form\ModuleModificationForm;
+use Thelia\Form\OrderStatus\OrderStatusCreationForm;
+use Thelia\Form\OrderStatus\OrderStatusModificationForm;
+use Thelia\Form\OrderUpdateAddress;
+use Thelia\Form\ProductCloneForm;
+use Thelia\Form\ProductCombinationGenerationForm;
+use Thelia\Form\ProductCreationForm;
+use Thelia\Form\ProductDefaultSaleElementUpdateForm;
+use Thelia\Form\ProductDocumentModification;
+use Thelia\Form\ProductImageModification;
+use Thelia\Form\ProductModificationForm;
+use Thelia\Form\ProductSaleElementUpdateForm;
+use Thelia\Form\ProfileCreationForm;
+use Thelia\Form\ProfileModificationForm;
+use Thelia\Form\ProfileUpdateModuleAccessForm;
+use Thelia\Form\ProfileUpdateResourceAccessForm;
+use Thelia\Form\Sale\SaleCreationForm;
+use Thelia\Form\Sale\SaleModificationForm;
+use Thelia\Form\SeoForm;
+use Thelia\Form\ShippingZone\ShippingZoneAddArea;
+use Thelia\Form\ShippingZone\ShippingZoneRemoveArea;
+use Thelia\Form\State\StateCreationForm;
+use Thelia\Form\State\StateModificationForm;
+use Thelia\Form\SystemLogConfigurationForm;
+use Thelia\Form\TaxCreationForm;
+use Thelia\Form\TaxModificationForm;
+use Thelia\Form\TaxRuleCreationForm;
+use Thelia\Form\TaxRuleModificationForm;
+use Thelia\Form\TaxRuleTaxListUpdateForm;
+use Thelia\Form\TemplateCreationForm;
+use Thelia\Form\TemplateModificationForm;
+use Thelia\Form\TranslationsCustomerTitleForm;
+
+return [
+    // Common admin forms (legacy keys)
+    'thelia.order.update.address' => OrderUpdateAddress::class,
+    'thelia.shopping_zone_area' => ShippingZoneAddArea::class,
+    'thelia.shipping_zone_area' => ShippingZoneAddArea::class,
+    'thelia.shopping_zone_remove_area' => ShippingZoneRemoveArea::class,
+    'thelia.lang.update' => LangUpdateForm::class,
+    'thelia.lang.create' => LangCreateForm::class,
+    'thelia.lang.defaultBehavior' => LangDefaultBehaviorForm::class,
+    'thelia.lang.url' => LangUrlForm::class,
+    'thelia.configuration.store' => ConfigStoreForm::class,
+    'thelia.system-logs.configuration' => SystemLogConfigurationForm::class,
+    'thelia.cache.flush' => CacheFlushForm::class,
+    'thelia.assets.flush' => AssetsFlushForm::class,
+    'thelia.images-and-documents-cache.flush' => ImagesAndDocumentsCacheFlushForm::class,
+    'thelia.export' => ExportForm::class,
+    'thelia.import' => ImportForm::class,
+
+    // Backend forms
+    'thelia.admin.login' => AdminLogin::class,
+    'thelia.admin.lostpassword' => AdminLostPassword::class,
+    'thelia.admin.createpassword' => AdminCreatePassword::class,
+    'thelia.admin.seo' => SeoForm::class,
+    'thelia.admin.product_sale_element.update' => ProductSaleElementUpdateForm::class,
+    'thelia.admin.product_default_sale_element.update' => ProductDefaultSaleElementUpdateForm::class,
+    'thelia.admin.product_combination.build' => ProductCombinationGenerationForm::class,
+    'thelia.admin.product.deletion' => ProductModificationForm::class,
+    'thelia.admin.attributeav.creation' => AttributeAvCreationForm::class,
+    'thelia.admin.attributeav.modification' => AttributeAvCreationForm::class,
+    'thelia.admin.featureav.creation' => FeatureAvCreationForm::class,
+    'thelia.admin.taxrule.modification' => TaxRuleModificationForm::class,
+    'thelia.admin.taxrule.taxlistupdate' => TaxRuleTaxListUpdateForm::class,
+    'thelia.admin.taxrule.add' => TaxRuleCreationForm::class,
+    'thelia.admin.tax.add' => TaxCreationForm::class,
+    'thelia.admin.profile.add' => ProfileCreationForm::class,
+    'thelia.admin.profile.resource-access.modification' => ProfileUpdateResourceAccessForm::class,
+    'thelia.admin.profile.module-access.modification' => ProfileUpdateModuleAccessForm::class,
+    'thelia.admin.administrator.add' => AdministratorCreationForm::class,
+    'thelia.admin.administrator.update' => AdministratorModificationForm::class,
+    'thelia.admin.mailing-system.update' => MailingSystemModificationForm::class,
+    'thelia.admin.area.delete.country' => AreaDeleteCountryForm::class,
+    'thelia.admin.message.send-sample' => MessageSendSampleForm::class,
+    'thelia.admin.module-hook.creation' => ModuleHookCreationForm::class,
+    'thelia.admin.module-hook.modification' => ModuleHookModificationForm::class,
+    'thelia.admin.order-status.creation' => OrderStatusCreationForm::class,
+    'thelia.admin.order-status.modification' => OrderStatusModificationForm::class,
+    'thelia.admin.customer.create' => CustomerCreateForm::class,
+    'thelia.admin.customer.update' => CustomerUpdateForm::class,
+    'thelia.admin.address.create' => AddressCreateForm::class,
+    'thelia.admin.address.update' => AddressUpdateForm::class,
+    'thelia.admin.category.creation' => CategoryCreationForm::class,
+    'thelia.admin.category.modification' => CategoryModificationForm::class,
+    'thelia.admin.category.image.modification' => CategoryImageModification::class,
+    'thelia.admin.category.document.modification' => CategoryDocumentModification::class,
+    'thelia.admin.product.creation' => ProductCreationForm::class,
+    'thelia.admin.product.modification' => ProductModificationForm::class,
+    'thelia.admin.product.clone' => ProductCloneForm::class,
+    'thelia.admin.product.combination.generation' => ProductCombinationGenerationForm::class,
+    'thelia.admin.product.image.modification' => ProductImageModification::class,
+    'thelia.admin.product.document.modification' => ProductDocumentModification::class,
+    'thelia.admin.product.sale_elements.update' => ProductSaleElementUpdateForm::class,
+    'thelia.admin.product.sale_elements.default_update' => ProductDefaultSaleElementUpdateForm::class,
+    'thelia.admin.folder.creation' => FolderCreationForm::class,
+    'thelia.admin.folder.modification' => FolderModificationForm::class,
+    'thelia.admin.folder.image.modification' => FolderImageModification::class,
+    'thelia.admin.folder.document.modification' => FolderDocumentModification::class,
+    'thelia.admin.content.creation' => ContentCreationForm::class,
+    'thelia.admin.content.modification' => ContentModificationForm::class,
+    'thelia.admin.content.image.modification' => ContentImageModification::class,
+    'thelia.admin.content.document.modification' => ContentDocumentModification::class,
+    'thelia.admin.brand.creation' => BrandCreationForm::class,
+    'thelia.admin.brand.modification' => BrandModificationForm::class,
+    'thelia.admin.brand.image.modification' => BrandImageModification::class,
+    'thelia.admin.brand.document.modification' => BrandDocumentModification::class,
+    'thelia.admin.attribute.creation' => AttributeCreationForm::class,
+    'thelia.admin.attribute.modification' => AttributeModificationForm::class,
+    'thelia.admin.attribute_av.creation' => AttributeAvCreationForm::class,
+    'thelia.admin.feature.creation' => FeatureCreationForm::class,
+    'thelia.admin.feature.modification' => FeatureModificationForm::class,
+    'thelia.admin.feature_av.creation' => FeatureAvCreationForm::class,
+    'thelia.admin.template.creation' => TemplateCreationForm::class,
+    'thelia.admin.template.modification' => TemplateModificationForm::class,
+    'thelia.admin.country.creation' => CountryCreationForm::class,
+    'thelia.admin.country.modification' => CountryModificationForm::class,
+    'thelia.admin.state.creation' => StateCreationForm::class,
+    'thelia.admin.state.modification' => StateModificationForm::class,
+    'thelia.admin.area.create' => AreaCreateForm::class,
+    'thelia.admin.area.modification' => AreaModificationForm::class,
+    'thelia.admin.area.country' => AreaCountryForm::class,
+    'thelia.admin.area.postage' => AreaPostageForm::class,
+    'thelia.admin.area.delete_country' => AreaDeleteCountryForm::class,
+    'thelia.admin.tax.creation' => TaxCreationForm::class,
+    'thelia.admin.tax.modification' => TaxModificationForm::class,
+    'thelia.admin.tax_rule.creation' => TaxRuleCreationForm::class,
+    'thelia.admin.tax_rule.modification' => TaxRuleModificationForm::class,
+    'thelia.admin.tax_rule.tax_list_update' => TaxRuleTaxListUpdateForm::class,
+    'thelia.admin.profile.creation' => ProfileCreationForm::class,
+    'thelia.admin.profile.modification' => ProfileModificationForm::class,
+    'thelia.admin.profile.resource.access.modification' => ProfileUpdateResourceAccessForm::class,
+    'thelia.admin.profile.module.access.modification' => ProfileUpdateModuleAccessForm::class,
+    'thelia.admin.administrator.creation' => AdministratorCreationForm::class,
+    'thelia.admin.administrator.modification' => AdministratorModificationForm::class,
+    'thelia.admin.currency.creation' => CurrencyCreationForm::class,
+    'thelia.admin.currency.modification' => CurrencyModificationForm::class,
+    'thelia.admin.coupon.creation' => CouponCreationForm::class,
+    'thelia.admin.order_status.creation' => OrderStatusCreationForm::class,
+    'thelia.admin.order_status.modification' => OrderStatusModificationForm::class,
+    'thelia.admin.sale.creation' => SaleCreationForm::class,
+    'thelia.admin.sale.modification' => SaleModificationForm::class,
+    'thelia.admin.module.modification' => ModuleModificationForm::class,
+    'thelia.admin.module.install' => ModuleInstallForm::class,
+    'thelia.admin.module.image.modification' => ModuleImageModification::class,
+    'thelia.admin.hook.creation' => HookCreationForm::class,
+    'thelia.admin.hook.modification' => HookModificationForm::class,
+    'thelia.admin.module_hook.creation' => ModuleHookCreationForm::class,
+    'thelia.admin.module_hook.modification' => ModuleHookModificationForm::class,
+    'thelia.admin.message.creation' => MessageCreationForm::class,
+    'thelia.admin.message.modification' => MessageModificationForm::class,
+    'thelia.admin.message.send' => MessageSendSampleForm::class,
+    'thelia.admin.mailing.modification' => MailingSystemModificationForm::class,
+    'thelia.admin.config.creation' => ConfigCreationForm::class,
+    'thelia.admin.config.modification' => ConfigModificationForm::class,
+    'thelia.admin.translations.customer_title' => TranslationsCustomerTitleForm::class,
+];

--- a/Config/Resources/routing/admin.xml
+++ b/Config/Resources/routing/admin.xml
@@ -1,0 +1,1592 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="admin" path="/admin">
+      <default key="_controller">Thelia\Controller\Admin\AdminController::indexAction</default>
+      <default key="not-logged">1</default>
+    </route>
+    <route id="admin.home" path="/admin/home">
+      <default key="_controller">Thelia\Controller\Admin\AdminController::indexAction</default>
+    </route>
+
+
+    <!-- Route to the administration login page -->
+    <route id="admin.login" path="/admin/login">
+        <default key="_controller">Thelia\Controller\Admin\SessionController::showLoginAction</default>
+        <default key="not-logged">1</default>
+    </route>
+
+    <route id="admin.lost-password" path="/admin/lost-password">
+        <default key="_controller">Thelia\Controller\Admin\SessionController::showLostPasswordAction</default>
+        <default key="not-logged">1</default>
+    </route>
+
+    <route id="admin.password-create" path="/admin/password-create-request" methods="POST">
+        <default key="_controller">Thelia\Controller\Admin\SessionController::passwordCreateRequestAction</default>
+        <default key="not-logged">1</default>
+    </route>
+
+    <route id="admin.password-create-success" path="/admin/password-create-request-success">
+        <default key="_controller">Thelia\Controller\Admin\SessionController::passwordCreateRequestSuccessAction</default>
+        <default key="not-logged">1</default>
+    </route>
+
+
+    <route id="admin.password-create-form" path="/admin/password-create/{token}">
+        <default key="_controller">Thelia\Controller\Admin\SessionController::displayCreateFormAction</default>
+        <requirement key="token">.*</requirement>
+        <default key="not-logged">1</default>
+    </route>
+
+    <route id="admin.password-renewed" path="/admin/password-created">
+        <default key="_controller">Thelia\Controller\Admin\SessionController::passwordCreatedAction</default>
+        <default key="not-logged">1</default>
+    </route>
+
+    <route id="admin.password-renewed-success" path="/admin/password-create-success">
+        <default key="_controller">Thelia\Controller\Admin\SessionController::passwordCreatedSuccessAction</default>
+        <default key="not-logged">1</default>
+    </route>
+
+    <route id="admin.set-email-address" path="/admin/set-email-address">
+        <default key="_controller">Thelia\Controller\Admin\AdministratorController::setEmailAction</default>
+    </route>
+
+    <!-- Route to the administration logout page -->
+    <route id="admin.logout" path="/admin/logout">
+        <default key="_controller">Thelia\Controller\Admin\SessionController::checkLogoutAction</default>
+    </route>
+
+    <!-- Route to the login check controller -->
+    <route id="admin.checklogin" path="/admin/checklogin">
+        <default key="_controller">Thelia\Controller\Admin\SessionController::checkLoginAction</default>
+        <default key="not-logged">1</default>
+    </route>
+
+    <!-- Route to the catalog controller -->
+
+    <route id="admin.catalog" path="/admin/catalog">
+        <default key="_controller">Thelia\Controller\Admin\CategoryController::defaultAction</default>
+    </route>
+
+    <!-- Route to the file controller -->
+
+    <route id="admin.image.save-ajax" path="/admin/image/type/{parentType}/{parentId}/save-ajax">
+        <default key="_controller">Thelia\Controller\Admin\FileController::saveImageAjaxAction</default>
+        <requirement key="parentType">.*</requirement>
+        <requirement key="parentId">\d+</requirement>
+    </route>
+    <route id="admin.image.form-ajax" path="/admin/image/type/{parentType}/{parentId}/form-ajax">
+        <default key="_controller">Thelia\Controller\Admin\FileController::getImageFormAjaxAction</default>
+        <requirement key="parentType">.*</requirement>
+        <requirement key="parentId">\d+</requirement>
+    </route>
+    <route id="admin.image.list-ajax" path="/admin/image/type/{parentType}/{parentId}/list-ajax">
+        <default key="_controller">Thelia\Controller\Admin\FileController::getImageListAjaxAction</default>
+        <requirement key="parentType">.*</requirement>
+        <requirement key="parentId">\d+</requirement>
+    </route>
+    <route id="admin.image.update-position" path="/admin/image/type/{parentType}/{parentId}/update-position">
+        <default key="_controller">Thelia\Controller\Admin\FileController::updateImagePositionAction</default>
+        <requirement key="parentType">.*</requirement>
+        <requirement key="parentId">\d+</requirement>
+    </route>
+    <route id="admin.image.update-title" path="/admin/image/type/{parentType}/{imageId}/update-title" methods="post">
+        <default key="_controller">Thelia\Controller\Admin\FileController::updateImageTitleAction</default>
+        <requirement key="parentType">.*</requirement>
+        <requirement key="imageId">\d+</requirement>
+    </route>
+    <route id="admin.image.toggle.process" path="/admin/image/type/{parentType}/{documentId}/toggle">
+        <default key="_controller">Thelia\Controller\Admin\FileController::toggleVisibilityImageAction</default>
+        <requirement key="parentType">.*</requirement>
+        <requirement key="documentId">\d+</requirement>
+    </route>
+    <route id="admin.image.update.view" path="/admin/image/type/{parentType}/{imageId}/update" methods="get">
+        <default key="_controller">Thelia\Controller\Admin\FileController::viewImageAction</default>
+        <requirement key="parentType">.*</requirement>
+        <requirement key="imageId">\d+</requirement>
+    </route>
+    <route id="admin.image.update.process" path="/admin/image/type/{parentType}/{imageId}/update" methods="post">
+        <default key="_controller">Thelia\Controller\Admin\FileController::updateImageAction</default>
+        <requirement key="parentType">.*</requirement>
+        <requirement key="imageId">\d+</requirement>
+    </route>
+    <route id="admin.image.delete" path="/admin/image/type/{parentType}/delete/{imageId}">
+        <default key="_controller">Thelia\Controller\Admin\FileController::deleteImageAction</default>
+        <requirement key="parentType">.*</requirement>
+        <requirement key="imageId">\d+</requirement>
+    </route>
+
+    <route id="admin.document.save-ajax" path="/admin/document/type/{parentType}/{parentId}/save-ajax">
+        <default key="_controller">Thelia\Controller\Admin\FileController::saveDocumentAjaxAction</default>
+        <requirement key="parentType">.*</requirement>
+        <requirement key="parentId">\d+</requirement>
+    </route>
+    <route id="admin.document.form-ajax" path="/admin/document/type/{parentType}/{parentId}/form-ajax">
+        <default key="_controller">Thelia\Controller\Admin\FileController::getDocumentFormAjaxAction</default>
+        <requirement key="parentType">.*</requirement>
+        <requirement key="parentId">\d+</requirement>
+    </route>
+    <route id="admin.document.list-ajax" path="/admin/document/type/{parentType}/{parentId}/list-ajax">
+        <default key="_controller">Thelia\Controller\Admin\FileController::getDocumentListAjaxAction</default>
+        <requirement key="parentType">.*</requirement>
+        <requirement key="parentId">\d+</requirement>
+    </route>
+    <route id="admin.document.update-position" path="/admin/document/type/{parentType}/{parentId}/update-position">
+        <default key="_controller">Thelia\Controller\Admin\FileController::updateDocumentPositionAction</default>
+        <requirement key="parentType">.*</requirement>
+        <requirement key="parentId">\d+</requirement>
+    </route>
+    <route id="admin.document.toggle.process" path="/admin/document/type/{parentType}/{documentId}/toggle">
+        <default key="_controller">Thelia\Controller\Admin\FileController::toggleVisibilityDocumentAction</default>
+        <requirement key="parentType">.*</requirement>
+        <requirement key="documentId">\d+</requirement>
+    </route>
+    <route id="admin.document.update.view" path="/admin/document/type/{parentType}/{documentId}/update" methods="get">
+        <default key="_controller">Thelia\Controller\Admin\FileController::viewDocumentAction</default>
+        <requirement key="parentType">.*</requirement>
+        <requirement key="documentId">\d+</requirement>
+    </route>
+    <route id="admin.document.update.process" path="/admin/document/type/{parentType}/{documentId}/update" methods="post">
+        <default key="_controller">Thelia\Controller\Admin\FileController::updateDocumentAction</default>
+        <requirement key="parentType">.*</requirement>
+        <requirement key="documentId">\d+</requirement>
+    </route>
+    <route id="admin.document.delete" path="/admin/document/type/{parentType}/delete/{documentId}">
+        <default key="_controller">Thelia\Controller\Admin\FileController::deleteDocumentAction</default>
+        <requirement key="parentType">.*</requirement>
+        <requirement key="documentId">\d+</requirement>
+    </route>
+
+    <!-- Customer rule management -->
+
+    <route id="admin.customers" path="/admin/customers">
+        <default key="_controller">Thelia\Controller\Admin\CustomerController::defaultAction</default>
+    </route>
+
+    <route id="admin.customer.update.view" path="/admin/customer/update">
+        <default key="_controller">Thelia\Controller\Admin\CustomerController::updateAction</default>
+    </route>
+
+    <route id="admin.customer.update.process" path="/admin/customer/save">
+        <default key="_controller">Thelia\Controller\Admin\CustomerController::processUpdateAction</default>
+    </route>
+
+    <route id="admin.customer.delete" path="/admin/customer/delete">
+        <default key="_controller">Thelia\Controller\Admin\CustomerController::deleteAction</default>
+    </route>
+
+    <route id="admin.customer.create" path="/admin/customer/create">
+        <default key="_controller">Thelia\Controller\Admin\CustomerController::createAction</default>
+    </route>
+
+    <!-- end Customer rule management -->
+
+    <!-- address management -->
+
+    <route id="admin.address.delete" path="/admin/address/delete" methods="post">
+        <default key="_controller">Thelia\Controller\Admin\AddressController::deleteAction</default>
+    </route>
+
+    <route id="admin.address.makeItDefault" path="/admin/address/use" methods="post">
+        <default key="_controller">Thelia\Controller\Admin\AddressController::useAddressAction</default>
+    </route>
+
+    <route id="admin.address.create" path="/admin/address/create" methods="post">
+        <default key="_controller">Thelia\Controller\Admin\AddressController::createAction</default>
+    </route>
+
+    <route id="admin.address.update.view" path="/admin/address/update">
+        <default key="_controller">Thelia\Controller\Admin\AddressController::updateAction</default>
+    </route>
+
+    <route id="admin.address.save" path="/admin/address/save">
+        <default key="_controller">Thelia\Controller\Admin\AddressController::processUpdateAction</default>
+    </route>
+
+    <!-- end address management -->
+
+    <!-- order management -->
+
+    <route id="admin.order.list" path="/admin/orders">
+        <default key="_controller">Thelia\Controller\Admin\OrderController::indexAction</default>
+    </route>
+
+    <route id="admin.order.update.view" path="/admin/order/update/{order_id}">
+        <default key="_controller">Thelia\Controller\Admin\OrderController::viewAction</default>
+        <requirement key="order_id">\d+</requirement>
+    </route>
+
+    <route id="admin.order.list.update.status" path="/admin/order/update/status">
+        <default key="_controller">Thelia\Controller\Admin\OrderController::updateStatus</default>
+    </route>
+
+    <route id="admin.order.update.status" path="/admin/order/update/{order_id}/status">
+        <default key="_controller">Thelia\Controller\Admin\OrderController::updateStatus</default>
+    </route>
+
+    <route id="admin.order.update.deliveryRef" path="/admin/order/update/{order_id}/delivery-ref">
+        <default key="_controller">Thelia\Controller\Admin\OrderController::updateDeliveryRef</default>
+    </route>
+
+    <route id="admin.order.update.address" path="/admin/order/update/{order_id}/address">
+        <default key="_controller">Thelia\Controller\Admin\OrderController::updateAddress</default>
+    </route>
+
+    <route id="admin.order.pdf.invoice" path="/admin/order/pdf/invoice/{order_id}/{browser}">
+        <default key="_controller">Thelia\Controller\Admin\OrderController::generateInvoicePdf</default>
+        <default key="browser">0</default>
+        <requirement key="browser">[0|1]</requirement>
+        <requirement key="order_id">\d+</requirement>
+    </route>
+
+    <route id="admin.order.pdf.delivery" path="/admin/order/pdf/delivery/{order_id}/{browser}">
+        <default key="_controller">Thelia\Controller\Admin\OrderController::generateDeliveryPdf</default>
+        <default key="browser">0</default>
+        <requirement key="browser">[0|1]</requirement>
+        <requirement key="order_id">\d+</requirement>
+    </route>
+
+    <!-- end order management -->
+
+    <!-- order status management -->
+
+    <route id="admin.order-status.default" path="/admin/configuration/order-status">
+        <default key="_controller">Thelia\Controller\Admin\OrderStatusController::defaultAction</default>
+    </route>
+
+    <route id="admin.order-status.create" path="/admin/configuration/order-status/create">
+        <default key="_controller">Thelia\Controller\Admin\OrderStatusController::createAction</default>
+    </route>
+
+    <route id="admin.order-status.update" path="/admin/configuration/order-status/update/{order_status_id}">
+        <default key="_controller">Thelia\Controller\Admin\OrderStatusController::updateAction</default>
+        <requirement key="order_status_id">\d+</requirement>
+    </route>
+
+    <route id="admin.order-status.save" path="/admin/configuration/order-status/save/{order_status_id}">
+        <default key="_controller">Thelia\Controller\Admin\OrderStatusController::processUpdateAction</default>
+        <requirement key="order_status_id">\d+</requirement>
+    </route>
+
+    <route id="admin.order-status.delete" path="/admin/configuration/order-status/delete">
+        <default key="_controller">Thelia\Controller\Admin\OrderStatusController::deleteAction</default>
+    </route>
+
+    <route id="admin.order-status.update-position" path="/admin/configuration/order-status/update-position">
+        <default key="_controller">Thelia\Controller\Admin\OrderStatusController::updatePositionAction</default>
+    </route>
+
+    <!-- end order status management -->
+
+    <!-- Categories management -->
+
+    <route id="admin.categories.default" path="/admin/categories">
+        <default key="_controller">Thelia\Controller\Admin\CategoryController::defaultAction</default>
+    </route>
+
+    <route id="admin.categories.create" path="/admin/categories/create">
+        <default key="_controller">Thelia\Controller\Admin\CategoryController::createAction</default>
+    </route>
+
+    <route id="admin.categories.update" path="/admin/categories/update">
+        <default key="_controller">Thelia\Controller\Admin\CategoryController::updateAction</default>
+    </route>
+
+    <route id="admin.categories.save" path="/admin/categories/save">
+        <default key="_controller">Thelia\Controller\Admin\CategoryController::processUpdateAction</default>
+    </route>
+
+    <route id="admin.categories.seo.save" path="/admin/categories/seo/save">
+        <default key="_controller">Thelia\Controller\Admin\CategoryController::processUpdateSeoAction</default>
+    </route>
+
+    <route id="admin.categories.set-default" path="/admin/categories/toggle-online">
+        <default key="_controller">Thelia\Controller\Admin\CategoryController::setToggleVisibilityAction</default>
+    </route>
+
+    <route id="admin.categories.delete" path="/admin/categories/delete">
+        <default key="_controller">Thelia\Controller\Admin\CategoryController::deleteAction</default>
+    </route>
+
+    <route id="admin.categories.update-position" path="/admin/categories/update-position">
+        <default key="_controller">Thelia\Controller\Admin\CategoryController::updatePositionAction</default>
+    </route>
+
+    <route id="admin.categories.related-content.add" path="/admin/categories/related-content/add">
+        <default key="_controller">Thelia\Controller\Admin\CategoryController::addRelatedContentAction</default>
+    </route>
+
+    <route id="admin.categories.related-picture.add" path="/admin/categories/related-picture/add">
+        <default key="_controller">Thelia\Controller\Admin\CategoryController::addRelatedPictureAction</default>
+    </route>
+
+    <route id="admin.categories.related-content.delete" path="/admin/categories/related-content/delete">
+        <default key="_controller">Thelia\Controller\Admin\CategoryController::deleteRelatedContentAction</default>
+    </route>
+
+    <route id="admin.category.available-related-content" path="/admin/category/{categoryId}/available-related-content/{folderId}.{_format}" methods="GET">
+        <default key="_controller">Thelia\Controller\Admin\CategoryController::getAvailableRelatedContentAction</default>
+        <requirement key="_format">xml|json</requirement>
+    </route>
+
+    <!--  Product Management -->
+
+    <route id="admin.products.default" path="/admin/products">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::defaultAction</default>
+    </route>
+
+    <route id="admin.products.create" path="/admin/products/create">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::createAction</default>
+    </route>
+
+    <route id="admin.products.clone" path="/admin/products/clone">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::cloneAction</default>
+    </route>
+
+    <route id="admin.products.update" path="/admin/products/update">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::updateAction</default>
+    </route>
+
+    <route id="admin.products.save" path="/admin/products/save">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::processUpdateAction</default>
+    </route>
+
+    <route id="admin.products.seo.save" path="/admin/products/seo/save">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::processUpdateSeoAction</default>
+    </route>
+
+    <route id="admin.products.set-default" path="/admin/products/toggle-online">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::setToggleVisibilityAction</default>
+    </route>
+
+    <route id="admin.products.delete" path="/admin/products/delete">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::deleteAction</default>
+    </route>
+
+    <route id="admin.products.update-position" path="/admin/products/update-position">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::updatePositionAction</default>
+    </route>
+
+    <!-- Product categories, content and accessories -->
+
+    <route id="admin.products.related.tab" path="/admin/products/related/tab">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::loadRelatedAjaxTabAction</default>
+    </route>
+
+    <route id="admin.products.related.tab.categories.search" path="/admin/products/related/tab/categories/search">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::searchCategoryAction</default>
+    </route>
+
+    <route id="admin.products.related.tab.products.search" path="/admin/products/related/tab/products/search">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::searchProductAction</default>
+    </route>
+
+    <!-- categories -->
+
+    <route id="admin.products.additional-category.add" path="/admin/products/category/add">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::addAdditionalCategoryAction</default>
+    </route>
+
+    <route id="admin.products.additional-category.delete" path="/admin/products/category/delete">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::deleteAdditionalCategoryAction</default>
+    </route>
+
+    <!--  content -->
+
+    <route id="admin.products.related-content.add" path="/admin/products/content/add">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::addRelatedContentAction</default>
+    </route>
+
+    <route id="admin.products.related-content.delete" path="/admin/products/content/delete">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::deleteRelatedContentAction</default>
+    </route>
+
+    <route id="admin.product.available-related-content" path="/admin/product/{productId}/available-content/{folderId}.{_format}" methods="GET">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::getAvailableRelatedContentAction</default>
+        <requirement key="_format">xml|json</requirement>
+    </route>
+
+    <route id="admin.product.update-content-position" path="/admin/product/update-content-position">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::updateContentPositionAction</default>
+    </route>
+
+    <route id="admin.product.calculate-price" path="/admin/product/calculate-price">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::priceCalculator</default>
+    </route>
+
+    <route id="admin.product.calculate-raw-price" path="/admin/product/calculate-raw-price">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::calculatePrice</default>
+    </route>
+
+    <route id="admin.product.load-converted-prices" path="/admin/product/load-converted-prices">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::loadConvertedPrices</default>
+    </route>
+
+    <route id="admin.product.product-sale-element-visibility" path="/admin/product/product-sale-element-visibility">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::toggleProductSaleElementVisibility</default>
+    </route>
+
+    <route id="admin.product.product-sale-element-position" path="/admin/product/product-sale-element-position">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::updateProductSalementPosition</default>
+    </route>
+
+    <!-- accessories -->
+
+    <route id="admin.products.accessories.add" path="/admin/products/accessory/add">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::addAccessoryAction</default>
+    </route>
+
+    <route id="admin.products.accessories.delete" path="/admin/products/accessory/delete">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::deleteAccessoryAction</default>
+    </route>
+
+    <route id="admin.product.accessories-content" path="/admin/product/{productId}/available-accessories/{categoryId}.{_format}" methods="GET">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::getAvailableAccessoriesAction</default>
+        <requirement key="_format">xml|json</requirement>
+    </route>
+
+    <route id="admin.product.update-accessory-position" path="/admin/product/update-accessory-position">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::updateAccessoryPositionAction</default>
+    </route>
+
+    <!--Product Features and attributes -->
+
+    <route id="admin.products.attributes.tab" path="/admin/products/attributes/tab">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::loadAttributesAjaxTabAction</default>
+    </route>
+
+    <route id="admin.products.set-product-template" path="/admin/product/{productId}/set-product-template">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::setProductTemplateAction</default>
+    </route>
+
+    <route id="admin.products.update-attributes-and-features" path="/admin/product/{productId}/update-attributes-and-features">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::updateAttributesAndFeaturesAction</default>
+    </route>
+
+    <!-- Combinations -->
+
+    <route id="admin.product.attribute-values" path="/admin/product/{productId}/attribute-values/{attributeId}.{_format}" methods="GET">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::getAttributeValuesAction</default>
+        <requirement key="_format">xml|json</requirement>
+    </route>
+
+    <route id="admin.product.add-attribute-value-to-combination" path="/admin/product/{productId}/add-attribute-value-to-combination/{attributeAvId}/{combination}.{_format}" methods="GET">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::addAttributeValueToCombinationAction</default>
+        <requirement key="_format">xml|json</requirement>
+    </route>
+
+    <route id="admin.product.combination.add" path="/admin/product/combination/add">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::addProductSaleElementAction</default>
+    </route>
+
+    <route id="admin.product.combination.delete" path="/admin/product/combination/delete">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::deleteProductSaleElementAction</default>
+    </route>
+
+    <route id="admin.product.combination.update" path="/admin/product/combinations/update">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::updateProductSaleElementsAction</default>
+    </route>
+
+    <route id="admin.product.combination.build" path="/admin/product/combination/build">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::buildCombinationsAction</default>
+    </route>
+
+    <route id="admin.product.combination.defaut-price.update" path="/admin/product/default-price/update">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::updateProductDefaultSaleElementAction</default>
+    </route>
+
+    <!-- Associate a product_sale_elements with a product document / image -->
+
+    <route id="admin.product_sale_elements.document_image_assoc" path="/admin/product_sale_elements/{pseId}/{type}/{typeId}" methods="get">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::productSaleElementsProductImageDocumentAssociation</default>
+        <requirement key="pseId">\d+</requirement>
+        <requirement key="type">.+</requirement>
+        <requirement key="typeId">\d+</requirement>
+    </route>
+
+    <route id="admin.product_sale_elements.document_image_assoc.get_assoc" path="/admin/product_sale_elements/ajax/{type}/{id}" methods="get">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::getAjaxProductSaleElementsImagesDocuments</default>
+        <requirement key="id">\d+</requirement>
+        <requirement key="type">.+</requirement>
+    </route>
+
+    <route id="admin.product.virtual_documents" path="/admin/product/virtual-documents/{productId}/{pseId}" methods="get">
+        <default key="_controller">Thelia\Controller\Admin\ProductController::getVirtualDocumentListAjaxAction</default>
+        <requirement key="productId">\d+</requirement>
+        <requirement key="pseId">\d+</requirement>
+    </route>
+
+
+    <!--  Folder routes management -->
+
+    <route id="admin.folders.default" path="/admin/folders">
+        <default key="_controller">Thelia\Controller\Admin\FolderController::defaultAction</default>
+    </route>
+
+    <route id="admin.folders.create" path="/admin/folders/create">
+        <default key="_controller">Thelia\Controller\Admin\FolderController::createAction</default>
+    </route>
+
+    <route id="admin.folders.update" path="/admin/folders/update/{folder_id}">
+        <default key="_controller">Thelia\Controller\Admin\FolderController::updateAction</default>
+        <requirement key="folder_id">\d+</requirement>
+    </route>
+
+    <route id="admin.folders.toggle-online" path="/admin/folders/toggle-online">
+        <default key="_controller">Thelia\Controller\Admin\FolderController::setToggleVisibilityAction</default>
+    </route>
+
+    <route id="admin.folders.save" path="/admin/folders/save">
+        <default key="_controller">Thelia\Controller\Admin\FolderController::processUpdateAction</default>
+    </route>
+
+    <route id="admin.folders.seo.save" path="/admin/folders/seo/save">
+        <default key="_controller">Thelia\Controller\Admin\FolderController::processUpdateSeoAction</default>
+    </route>
+
+    <route id="admin.folders.delete" path="/admin/folders/delete">
+        <default key="_controller">Thelia\Controller\Admin\FolderController::deleteAction</default>
+    </route>
+
+    <route id="admin.folders.update-position" path="/admin/folders/update-position">
+        <default key="_controller">Thelia\Controller\Admin\FolderController::updatePositionAction</default>
+    </route>
+
+    <!-- content routes management -->
+    <route id="admin.content.create" path="/admin/content/create">
+        <default key="_controller">Thelia\Controller\Admin\ContentController::createAction</default>
+    </route>
+
+    <route id="admin.content.update" path="/admin/content/update/{content_id}">
+        <default key="_controller">Thelia\Controller\Admin\ContentController::updateAction</default>
+        <requirement key="content_id">\d+</requirement>
+    </route>
+
+    <route id="admin.content.save" path="/admin/content/save">
+        <default key="_controller">Thelia\Controller\Admin\ContentController::processUpdateAction</default>
+    </route>
+
+    <route id="admin.content.seo.save" path="/admin/content/seo/save">
+        <default key="_controller">Thelia\Controller\Admin\ContentController::processUpdateSeoAction</default>
+    </route>
+
+    <route id="admin.content.update-position" path="/admin/content/update-position">
+        <default key="_controller">Thelia\Controller\Admin\ContentController::updatePositionAction</default>
+    </route>
+
+    <route id="admin.content.toggle-online" path="/admin/content/toggle-online">
+        <default key="_controller">Thelia\Controller\Admin\ContentController::setToggleVisibilityAction</default>
+    </route>
+
+    <route id="admin.content.delete" path="/admin/content/delete">
+        <default key="_controller">Thelia\Controller\Admin\ContentController::deleteAction</default>
+    </route>
+
+    <route id="admin.content.additional-folder.add" path="/admin/content/folder/add">
+        <default key="_controller">Thelia\Controller\Admin\ContentController::addAdditionalFolderAction</default>
+    </route>
+
+    <route id="admin.content.additional-folder.delete" path="/admin/content/folder/delete">
+        <default key="_controller">Thelia\Controller\Admin\ContentController::removeAdditionalFolderAction</default>
+    </route>
+
+
+    <!-- Route to the Coupon controller (process Coupon browsing) -->
+
+    <route id="admin.coupon.list" path="/admin/coupon">
+        <default key="_controller">Thelia\Controller\Admin\CouponController::browseAction</default>
+    </route>
+    <route id="admin.coupon.create" path="/admin/coupon/create">
+        <default key="_controller">Thelia\Controller\Admin\CouponController::createAction</default>
+    </route>
+    <route id="admin.coupon.update" path="/admin/coupon/update/{couponId}">
+        <default key="_controller">Thelia\Controller\Admin\CouponController::updateAction</default>
+        <requirement key="couponId">\d+</requirement>
+    </route>
+    <route id="admin.coupon.delete" path="/admin/coupon/delete">
+        <default key="_controller">Thelia\Controller\Admin\CouponController::deleteAction</default>
+    </route>
+    <route id="admin.coupon.draw.inputs.ajax" path="/admin/coupon/draw/inputs/{couponServiceId}">
+        <default key="_controller">Thelia\Controller\Admin\CouponController::getBackOfficeInputsAjaxAction</default>
+        <requirement key="couponServiceId">.*</requirement>
+    </route>
+    <route id="admin.coupon.draw.condition.summaries.ajax" path="/admin/coupon/draw/conditionsSummaries/{couponId}">
+        <default key="_controller">Thelia\Controller\Admin\CouponController::getBackOfficeConditionSummariesAjaxAction</default>
+        <requirement key="couponId">\d+</requirement>
+    </route>
+    <route id="admin.coupon.draw.condition.read.inputs.ajax" path="/admin/coupon/draw/read/conditionInputs/{conditionId}">
+        <default key="_controller">Thelia\Controller\Admin\CouponController::getConditionEmptyInputAjaxAction</default>
+        <requirement key="conditionId">.*</requirement>
+    </route>
+    <route id="admin.coupon.draw.condition.update.inputs.ajax" path="/admin/coupon/draw/update/conditionInputs/{couponId}/{conditionIndex}">
+        <default key="_controller">Thelia\Controller\Admin\CouponController::getConditionToUpdateInputAjaxAction</default>
+        <requirement key="couponId">\d+</requirement>
+        <requirement key="conditionIndex">\d+</requirement>
+    </route>
+    <route id="admin.coupon.condition.save" path="/admin/coupon/{couponId}/condition/save" methods="post">
+        <default key="_controller">Thelia\Controller\Admin\CouponController::saveConditionsAction</default>
+        <requirement key="couponId">\d+</requirement>
+    </route>
+    <route id="admin.coupon.condition.delete" path="/admin/coupon/{couponId}/condition/delete/{conditionIndex}">
+        <default key="_controller">Thelia\Controller\Admin\CouponController::deleteConditionsAction</default>
+        <requirement key="couponId">\d+</requirement>
+        <requirement key="conditionIndex">\d+</requirement>
+    </route>
+
+    <!-- Routes to the Config (system variables) controller -->
+
+    <route id="admin.configuration.index" path="/admin/configuration">
+        <default key="_controller">Thelia\Controller\Admin\ConfigurationController::indexAction</default>
+    </route>
+
+    <route id="admin.configuration.variables.default" path="/admin/configuration/variables">
+        <default key="_controller">Thelia\Controller\Admin\ConfigController::defaultAction</default>
+    </route>
+
+    <route id="admin.configuration.variables.update-values" path="/admin/configuration/variables/update-values">
+        <default key="_controller">Thelia\Controller\Admin\ConfigController::changeValuesAction</default>
+    </route>
+
+    <route id="admin.configuration.variables.create" path="/admin/configuration/variables/create">
+        <default key="_controller">Thelia\Controller\Admin\ConfigController::createAction</default>
+    </route>
+
+    <route id="admin.configuration.variables.update" path="/admin/configuration/variables/update">
+        <default key="_controller">Thelia\Controller\Admin\ConfigController::updateAction</default>
+    </route>
+
+    <route id="admin.configuration.variables.save" path="/admin/configuration/variables/save">
+        <default key="_controller">Thelia\Controller\Admin\ConfigController::processUpdateAction</default>
+    </route>
+
+    <route id="admin.configuration.variables.delete" path="/admin/configuration/variables/delete">
+        <default key="_controller">Thelia\Controller\Admin\ConfigController::deleteAction</default>
+    </route>
+
+    <!--  Routes to the ConfigStore controller -->
+
+    <route id="admin.configuration.store.default" path="/admin/configuration/store">
+        <default key="_controller">Thelia\Controller\Admin\ConfigStoreController::defaultAction</default>
+    </route>
+
+    <route id="admin.configuration.store.save" path="/admin/configuration/store/save">
+        <default key="_controller">Thelia\Controller\Admin\ConfigStoreController::saveAction</default>
+    </route>
+
+
+    <!--  Routes to the SystemLog controller -->
+
+    <route id="admin.configuration.system-logs.default" path="/admin/configuration/system-logs">
+        <default key="_controller">Thelia\Controller\Admin\SystemLogController::defaultAction</default>
+    </route>
+
+    <route id="admin.configuration.system-logs.save" path="/admin/configuration/system-logs/save">
+        <default key="_controller">Thelia\Controller\Admin\SystemLogController::saveAction</default>
+    </route>
+
+    <!-- Routes to the Messages controller -->
+
+    <route id="admin.configuration.messages.default" path="/admin/configuration/messages">
+        <default key="_controller">Thelia\Controller\Admin\MessageController::defaultAction</default>
+    </route>
+
+    <route id="admin.configuration.messages.create" path="/admin/configuration/messages/create">
+        <default key="_controller">Thelia\Controller\Admin\MessageController::createAction</default>
+    </route>
+
+    <route id="admin.configuration.messages.update" path="/admin/configuration/messages/update">
+        <default key="_controller">Thelia\Controller\Admin\MessageController::updateAction</default>
+    </route>
+
+    <route id="admin.configuration.messages.save" path="/admin/configuration/messages/save">
+        <default key="_controller">Thelia\Controller\Admin\MessageController::processUpdateAction</default>
+    </route>
+
+    <route id="admin.configuration.messages.delete" path="/admin/configuration/messages/delete">
+        <default key="_controller">Thelia\Controller\Admin\MessageController::deleteAction</default>
+    </route>
+
+    <!-- Routes to the Currencies controller -->
+
+    <route id="admin.configuration.currencies.default" path="/admin/configuration/currencies">
+        <default key="_controller">Thelia\Controller\Admin\CurrencyController::defaultAction</default>
+    </route>
+
+    <route id="admin.configuration.currencies.create" path="/admin/configuration/currencies/create">
+        <default key="_controller">Thelia\Controller\Admin\CurrencyController::createAction</default>
+    </route>
+
+    <route id="admin.configuration.currencies.update" path="/admin/configuration/currencies/update">
+        <default key="_controller">Thelia\Controller\Admin\CurrencyController::updateAction</default>
+    </route>
+
+    <route id="admin.configuration.currencies.save" path="/admin/configuration/currencies/save">
+        <default key="_controller">Thelia\Controller\Admin\CurrencyController::processUpdateAction</default>
+    </route>
+
+    <route id="admin.configuration.currencies.set-default" path="/admin/configuration/currencies/set-default">
+        <default key="_controller">Thelia\Controller\Admin\CurrencyController::setDefaultAction</default>
+    </route>
+
+    <route id="admin.configuration.currencies.set-visible" path="/admin/configuration/currencies/set-visible">
+        <default key="_controller">Thelia\Controller\Admin\CurrencyController::setVisibleAction</default>
+    </route>
+
+    <route id="admin.configuration.currencies.update-position" path="/admin/configuration/currencies/update-position">
+        <default key="_controller">Thelia\Controller\Admin\CurrencyController::updatePositionAction</default>
+    </route>
+
+    <route id="admin.configuration.currencies.update-rates" path="/admin/configuration/currencies/update-rates">
+        <default key="_controller">Thelia\Controller\Admin\CurrencyController::updateRatesAction</default>
+    </route>
+
+    <route id="admin.configuration.currencies.delete" path="/admin/configuration/currencies/delete">
+        <default key="_controller">Thelia\Controller\Admin\CurrencyController::deleteAction</default>
+    </route>
+
+
+    <!-- Product templates management -->
+
+    <route id="admin.configuration.templates.default" path="/admin/configuration/templates">
+        <default key="_controller">Thelia\Controller\Admin\TemplateController::defaultAction</default>
+    </route>
+
+    <route id="admin.configuration.templates.create" path="/admin/configuration/templates/create">
+        <default key="_controller">Thelia\Controller\Admin\TemplateController::createAction</default>
+    </route>
+
+    <route id="admin.configuration.templates.update" path="/admin/configuration/templates/update">
+        <default key="_controller">Thelia\Controller\Admin\TemplateController::updateAction</default>
+    </route>
+
+    <route id="admin.configuration.templates.save" path="/admin/configuration/templates/save">
+        <default key="_controller">Thelia\Controller\Admin\TemplateController::processUpdateAction</default>
+    </route>
+
+    <route id="admin.configuration.templates.delete" path="/admin/configuration/templates/delete">
+        <default key="_controller">Thelia\Controller\Admin\TemplateController::deleteAction</default>
+    </route>
+
+    <route id="admin.configuration.templates.duplicate" path="/admin/configuration/templates/duplicate">
+        <default key="_controller">Thelia\Controller\Admin\TemplateController::duplicateAction</default>
+    </route>
+
+    <route id="admin.configuration.templates.features.list" path="/admin/configuration/templates/features/list">
+        <default key="_controller">Thelia\Controller\Admin\TemplateController::getAjaxFeaturesAction</default>
+    </route>
+
+    <route id="admin.configuration.templates.features.add" path="/admin/configuration/templates/features/add">
+        <default key="_controller">Thelia\Controller\Admin\TemplateController::addFeatureAction</default>
+    </route>
+
+    <route id="admin.configuration.templates.features.delete" path="/admin/configuration/templates/features/delete">
+        <default key="_controller">Thelia\Controller\Admin\TemplateController::deleteFeatureAction</default>
+    </route>
+
+    <route id="admin.configuration.templates.attributes.update-feature-position" path="/admin/template/update-feature-position">
+        <default key="_controller">Thelia\Controller\Admin\TemplateController::updateFeaturePositionAction</default>
+    </route>
+
+    <route id="admin.configuration.templates.attributes.list" path="/admin/configuration/templates/attributes/list">
+        <default key="_controller">Thelia\Controller\Admin\TemplateController::getAjaxAttributesAction</default>
+    </route>
+
+    <route id="admin.configuration.templates.attributes.add" path="/admin/configuration/templates/attributes/add">
+        <default key="_controller">Thelia\Controller\Admin\TemplateController::addAttributeAction</default>
+    </route>
+
+    <route id="admin.configuration.templates.attributes.delete" path="/admin/configuration/templates/attributes/delete">
+        <default key="_controller">Thelia\Controller\Admin\TemplateController::deleteAttributeAction</default>
+    </route>
+
+    <route id="admin.configuration.templates.attributes.update-attribute-position" path="/admin/template/update-attribute-position">
+        <default key="_controller">Thelia\Controller\Admin\TemplateController::updateAttributePositionAction</default>
+    </route>
+
+
+    <!-- attribute and attributes value management -->
+
+    <route id="admin.configuration.attributes.default" path="/admin/configuration/attributes">
+        <default key="_controller">Thelia\Controller\Admin\AttributeController::defaultAction</default>
+    </route>
+
+    <route id="admin.configuration.attributes.create" path="/admin/configuration/attributes/create">
+        <default key="_controller">Thelia\Controller\Admin\AttributeController::createAction</default>
+    </route>
+
+    <route id="admin.configuration.attributes.update" path="/admin/configuration/attributes/update">
+        <default key="_controller">Thelia\Controller\Admin\AttributeController::updateAction</default>
+    </route>
+
+    <route id="admin.configuration.attributes.save" path="/admin/configuration/attributes/save">
+        <default key="_controller">Thelia\Controller\Admin\AttributeController::processUpdateAction</default>
+    </route>
+
+    <route id="admin.configuration.attributes.delete" path="/admin/configuration/attributes/delete">
+        <default key="_controller">Thelia\Controller\Admin\AttributeController::deleteAction</default>
+    </route>
+
+    <route id="admin.configuration.attributes.update-position" path="/admin/configuration/attributes/update-position">
+        <default key="_controller">Thelia\Controller\Admin\AttributeController::updatePositionAction</default>
+    </route>
+
+    <route id="admin.configuration.attributes.rem-from-all" path="/admin/configuration/attributes/remove-from-all-templates">
+        <default key="_controller">Thelia\Controller\Admin\AttributeController::removeFromAllTemplates</default>
+    </route>
+
+    <route id="admin.configuration.attributes.add-to-all" path="/admin/configuration/attributes/add-to-all-templates">
+        <default key="_controller">Thelia\Controller\Admin\AttributeController::addToAllTemplates</default>
+    </route>
+
+
+    <route id="admin.configuration.attributes-av.create" path="/admin/configuration/attributes-av/create">
+        <default key="_controller">Thelia\Controller\Admin\AttributeAvController::createAction</default>
+    </route>
+
+    <route id="admin.configuration.attributes-av.update" path="/admin/configuration/attributes-av/update">
+        <default key="_controller">Thelia\Controller\Admin\AttributeAvController::updateAction</default>
+    </route>
+
+    <route id="admin.configuration.attributes-av.save" path="/admin/configuration/attributes-av/save">
+        <default key="_controller">Thelia\Controller\Admin\AttributeAvController::processUpdateAction</default>
+    </route>
+
+    <route id="admin.configuration.attributes-av.delete" path="/admin/configuration/attributes-av/delete">
+        <default key="_controller">Thelia\Controller\Admin\AttributeAvController::deleteAction</default>
+    </route>
+
+    <route id="admin.configuration.attributes-av.update-position" path="/admin/configuration/attributes-av/update-position">
+        <default key="_controller">Thelia\Controller\Admin\AttributeAvController::updatePositionAction</default>
+    </route>
+
+    <!-- end attribute and feature routes  management -->
+
+
+
+    <!-- end countries routes management -->
+
+    <!-- Shipping zones routes management -->
+
+    <route id="admin.configuration.shipping-zones.default" path="/admin/configuration/shipping_zones">
+        <default key="_controller">Thelia\Controller\Admin\ShippingZoneController::indexAction</default>
+    </route>
+
+    <route id="admin.configuration.shipping-zones.update.view" path="/admin/configuration/shipping_zones/update/{delivery_module_id}" methods="get">
+        <default key="_controller">Thelia\Controller\Admin\ShippingZoneController::updateAction</default>
+        <requirement key="delivery_module_id">\d+</requirement>
+    </route>
+
+    <route id="admin.configuration.shipping-zones.area.add" path="/admin/configuration/shipping_zones/area/add" methods="post">
+        <default key="_controller">Thelia\Controller\Admin\ShippingZoneController::addArea</default>
+    </route>
+
+    <route id="admin.configuration.shipping-zones.area.remove" path="/admin/configuration/shipping_zones/area/remove">
+        <default key="_controller">Thelia\Controller\Admin\ShippingZoneController::removeArea</default>
+    </route>
+
+    <!-- end shipping routes management -->
+
+    <!-- Shipping zones routes management -->
+
+    <route id="admin.configuration.shipping-configuration.default" path="/admin/configuration/shipping_configuration">
+        <default key="_controller">Thelia\Controller\Admin\AreaController::defaultAction</default>
+    </route>
+
+    <route id="admin.configuration.shipping-configuration.update.view" path="/admin/configuration/shipping_configuration/update/{area_id}">
+        <default key="_controller">Thelia\Controller\Admin\AreaController::updateAction</default>
+        <requirement key="area_id">\d+</requirement>
+    </route>
+
+    <route id="admin.configuration.shipping-configuration.save" path="/admin/configuration/shipping_configuration/save/{area_id}">
+        <default key="_controller">Thelia\Controller\Admin\AreaController::processUpdateAction</default>
+        <requirement key="area_id">\d+</requirement>
+    </route>
+
+    <route id="admin.configuration.shipping-configuration.delete" path="/admin/configuration/shipping_configuration/delete">
+        <default key="_controller">Thelia\Controller\Admin\AreaController::deleteAction</default>
+    </route>
+
+    <route id="admin.configuration.shipping-configuration.create" path="/admin/configuration/shipping_configuration/create">
+        <default key="_controller">Thelia\Controller\Admin\AreaController::createAction</default>
+    </route>
+
+    <route id="admin.configuration.shipping-configuration.update.postage" path="/admin/configuration/shipping_configuration/update_postage/{area_id}">
+        <default key="_controller">Thelia\Controller\Admin\AreaController::updatePostageAction</default>
+        <requirement key="area_id">\d+</requirement>
+    </route>
+
+    <route id="admin.configuration.shipping-configuration.country.add" path="/admin/configuration/shipping_configuration/country/add" methods="post">
+        <default key="_controller">Thelia\Controller\Admin\AreaController::addCountry</default>
+    </route>
+
+    <route id="admin.configuration.shipping-configuration.country.remove" path="/admin/configuration/shipping_configuration/country/remove" methods="post">
+        <default key="_controller">Thelia\Controller\Admin\AreaController::removeCountry</default>
+    </route>
+
+    <route id="admin.configuration.shipping-configuration.countries.remove" path="/admin/configuration/shipping_configuration/countries/remove" methods="post">
+        <default key="_controller">Thelia\Controller\Admin\AreaController::removeCountries</default>
+    </route>
+
+    <!-- end shipping routes management -->
+
+    <!-- Countries routes management -->
+
+    <route id="admin.configuration.countries.default" path="/admin/configuration/countries">
+        <default key="_controller">Thelia\Controller\Admin\CountryController::defaultAction</default>
+    </route>
+
+    <route id="admin.configuration.countries.create" path="/admin/configuration/countries/create">
+        <default key="_controller">Thelia\Controller\Admin\CountryController::createAction</default>
+    </route>
+
+    <route id="admin.configuration.countries.update" path="/admin/configuration/country/update/{country_id}">
+        <default key="_controller">Thelia\Controller\Admin\CountryController::updateAction</default>
+        <requirement key="country_id">\d+</requirement>
+    </route>
+
+    <route id="admin.configuration.countries.save" path="/admin/configuration/country/save/{country_id}">
+        <default key="_controller">Thelia\Controller\Admin\CountryController::processUpdateAction</default>
+        <requirement key="country_id">\d+</requirement>
+    </route>
+
+    <route id="admin.configuration.countries.delete" path="/admin/configuration/countries/delete">
+        <default key="_controller">Thelia\Controller\Admin\CountryController::deleteAction</default>
+    </route>
+
+    <route id="admin.configuration.countries.toggle-default" path="/admin/configuration/country/toggleDefault">
+        <default key="_controller">Thelia\Controller\Admin\CountryController::toggleDefaultAction</default>
+    </route>
+
+    <route id="admin.configuration.countries.toggle-online" path="/admin/configuration/country/toggle-online">
+        <default key="_controller">Thelia\Controller\Admin\CountryController::setToggleVisibilityAction</default>
+    </route>
+
+    <route id="admin.configuration.countries.data" path="/admin/configuration/countries/data">
+        <default key="_controller">Thelia\Controller\Admin\CountryController::getDataAction</default>
+    </route>
+
+    <!-- end countries routes management -->
+
+    <!-- States routes management -->
+
+    <route id="admin.configuration.states.default" path="/admin/configuration/states">
+        <default key="_controller">Thelia\Controller\Admin\StateController::defaultAction</default>
+    </route>
+
+    <route id="admin.configuration.states.create" path="/admin/configuration/states/create">
+        <default key="_controller">Thelia\Controller\Admin\StateController::createAction</default>
+    </route>
+
+    <route id="admin.configuration.states.update" path="/admin/configuration/state/update/{state_id}">
+        <default key="_controller">Thelia\Controller\Admin\StateController::updateAction</default>
+        <requirement key="state_id">\d+</requirement>
+    </route>
+
+    <route id="admin.configuration.states.save" path="/admin/configuration/state/save/{state_id}">
+        <default key="_controller">Thelia\Controller\Admin\StateController::processUpdateAction</default>
+        <requirement key="state_id">\d+</requirement>
+    </route>
+
+    <route id="admin.configuration.states.delete" path="/admin/configuration/states/delete">
+        <default key="_controller">Thelia\Controller\Admin\StateController::deleteAction</default>
+    </route>
+
+    <route id="admin.configuration.states.toggle-online" path="/admin/configuration/state/toggle-online">
+        <default key="_controller">Thelia\Controller\Admin\StateController::setToggleVisibilityAction</default>
+    </route>
+
+    <!-- end states routes management -->
+
+    <!-- profiles management -->
+
+    <route id="admin.configuration.profiles.list" path="/admin/configuration/profiles">
+        <default key="_controller">Thelia\Controller\Admin\ProfileController::defaultAction</default>
+        <requirement key="address_id">\d+</requirement>
+    </route>
+
+    <route id="admin.configuration.profiles.update" path="/admin/configuration/profiles/update/{profile_id}">
+        <default key="_controller">Thelia\Controller\Admin\ProfileController::updateAction</default>
+        <requirement key="tax_id">\d+</requirement>
+    </route>
+
+    <route id="admin.configuration.profiles.add" path="/admin/configuration/profiles/add">
+        <default key="_controller">Thelia\Controller\Admin\ProfileController::createAction</default>
+    </route>
+
+    <route id="admin.configuration.profiles.save" path="/admin/configuration/profiles/save">
+        <default key="_controller">Thelia\Controller\Admin\ProfileController::processUpdateAction</default>
+    </route>
+
+    <route id="admin.configuration.profiles.saveResourceAccess" path="/admin/configuration/profiles/saveResourceAccess">
+        <default key="_controller">Thelia\Controller\Admin\ProfileController::processUpdateResourceAccess</default>
+    </route>
+
+    <route id="admin.configuration.profiles.saveModuleAccess" path="/admin/configuration/profiles/saveModuleAccess">
+        <default key="_controller">Thelia\Controller\Admin\ProfileController::processUpdateModuleAccess</default>
+    </route>
+
+    <route id="admin.configuration.profiles.delete" path="/admin/configuration/profiles/delete">
+        <default key="_controller">Thelia\Controller\Admin\ProfileController::deleteAction</default>
+    </route>
+
+    <!-- end profiles management -->
+
+    <!-- administrator management -->
+
+    <route id="admin.configuration.administrators.view" path="/admin/configuration/administrators">
+        <default key="_controller">Thelia\Controller\Admin\AdministratorController::defaultAction</default>
+    </route>
+
+    <route id="admin.configuration.administrators.view-profile" path="/admin/configuration/administrators/view">
+        <default key="_controller">Thelia\Controller\Admin\AdministratorController::viewAction</default>
+    </route>
+
+    <route id="admin.configuration.administrators.add" path="/admin/configuration/administrators/add">
+        <default key="_controller">Thelia\Controller\Admin\AdministratorController::createAction</default>
+    </route>
+
+    <route id="admin.configuration.administrators.save" path="/admin/configuration/administrators/save">
+        <default key="_controller">Thelia\Controller\Admin\AdministratorController::processUpdateAction</default>
+    </route>
+
+    <route id="admin.configuration.administrators.delete" path="/admin/configuration/administrators/delete">
+        <default key="_controller">Thelia\Controller\Admin\AdministratorController::deleteAction</default>
+    </route>
+
+    <!-- end administrator management -->
+
+    <!-- mailing-system management -->
+
+    <route id="admin.configuration.mailing-system.view" path="/admin/configuration/mailingSystem">
+        <default key="_controller">Thelia\Controller\Admin\MailingSystemController::defaultAction</default>
+    </route>
+
+    <route id="admin.configuration.mailing-system.save" path="/admin/configuration/mailingSystem/save">
+        <default key="_controller">Thelia\Controller\Admin\MailingSystemController::updateAction</default>
+    </route>
+
+    <route id="admin.configuration.mailing-system.test" path="/admin/configuration/mailingSystem/test">
+        <default key="_controller">Thelia\Controller\Admin\MailingSystemController::testAction</default>
+    </route>
+
+    <!-- end mailing-system management -->
+
+    <!-- admin logs display -->
+
+    <route id="admin.configuration.admin-logs.view" path="/admin/configuration/adminLogs">
+        <default key="_controller">Thelia\Controller\Admin\AdminLogsController::defaultAction</default>
+    </route>
+
+    <route id="admin.configuration.admin-logs.logger" path="/admin/configuration/adminLogs/logger">
+        <default key="_controller">Thelia\Controller\Admin\AdminLogsController::loadLoggerAjaxAction</default>
+    </route>
+
+    <!-- end admin logs display -->
+
+    <!-- feature and features value management -->
+
+    <route id="admin.configuration.features.default" path="/admin/configuration/features">
+        <default key="_controller">Thelia\Controller\Admin\FeatureController::defaultAction</default>
+    </route>
+
+    <route id="admin.configuration.features.create" path="/admin/configuration/features/create">
+        <default key="_controller">Thelia\Controller\Admin\FeatureController::createAction</default>
+    </route>
+
+    <route id="admin.configuration.features.update" path="/admin/configuration/features/update">
+        <default key="_controller">Thelia\Controller\Admin\FeatureController::updateAction</default>
+    </route>
+
+    <route id="admin.configuration.features.save" path="/admin/configuration/features/save">
+        <default key="_controller">Thelia\Controller\Admin\FeatureController::processUpdateAction</default>
+    </route>
+
+    <route id="admin.configuration.features.delete" path="/admin/configuration/features/delete">
+        <default key="_controller">Thelia\Controller\Admin\FeatureController::deleteAction</default>
+    </route>
+
+    <route id="admin.configuration.features.update-position" path="/admin/configuration/features/update-position">
+        <default key="_controller">Thelia\Controller\Admin\FeatureController::updatePositionAction</default>
+    </route>
+
+    <route id="admin.configuration.features.rem-from-all" path="/admin/configuration/features/remove-from-all-templates">
+        <default key="_controller">Thelia\Controller\Admin\FeatureController::removeFromAllTemplates</default>
+    </route>
+
+    <route id="admin.configuration.features.add-to-all" path="/admin/configuration/features/add-to-all-templates">
+        <default key="_controller">Thelia\Controller\Admin\FeatureController::addToAllTemplates</default>
+    </route>
+
+
+    <route id="admin.configuration.features-av.create" path="/admin/configuration/features-av/create">
+        <default key="_controller">Thelia\Controller\Admin\FeatureAvController::createAction</default>
+    </route>
+
+    <route id="admin.configuration.features-av.update" path="/admin/configuration/features-av/update">
+        <default key="_controller">Thelia\Controller\Admin\FeatureAvController::updateAction</default>
+    </route>
+
+    <route id="admin.configuration.features-av.save" path="/admin/configuration/features-av/save">
+        <default key="_controller">Thelia\Controller\Admin\FeatureAvController::processUpdateAction</default>
+    </route>
+
+    <route id="admin.configuration.features-av.delete" path="/admin/configuration/features-av/delete">
+        <default key="_controller">Thelia\Controller\Admin\FeatureAvController::deleteAction</default>
+    </route>
+
+    <route id="admin.configuration.features-av.update-position" path="/admin/configuration/features-av/update-position">
+        <default key="_controller">Thelia\Controller\Admin\FeatureAvController::updatePositionAction</default>
+    </route>
+
+    <!-- end feature and feature routes  management -->
+
+    <!-- cache route management -->
+    <route id="admin.configuration.advanced" path="/admin/configuration/advanced">
+        <default key="_controller">Thelia\Controller\Admin\AdvancedConfigurationController::defaultAction</default>
+    </route>
+
+    <route id="admin.configuration.advanced.flush-cache" path="/admin/configuration/advanced/flush-cache">
+        <default key="_controller">Thelia\Controller\Admin\AdvancedConfigurationController::flushCacheAction</default>
+    </route>
+
+    <route id="admin.configuration.advanced.flush-assets" path="/admin/configuration/advanced/flush-assets">
+        <default key="_controller">Thelia\Controller\Admin\AdvancedConfigurationController::flushAssetsAction</default>
+    </route>
+
+    <route id="admin.configuration.advanced.flush-images-and-documents" path="/admin/configuration/advanced/flush-images-and-documents">
+        <default key="_controller">Thelia\Controller\Admin\AdvancedConfigurationController::flushImagesAndDocumentsAction</default>
+    </route>
+
+    <!-- and cache route management -->
+
+    <!-- Modules rule management -->
+
+    <route id="admin.module" path="/admin/modules">
+        <default key="_controller">Thelia\Controller\Admin\ModuleController::indexAction</default>
+    </route>
+
+    <route id="admin.module.update" path="/admin/module/update/{module_id}">
+        <default key="_controller">Thelia\Controller\Admin\ModuleController::updateAction</default>
+        <requirement key="module_id">\d+</requirement>
+    </route>
+
+    <route id="admin.module.save" path="/admin/module/save">
+        <default key="_controller">Thelia\Controller\Admin\ModuleController::processUpdateAction</default>
+    </route>
+
+    <route id="admin.module.toggle-activation" path="/admin/module/toggle-activation/{module_id}">
+        <default key="_controller">Thelia\Controller\Admin\ModuleController::toggleActivationAction</default>
+        <requirement key="module_id">\d+</requirement>
+    </route>
+
+    <route id="admin.module.delete" path="/admin/module/delete">
+        <default key="_controller">Thelia\Controller\Admin\ModuleController::deleteAction</default>
+    </route>
+
+    <route id="admin.module.update-position" path="/admin/module/update-position">
+        <default key="_controller">Thelia\Controller\Admin\ModuleController::updatePositionAction</default>
+    </route>
+
+    <route id="admin.module.install" path="/admin/module/install" methods="post">
+        <default key="_controller">Thelia\Controller\Admin\ModuleController::installAction</default>
+    </route>
+
+    <route id="admin.module.information" path="/admin/module/information/{module_id}">
+        <default key="_controller">Thelia\Controller\Admin\ModuleController::informationAction</default>
+        <requirement key="module_id">\d+</requirement>
+    </route>
+
+    <route id="admin.module.documentation" path="/admin/module/documentation/{module_id}">
+        <default key="_controller">Thelia\Controller\Admin\ModuleController::documentationAction</default>
+        <requirement key="module_id">\d+</requirement>
+    </route>
+
+    <!--
+        Generic module route.
+        Will be use if module route is not define in module own config file.
+    -->
+    <route id="admin.module.configure" path="/admin/module/{module_code}">
+        <default key="_controller">Thelia\Controller\Admin\ModuleController::configureAction</default>
+    </route>
+
+
+
+    <!-- end Modules rule management -->
+
+    <!-- Hooks rule management -->
+
+    <route id="admin.hook" path="/admin/hooks">
+        <default key="_controller">Thelia\Controller\Admin\HookController::indexAction</default>
+    </route>
+
+    <route id="admin.hook.discover" path="/admin/hooks/discover">
+        <default key="_controller">Thelia\Controller\Admin\HookController::discoverAction</default>
+    </route>
+
+    <route id="admin.hook.discover.save" path="/admin/hooks/discover/save">
+        <default key="_controller">Thelia\Controller\Admin\HookController::discoverSaveAction</default>
+    </route>
+
+    <route id="admin.hook.create" path="/admin/hooks/create">
+        <default key="_controller">Thelia\Controller\Admin\HookController::createAction</default>
+    </route>
+
+    <route id="admin.hook.update" path="/admin/hook/update/{hook_id}">
+        <default key="_controller">Thelia\Controller\Admin\HookController::updateAction</default>
+        <requirement key="hook_id">\d+</requirement>
+    </route>
+
+    <route id="admin.hook.save" path="/admin/hook/save/{hook_id}">
+        <default key="_controller">Thelia\Controller\Admin\HookController::processUpdateAction</default>
+        <requirement key="hook_id">\d+</requirement>
+    </route>
+
+    <route id="admin.hook.delete" path="/admin/hooks/delete">
+        <default key="_controller">Thelia\Controller\Admin\HookController::deleteAction</default>
+    </route>
+
+    <route id="admin.hook.toggle-activation" path="/admin/hook/toggle-activation">
+        <default key="_controller">Thelia\Controller\Admin\HookController::toggleActivationAction</default>
+    </route>
+
+    <route id="admin.hook.toggle-native" path="/admin/hook/toggle-native">
+        <default key="_controller">Thelia\Controller\Admin\HookController::toggleNativeAction</default>
+    </route>
+
+    <route id="admin.module-hook" path="/admin/module-hooks">
+        <default key="_controller">Thelia\Controller\Admin\ModuleHookController::indexAction</default>
+    </route>
+
+    <route id="admin.module-hook.create" path="/admin/module-hooks/create">
+        <default key="_controller">Thelia\Controller\Admin\ModuleHookController::createAction</default>
+    </route>
+
+    <route id="admin.module-hook.update" path="/admin/module-hook/update/{module_hook_id}">
+        <default key="_controller">Thelia\Controller\Admin\ModuleHookController::updateAction</default>
+        <requirement key="module_hook_id">\d+</requirement>
+    </route>
+
+    <route id="admin.module-hook.save" path="/admin/module-hook/save/{module_hook_id}">
+        <default key="_controller">Thelia\Controller\Admin\ModuleHookController::processUpdateAction</default>
+        <requirement key="module_hook_id">\d+</requirement>
+    </route>
+
+    <route id="admin.module-hook.delete" path="/admin/module-hooks/delete">
+        <default key="_controller">Thelia\Controller\Admin\ModuleHookController::deleteAction</default>
+    </route>
+
+    <route id="admin.module-hook.toggle-activation" path="/admin/module-hooks/toggle-activation/{module_hook_id}">
+        <default key="_controller">Thelia\Controller\Admin\ModuleHookController::toggleActivationAction</default>
+        <requirement key="module_hook_id">\d+</requirement>
+    </route>
+
+    <route id="admin.module-hook.update-position" path="/admin/module-hooks/update-position">
+        <default key="_controller">Thelia\Controller\Admin\ModuleHookController::updatePositionAction</default>
+    </route>
+
+    <route id="admin.module-hook.get-module-hook-classnames" path="/admin/module-hooks/get-module-hook-classnames/{moduleId}">
+        <default key="_controller">Thelia\Controller\Admin\ModuleHookController::getModuleHookClassnames</default>
+    </route>
+
+    <route id="admin.module-hook.get-module-hook-methods" path="/admin/module-hooks/get-module-hook-methods/{moduleId}/{className}">
+        <default key="_controller">Thelia\Controller\Admin\ModuleHookController::getModuleHookMethods</default>
+    </route>
+
+    <!-- end Hooks rule management -->
+
+    <!-- tax management -->
+
+    <route id="admin.configuration.taxes.update" path="/admin/configuration/taxes/update/{tax_id}">
+        <default key="_controller">Thelia\Controller\Admin\TaxController::updateAction</default>
+        <requirement key="tax_id">\d+</requirement>
+    </route>
+
+    <route id="admin.configuration.taxes.add" path="/admin/configuration/taxes/add">
+        <default key="_controller">Thelia\Controller\Admin\TaxController::createAction</default>
+    </route>
+
+    <route id="admin.configuration.taxes.save" path="/admin/configuration/taxes/save">
+        <default key="_controller">Thelia\Controller\Admin\TaxController::processUpdateAction</default>
+    </route>
+
+    <route id="admin.configuration.taxes.delete" path="/admin/configuration/taxes/delete">
+        <default key="_controller">Thelia\Controller\Admin\TaxController::deleteAction</default>
+    </route>
+
+    <!-- end tax management -->
+
+    <!-- tax rules management -->
+
+    <route id="admin.configuration.taxes-rules.list" path="/admin/configuration/taxes_rules">
+        <default key="_controller">Thelia\Controller\Admin\TaxRuleController::defaultAction</default>
+    </route>
+
+    <route id="admin.configuration.taxes-rules.update" path="/admin/configuration/taxes_rules/update/{tax_rule_id}">
+        <default key="_controller">Thelia\Controller\Admin\TaxRuleController::updateAction</default>
+        <requirement key="tax_rule_id">\d+</requirement>
+    </route>
+
+    <route id="admin.configuration.taxes-rules.add" path="/admin/configuration/taxes_rules/add">
+        <default key="_controller">Thelia\Controller\Admin\TaxRuleController::createAction</default>
+    </route>
+
+    <route id="admin.configuration.taxes-rules.save" path="/admin/configuration/taxes_rules/save">
+        <default key="_controller">Thelia\Controller\Admin\TaxRuleController::processUpdateAction</default>
+    </route>
+
+    <route id="admin.configuration.taxes-rules.saveTaxes" path="/admin/configuration/taxes_rules/saveTaxes">
+        <default key="_controller">Thelia\Controller\Admin\TaxRuleController::processUpdateTaxesAction</default>
+    </route>
+
+    <route id="admin.configuration.taxes-rules.delete" path="/admin/configuration/taxes_rules/delete">
+        <default key="_controller">Thelia\Controller\Admin\TaxRuleController::deleteAction</default>
+    </route>
+
+    <route id="admin.configuration.taxes-rules.set-default" path="/admin/configuration/taxes_rules/update/set_default/{tax_rule_id}">
+        <default key="_controller">Thelia\Controller\Admin\TaxRuleController::setDefaultAction</default>
+        <requirement key="tax_rule_id">\d+</requirement>
+    </route>
+
+    <route id="admin.configuration.taxes-rules.get" path="/admin/configuration/taxes_rules/specs/{tax_rule_id}">
+        <default key="_controller">Thelia\Controller\Admin\TaxRuleController::specsAction</default>
+        <requirement key="tax_rule_id">\d+</requirement>
+    </route>
+
+    <!-- end tax rules management -->
+
+    <!-- language management -->
+
+    <route id="admin.configuration.languages" path="/admin/configuration/languages">
+        <default key="_controller">Thelia\Controller\Admin\LangController::defaultAction</default>
+    </route>
+
+    <route id="admin.configuration.languages.update" path="/admin/configuration/languages/update/{lang_id}">
+        <default key="_controller">Thelia\Controller\Admin\LangController::updateAction</default>
+        <requirement key="lang_id">\d+</requirement>
+    </route>
+
+    <route id="admin.configuration.languages.update.process" path="/admin/configuration/languages/save/{lang_id}">
+        <default key="_controller">Thelia\Controller\Admin\LangController::processUpdateAction</default>
+        <requirement key="lang_id">\d+</requirement>
+    </route>
+
+    <route id="admin.configuration.languages.toggleDefault" path="/admin/configuration/languages/toggleDefault/{lang_id}">
+        <default key="_controller">Thelia\Controller\Admin\LangController::toggleDefaultAction</default>
+        <requirement key="lang_id">\d+</requirement>
+    </route>
+
+    <route id="admin.configuration.languages.toggleActive" path="/admin/configuration/languages/toggleActive/{lang_id}">
+        <default key="_controller">Thelia\Controller\Admin\LangController::toggleActiveAction</default>
+        <requirement key="lang_id">\d+</requirement>
+    </route>
+
+    <route id="admin.configuration.languages.toggleVisible" path="/admin/configuration/languages/toggleVisible/{lang_id}">
+        <default key="_controller">Thelia\Controller\Admin\LangController::toggleVisibleAction</default>
+        <requirement key="lang_id">\d+</requirement>
+    </route>
+
+    <route id="admin.configuration.languages.add" path="/admin/configuration/languages/add">
+        <default key="_controller">Thelia\Controller\Admin\LangController::addAction</default>
+    </route>
+
+    <route id="admin.configuration.languages.delete" path="/admin/configuration/languages/delete">
+        <default key="_controller">Thelia\Controller\Admin\LangController::deleteAction</default>
+    </route>
+
+    <route id="admin.configuration.languages.defaultBehavior" path="/admin/configuration/languages/defaultBehavior">
+        <default key="_controller">Thelia\Controller\Admin\LangController::defaultBehaviorAction</default>
+    </route>
+
+    <route id="admin.configuration.languages.updateUrl" path="/admin/configuration/languages/updateUrl">
+        <default key="_controller">Thelia\Controller\Admin\LangController::domainAction</default>
+    </route>
+
+    <route id="admin.configuration.languages.domain.activation" path="/admin/configuration/languages/domain/activate">
+        <default key="_controller">Thelia\Controller\Admin\LangController::activateDomainAction</default>
+    </route>
+
+    <route id="admin.configuration.languages.domain.deactivation" path="/admin/configuration/languages/domain/deactivate">
+        <default key="_controller">Thelia\Controller\Admin\LangController::deactivateDomainAction</default>
+    </route>
+
+    <!-- translations management -->
+
+    <route id="admin.configuration.translations" path="/admin/configuration/translations">
+        <default key="_controller">Thelia\Controller\Admin\TranslationsController::defaultAction</default>
+    </route>
+
+    <route id="admin.configuration.translations.update" path="/admin/configuration/translations/update">
+        <default key="_controller">Thelia\Controller\Admin\TranslationsController::updateAction</default>
+    </route>
+
+    <route id="admin.configuration.translations-customers-title" path="/admin/configuration/translations-customers-title">
+        <default key="_controller">Thelia\Controller\Admin\TranslationsCustomerTitleController::defaultAction</default>
+    </route>
+    <route id="admin.configuration.translations-customers-title.update" path="/admin/configuration/translations-customers-title/update">
+        <default key="_controller">Thelia\Controller\Admin\TranslationsCustomerTitleController::updateAction</default>
+    </route>
+
+    <!-- Routes to the Brands controller -->
+
+    <route id="admin.brand.default" path="/admin/brand">
+        <default key="_controller">Thelia\Controller\Admin\BrandController::defaultAction</default>
+    </route>
+
+    <route id="admin.brand.create" path="/admin/brand/create">
+        <default key="_controller">Thelia\Controller\Admin\BrandController::createAction</default>
+    </route>
+
+    <route id="admin.brand.update" path="/admin/brand/update/{brand_id}">
+        <default key="_controller">Thelia\Controller\Admin\BrandController::updateAction</default>
+        <requirement key="brand_id">\d+</requirement>
+    </route>
+
+    <route id="admin.brand.save" path="/admin/brand/save/{brand_id}">
+        <default key="_controller">Thelia\Controller\Admin\BrandController::processUpdateAction</default>
+        <requirement key="brand_id">\d+</requirement>
+    </route>
+
+    <route id="admin.brand.seo.save" path="/admin/brand/seo/save">
+        <default key="_controller">Thelia\Controller\Admin\BrandController::processUpdateSeoAction</default>
+    </route>
+
+    <route id="admin.brand.toggle-online" path="/admin/brand/toggle-online">
+        <default key="_controller">Thelia\Controller\Admin\BrandController::setToggleVisibilityAction</default>
+    </route>
+
+    <route id="admin.brand.update-position" path="/admin/brand/update-position">
+        <default key="_controller">Thelia\Controller\Admin\BrandController::updatePositionAction</default>
+    </route>
+
+    <route id="admin.brand.delete" path="/admin/brand/delete">
+        <default key="_controller">Thelia\Controller\Admin\BrandController::deleteAction</default>
+    </route>
+
+    <!-- export management -->
+
+    <route id="export.list" path="/admin/export" methods="get">
+        <default key="_controller">Thelia\Controller\Admin\ExportController::indexAction</default>
+    </route>
+
+    <route id="export.position" path="/admin/export/position" methods="get">
+        <default key="_controller">Thelia\Controller\Admin\ExportController::changeExportPositionAction</default>
+    </route>
+
+    <route id="export.category.position" path="/admin/export/position/category" methods="get">
+        <default key="_controller">Thelia\Controller\Admin\ExportController::changeCategoryPositionAction</default>
+    </route>
+
+    <route id="export.view" path="/admin/export/{id}" methods="get">
+        <default key="_controller">Thelia\Controller\Admin\ExportController::configureAction</default>
+
+        <requirement key="id">\d+</requirement>
+    </route>
+
+    <route id="export.process" path="/admin/export/{id}" methods="post">
+        <default key="_controller">Thelia\Controller\Admin\ExportController::exportAction</default>
+
+        <requirement key="id">\d+</requirement>
+    </route>
+
+    <!-- import management -->
+
+    <route id="import.list" path="/admin/import">
+        <default key="_controller">Thelia\Controller\Admin\ImportController::indexAction</default>
+    </route>
+
+    <route id="import.position" path="/admin/import/position" methods="get">
+        <default key="_controller">Thelia\Controller\Admin\ImportController::changeImportPositionAction</default>
+    </route>
+
+    <route id="import.category.position" path="/admin/import/position/category" methods="get">
+        <default key="_controller">Thelia\Controller\Admin\ImportController::changeCategoryPositionAction</default>
+    </route>
+
+    <route id="import.view" path="/admin/import/{id}" methods="get">
+        <default key="_controller">Thelia\Controller\Admin\ImportController::configureAction</default>
+
+        <requirement key="id">\d+</requirement>
+    </route>
+
+    <route id="import.process" path="/admin/import/{id}" methods="post">
+        <default key="_controller">Thelia\Controller\Admin\ImportController::importAction</default>
+
+        <requirement key="id">\d+</requirement>
+    </route>
+
+    <!-- Routes to the sales & promotions management -->
+
+    <route id="admin.sale.default" path="/admin/sales">
+        <default key="_controller">Thelia\Controller\Admin\SaleController::defaultAction</default>
+    </route>
+
+    <route id="admin.sale.reset" path="/admin/sales/reset">
+        <default key="_controller">Thelia\Controller\Admin\SaleController::resetSaleStatus</default>
+    </route>
+
+    <route id="admin.sale.check-activation" path="/admin/sales/check-activation">
+        <default key="_controller">Thelia\Controller\Admin\SaleController::checkSalesActivationStatus</default>
+    </route>
+
+    <route id="admin.sale.create" path="/admin/sale/create">
+        <default key="_controller">Thelia\Controller\Admin\SaleController::createAction</default>
+    </route>
+
+    <route id="admin.sale.update" path="/admin/sale/update/{sale_id}">
+        <default key="_controller">Thelia\Controller\Admin\SaleController::updateAction</default>
+        <requirement key="sale_id">\d+</requirement>
+    </route>
+
+    <route id="admin.sale.save" path="/admin/sale/save/{sale_id}">
+        <default key="_controller">Thelia\Controller\Admin\SaleController::processUpdateAction</default>
+        <requirement key="sale_id">\d+</requirement>
+    </route>
+
+    <route id="admin.sale.delete" path="/admin/sale/delete">
+        <default key="_controller">Thelia\Controller\Admin\SaleController::deleteAction</default>
+    </route>
+
+    <route id="admin.sale.update.product.list" path="/admin/sale/update-product-list/{sale_id}">
+        <default key="_controller">Thelia\Controller\Admin\SaleController::updateProductList</default>
+        <requirement key="sale_id">\d+</requirement>
+    </route>
+
+    <route id="admin.sale.update.product.attribute.list" path="/admin/sale/update-product-attribute-list/{sale_id}/{product_id}">
+        <default key="_controller">Thelia\Controller\Admin\SaleController::updateProductAttributes</default>
+        <requirement key="sale_id">\d+</requirement>
+        <requirement key="product_id">\d+</requirement>
+    </route>
+
+    <route id="admin.sale.toggleActivity" path="/admin/sale/toggle-activity/{sale_id}">
+        <default key="_controller">Thelia\Controller\Admin\SaleController::toggleActivity</default>
+        <requirement key="sale_id">\d+</requirement>
+    </route>
+
+    <!-- Preview message -->
+    <route id="admin.email.preview_html" path="/admin/message/preview/{messageId}" methods="get">
+        <default key="_controller">Thelia\Controller\Admin\MessageController::previewAsHtmlAction</default>
+        <requirement key="messageId">\d+</requirement>
+    </route>
+
+    <route id="admin.email.preview_text" path="/admin/message/preview/text/{messageId}" methods="get">
+        <default key="_controller">Thelia\Controller\Admin\MessageController::previewAsTextAction</default>
+        <requirement key="messageId">\d+</requirement>
+    </route>
+
+    <route id="admin.email.test_send" path="/admin/message/send/{messageId}" methods="post">
+        <default key="_controller">Thelia\Controller\Admin\MessageController::sendSampleByEmailAction</default>
+        <requirement key="messageId">\d+</requirement>
+    </route>
+
+    <!-- The default route, to display a template -->
+
+    <route id="admin.processTemplate" path="/admin/{template}">
+        <default key="_controller">Thelia\Controller\Admin\AdminController::processTemplateAction</default>
+        <requirement key="template">.*</requirement>
+    </route>
+
+</routes>

--- a/Controller/Admin/AddressController.php
+++ b/Controller/Admin/AddressController.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Propel\Runtime\Event\ActiveRecordEvent;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\Address\AddressCreateOrUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Form\AddressCreateForm;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Log\Tlog;
+use Thelia\Model\Address;
+use Thelia\Model\AddressQuery;
+use Thelia\Model\CustomerQuery;
+use Thelia\Model\Event\AddressEvent;
+
+/**
+ * Class AddressController.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class AddressController extends AbstractCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'registration_date',
+            null,
+            null,
+            AdminResources::ADDRESS,
+            TheliaEvents::ADDRESS_CREATE,
+            TheliaEvents::ADDRESS_UPDATE,
+            TheliaEvents::ADDRESS_DELETE,
+        );
+    }
+
+    public function useAddressAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $address_id = (int) $this->getRequest()->request->get('address_id');
+
+        try {
+            $address = AddressQuery::create()->findPk($address_id);
+
+            if (null === $address) {
+                throw new \InvalidArgumentException(\sprintf('%d address does not exists', $address_id));
+            }
+
+            $addressEvent = new AddressEvent($address);
+
+            $eventDispatcher->dispatch($addressEvent, TheliaEvents::ADDRESS_DEFAULT);
+
+            $this->adminLogAppend(
+                $this->resourceCode,
+                AccessManager::UPDATE,
+                \sprintf(
+                    'address %d for customer %d set as default address',
+                    $address_id,
+                    $address->getCustomerId(),
+                ),
+                $address_id,
+            );
+        } catch (\Exception $exception) {
+            Tlog::getInstance()->error(\sprintf(
+                'error during address setting as default with message %s',
+                $exception->getMessage(),
+            ));
+        }
+
+        return $this->redirectToEditionTemplate();
+    }
+
+    /**
+     * Return the creation form for this object.
+     */
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AddressCreateForm::class);
+    }
+
+    /**
+     * Return the update form for this object.
+     */
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::ADDRESS_UPDATE);
+    }
+
+    /**
+     * Fills in the form data array.
+     */
+    protected function createFormDataArray(Address $object): array
+    {
+        return [
+            'label' => $object->getLabel(),
+            'firstname' => $object->getFirstname(),
+            'lastname' => $object->getLastname(),
+            'address1' => $object->getAddress1(),
+            'address2' => $object->getAddress2(),
+            'address3' => $object->getAddress3(),
+            'zipcode' => $object->getZipcode(),
+            'city' => $object->getCity(),
+            'country' => $object->getCountryId(),
+            'state' => $object->getStateId(),
+            'cellphone' => $object->getCellphone(),
+            'phone' => $object->getPhone(),
+            'company' => $object->getCompany(),
+        ];
+    }
+
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        return $this->createForm(AdminForm::ADDRESS_UPDATE, FormType::class, $this->createFormDataArray($object));
+    }
+
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $event = $this->getCreateOrUpdateEvent($formData);
+
+        $customer = CustomerQuery::create()->findPk($this->getRequest()->get('customer_id'));
+
+        if (null === $customer) {
+            throw new \InvalidArgumentException(\sprintf('Customer #%s not found', $this->getRequest()->get('customer_id')));
+        }
+
+        $event->setCustomer($customer);
+
+        return $event;
+    }
+
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $event = $this->getCreateOrUpdateEvent($formData);
+
+        $event->setAddress($this->getExistingObject());
+
+        return $event;
+    }
+
+    protected function getCreateOrUpdateEvent($formData): AddressCreateOrUpdateEvent
+    {
+        return new AddressCreateOrUpdateEvent(
+            $formData['label'],
+            $formData['title'] ?? null,
+            $formData['firstname'],
+            $formData['lastname'],
+            $formData['address1'],
+            $formData['address2'],
+            $formData['address3'],
+            $formData['zipcode'],
+            $formData['city'],
+            $formData['country'],
+            $formData['cellphone'] ? (string) $formData['cellphone'] : null,
+            $formData['phone'] ? (string) $formData['phone'] : null,
+            $formData['company'],
+            $formData['is_default'],
+            isset($formData['state']) ? (int) $formData['state'] : null,
+        );
+    }
+
+    protected function getDeleteEvent(): ActiveRecordEvent
+    {
+        /** @var Address $address */
+        $address = $this->getExistingObject();
+
+        return new AddressEvent($address);
+    }
+
+    protected function eventContainsObject(Event $event): bool
+    {
+        return null !== $event->getAddress();
+    }
+
+    protected function getObjectFromEvent($event): null
+    {
+        return null;
+    }
+
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        return AddressQuery::create()->findPk($this->getRequest()->get('address_id'));
+    }
+
+    protected function getObjectLabel($object): string
+    {
+        return $object->getLabel();
+    }
+
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        // We render here the customer edit template.
+        return $this->renderEditionTemplate();
+    }
+
+    protected function renderEditionTemplate(): Response
+    {
+        return $this->render('customer-edit', [
+            'address_id' => $this->getRequest()->get('address_id'),
+            'page' => $this->getRequest()->get('page'),
+            'customer_id' => $this->getCustomerId(),
+        ]);
+    }
+
+    protected function redirectToEditionTemplate(): Response|RedirectResponse
+    {
+        // We display here the custromer edition template
+        return $this->generateRedirectFromRoute(
+            'admin.customer.update.view',
+            [
+                'page' => $this->getRequest()->get('page'),
+                'customer_id' => $this->getCustomerId(),
+            ],
+        );
+    }
+
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.home',
+            [
+                'page' => $this->getRequest()->get('page'),
+                'customer_id' => $this->getCustomerId(),
+            ],
+        );
+    }
+
+    protected function performAdditionalDeleteAction(ActionEvent|ActiveRecordEvent|null $deleteEvent): Response
+    {
+        return $this->redirectToEditionTemplate();
+    }
+
+    protected function performAdditionalCreateAction(ActionEvent|ActiveRecordEvent|null $createEvent): ?Response
+    {
+        return $this->redirectToEditionTemplate();
+    }
+
+    protected function performAdditionalUpdateAction(EventDispatcherInterface $eventDispatcher, ActionEvent|ActiveRecordEvent|null $updateEvent): Response
+    {
+        return $this->redirectToEditionTemplate();
+    }
+
+    protected function getCustomerId()
+    {
+        if (($address = $this->getExistingObject()) instanceof ActiveRecordInterface) {
+            return $address->getCustomerId();
+        }
+
+        return $this->getRequest()->get('customer_id', 0);
+    }
+}

--- a/Controller/Admin/AdminLogsController.php
+++ b/Controller/Admin/AdminLogsController.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Symfony\Component\HttpFoundation\Response;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Model\AdminLog;
+use Thelia\Model\AdminLogQuery;
+
+class AdminLogsController extends BaseAdminController
+{
+    public function defaultAction()
+    {
+        if (($response = $this->checkAuth(AdminResources::ADMIN_LOG, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        // Render the edition template.
+        return $this->render('admin-logs');
+    }
+
+    public function loadLoggerAjaxAction(): Response
+    {
+        $entries = [];
+
+        /** @var AdminLog $entry */
+        foreach (AdminLogQuery::getEntries(
+            $this->getRequest()->request->get('admins', []),
+            $this->getRequest()->request->get('fromDate'),
+            $this->getRequest()->request->get('toDate'),
+            array_merge((array) $this->getRequest()->request->get('resources', []), (array) $this->getRequest()->request->get('modules', [])),
+        ) as $entry) {
+            $entries[] = [
+                'head' => \sprintf(
+                    '%s|%s|%s:%s%s',
+                    date('Y-m-d H:i:s', $entry->getCreatedAt()->getTimestamp()),
+                    $entry->getAdminLogin(),
+                    $entry->getResource(),
+                    $entry->getAction(),
+                    (null !== $entry->getResourceId()) ? ':'.$entry->getResourceId() : '',
+                ),
+                'data' => $entry->getMessage(),
+            ];
+        }
+
+        return $this->render(
+            'ajax/logger',
+            [
+                'entries' => $entries,
+            ],
+        );
+    }
+}

--- a/Controller/Admin/AdministratorController.php
+++ b/Controller/Admin/AdministratorController.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Propel\Runtime\Event\ActiveRecordEvent;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\Administrator\AdministratorEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Model\Admin;
+use Thelia\Model\AdminQuery;
+
+class AdministratorController extends AbstractCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'administrator',
+            'manual',
+            'order',
+            AdminResources::ADMINISTRATOR,
+            TheliaEvents::ADMINISTRATOR_CREATE,
+            TheliaEvents::ADMINISTRATOR_UPDATE,
+            TheliaEvents::ADMINISTRATOR_DELETE,
+        );
+    }
+
+    public function viewAction(): Response
+    {
+        // Open the update dialog for the current administrator
+        return $this->render('administrators', ['show_update_dialog' => true]);
+    }
+
+    public function setEmailAction(): Response
+    {
+        // Open the update dialog for the current administrator, and display the "set email address" notice.
+        return $this->render(
+            'administrators',
+            [
+                'show_update_dialog' => true,
+                'show_email_change_notice' => true,
+            ],
+        );
+    }
+
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::ADMINISTRATOR_CREATION);
+    }
+
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::ADMINISTRATOR_MODIFICATION);
+    }
+
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $event = new AdministratorEvent();
+
+        $event->setLogin($formData['login']);
+        $event->setFirstname($formData['firstname']);
+        $event->setLastname($formData['lastname']);
+        $event->setPassword($formData['password']);
+        $event->setProfile($formData['profile'] ?: null);
+        $event->setLocale($formData['locale']);
+        $event->setEmail($formData['email']);
+
+        return $event;
+    }
+
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $event = new AdministratorEvent();
+
+        $event->setId($formData['id']);
+        $event->setLogin($formData['login']);
+        $event->setFirstname($formData['firstname']);
+        $event->setLastname($formData['lastname']);
+        $event->setPassword($formData['password']);
+        $event->setProfile($formData['profile'] ?: null);
+        $event->setLocale($formData['locale']);
+        $event->setEmail($formData['email']);
+
+        return $event;
+    }
+
+    protected function getDeleteEvent(): AdministratorEvent
+    {
+        $event = new AdministratorEvent();
+
+        $event->setId(
+            $this->getRequest()->get('administrator_id', 0),
+        );
+
+        return $event;
+    }
+
+    protected function eventContainsObject($event): bool
+    {
+        return $event->hasAdministrator();
+    }
+
+    /**
+     * @param Admin $object
+     */
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        $data = [
+            'id' => $object->getId(),
+            'firstname' => $object->getFirstname(),
+            'lastname' => $object->getLastname(),
+            'login' => $object->getLogin(),
+            'profile' => $object->getProfileId(),
+            'locale' => $object->getLocale(),
+            'email' => $object->getEmail(),
+        ];
+
+        // Setup the object form
+        return $this->createForm(AdminForm::ADMINISTRATOR_MODIFICATION, FormType::class, $data);
+    }
+
+    protected function getObjectFromEvent($event): ?Admin
+    {
+        return $event->hasAdministrator() ? $event->getAdministrator() : null;
+    }
+
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        return AdminQuery::create()
+            ->findOneById($this->getRequest()->get('administrator_id'));
+    }
+
+    protected function getObjectLabel(ActiveRecordInterface $object): string
+    {
+        if ($object instanceof Admin) {
+            return $object->getLogin();
+        }
+
+        return (string) $object;
+    }
+
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        if ($object instanceof Admin) {
+            return $object->getId();
+        }
+
+        return (int) $object;
+    }
+
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        // We always return to the feature edition form
+        return $this->render(
+            'administrators',
+        );
+    }
+
+    protected function renderEditionTemplate(): Response
+    {
+        // We always return to the feature edition form
+        return $this->render('administrators');
+    }
+
+    protected function redirectToEditionTemplate(): Response|RedirectResponse
+    {
+        // We always return to the feature edition form
+        return $this->redirectToListTemplate();
+    }
+
+    protected function performAdditionalCreateAction(ActionEvent|ActiveRecordEvent|null $createEvent): ?Response
+    {
+        // We always return to the feature edition form
+        return $this->redirectToListTemplate();
+    }
+
+    protected function performAdditionalUpdateAction(EventDispatcherInterface $eventDispatcher, ActionEvent|ActiveRecordEvent|null $updateEvent): ?Response
+    {
+        // We always return to the feature edition form
+        return $this->redirectToListTemplate();
+    }
+
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.configuration.administrators.view',
+        );
+    }
+}

--- a/Controller/Admin/AdvancedConfigurationController.php
+++ b/Controller/Admin/AdvancedConfigurationController.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\Cache\CacheEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Log\Tlog;
+use Thelia\Model\ConfigQuery;
+
+/**
+ * Class CacheController.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class AdvancedConfigurationController extends BaseAdminController
+{
+    public function defaultAction()
+    {
+        if (($result = $this->checkAuth(AdminResources::ADVANCED_CONFIGURATION, [], AccessManager::VIEW)) instanceof Response) {
+            return $result;
+        }
+
+        return $this->render('advanced-configuration');
+    }
+
+    public function flushCacheAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        if (($result = $this->checkAuth(AdminResources::ADVANCED_CONFIGURATION, [], AccessManager::UPDATE)) instanceof Response) {
+            return $result;
+        }
+
+        $form = $this->createForm(AdminForm::CACHE_FLUSH);
+
+        try {
+            $this->validateForm($form);
+
+            $event = new CacheEvent($this->container->getParameter('kernel.cache_dir'));
+            $eventDispatcher->dispatch($event, TheliaEvents::CACHE_CLEAR);
+        } catch (\Exception $exception) {
+            Tlog::getInstance()->addError(\sprintf('Flush cache error: %s', $exception->getMessage()));
+        }
+
+        return $this->generateRedirectFromRoute('admin.configuration.advanced');
+    }
+
+    public function flushAssetsAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        if (($result = $this->checkAuth(AdminResources::ADVANCED_CONFIGURATION, [], AccessManager::UPDATE)) instanceof Response) {
+            return $result;
+        }
+
+        $form = $this->createForm(AdminForm::ASSETS_FLUSH);
+
+        try {
+            $this->validateForm($form);
+
+            $event = new CacheEvent(THELIA_WEB_DIR.'assets');
+            $eventDispatcher->dispatch($event, TheliaEvents::CACHE_CLEAR);
+        } catch (\Exception $exception) {
+            Tlog::getInstance()->addError(\sprintf('Flush assets error: %s', $exception->getMessage()));
+        }
+
+        return $this->generateRedirectFromRoute('admin.configuration.advanced');
+    }
+
+    public function flushImagesAndDocumentsAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        if (($result = $this->checkAuth(AdminResources::ADVANCED_CONFIGURATION, [], AccessManager::UPDATE)) instanceof Response) {
+            return $result;
+        }
+
+        $form = $this->createForm(AdminForm::IMAGES_AND_DOCUMENTS_CACHE_FLUSH);
+
+        try {
+            $this->validateForm($form);
+
+            $event = new CacheEvent(
+                THELIA_WEB_DIR.ConfigQuery::read(
+                    'image_cache_dir_from_web_root',
+                    'cache'.DS.'images',
+                ),
+            );
+            $eventDispatcher->dispatch($event, TheliaEvents::CACHE_CLEAR);
+
+            $event = new CacheEvent(
+                THELIA_WEB_DIR.ConfigQuery::read(
+                    'document_cache_dir_from_web_root',
+                    'cache'.DS.'documents',
+                ),
+            );
+            $eventDispatcher->dispatch($event, TheliaEvents::CACHE_CLEAR);
+        } catch (\Exception $exception) {
+            Tlog::getInstance()->addError(\sprintf('Flush images and document error: %s', $exception->getMessage()));
+        }
+
+        return $this->generateRedirectFromRoute('admin.configuration.advanced');
+    }
+}

--- a/Controller/Admin/AreaController.php
+++ b/Controller/Admin/AreaController.php
@@ -1,0 +1,360 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Propel\Runtime\Event\ActiveRecordEvent;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\Area\AreaAddCountryEvent;
+use Thelia\Core\Event\Area\AreaRemoveCountryEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\Element\Exception\ElementNotFoundException;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Form\Exception\FormValidationException;
+use Thelia\Model\Area;
+use Thelia\Model\AreaQuery;
+use Thelia\Model\Event\AreaEvent;
+
+/**
+ * Class AreaController.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ * @author Franck Allimant <franck@cqfdev.fr>
+ */
+class AreaController extends AbstractCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'area',
+            null,
+            null,
+            AdminResources::AREA,
+            TheliaEvents::AREA_CREATE,
+            TheliaEvents::AREA_UPDATE,
+            TheliaEvents::AREA_DELETE,
+        );
+    }
+
+    protected function getAreaId(): mixed
+    {
+        return $this->getRequest()->get('area_id', 0);
+    }
+
+    /**
+     * Return the creation form for this object.
+     */
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::AREA_CREATE);
+    }
+
+    /**
+     * Return the update form for this object.
+     */
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::AREA_MODIFICATION);
+    }
+
+    /**
+     * Hydrate the update form for this object, before passing it to the update template.
+     *
+     * @param Area $object
+     */
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        $data = [
+            'area_id' => $object->getId(),
+            'name' => $object->getName(),
+        ];
+
+        return $this->createForm(AdminForm::AREA_MODIFICATION, FormType::class, $data);
+    }
+
+    /**
+     * Creates the creation event with the provided form data.
+     */
+    protected function getCreationEvent(array $formData): ActiveRecordEvent
+    {
+        $area = new Area();
+        $event = new AreaEvent($area);
+
+        return $this->hydrateEvent($event, $formData);
+    }
+
+    /**
+     * Creates the update event with the provided form data.
+     */
+    protected function getUpdateEvent(array $formData): ActiveRecordEvent
+    {
+        $area = $this->findAreaOrFail($formData['area_id']);
+        $event = new AreaEvent($area);
+
+        $this->hydrateEvent($event, $formData);
+
+        return $event;
+    }
+
+    private function hydrateEvent(AreaEvent $event, array $formData): ActiveRecordEvent
+    {
+        $event->getModel()->setName($formData['name']);
+
+        return $event;
+    }
+
+    /**
+     * Creates the delete event with the provided form data.
+     */
+    protected function getDeleteEvent(): AreaEvent
+    {
+        $area = $this->findAreaOrFail($this->getAreaId());
+
+        return new AreaEvent($area);
+    }
+
+    /**
+     * Load an existing object from the database.
+     */
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        return AreaQuery::create()->findPk($this->getAreaId());
+    }
+
+    /**
+     * Returns the object label form the object event (name, title, etc.).
+     *
+     * @param Area $object
+     */
+    protected function getObjectLabel(ActiveRecordInterface $object): ?string
+    {
+        return $object->getName();
+    }
+
+    /**
+     * Returns the object ID from the object.
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    /**
+     * Render the main list template.
+     */
+    protected function renderListTemplate(?string $currentOrder): Response
+    {
+        return $this->render('shipping-configuration');
+    }
+
+    /**
+     * Render the edition template.
+     */
+    protected function renderEditionTemplate(): Response
+    {
+        return $this->render(
+            'shipping-configuration-edit',
+            [
+                'area_id' => $this->getAreaId(),
+            ],
+        );
+    }
+
+    /**
+     * Redirect to the edition template.
+     */
+    protected function redirectToEditionTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.configuration.shipping-configuration.update.view',
+            [],
+            [
+                'area_id' => $this->getAreaId(),
+            ],
+        );
+    }
+
+    /**
+     * Redirect to the list template.
+     */
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute('admin.configuration.shipping-configuration.default');
+    }
+
+    /**
+     * add a country to a define area.
+     */
+    public function addCountry(EventDispatcherInterface $eventDispatcher): RedirectResponse|Response|null
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $areaCountryForm = $this->createForm(AdminForm::AREA_COUNTRY);
+        $error_msg = null;
+
+        try {
+            $form = $this->validateForm($areaCountryForm);
+
+            $area = $this->findAreaOrFail($form->get('area_id')->getData());
+
+            $event = new AreaAddCountryEvent($area, $form->get('country_id')->getData());
+
+            $eventDispatcher->dispatch($event, TheliaEvents::AREA_ADD_COUNTRY);
+
+            // Log object modification
+            if (null !== $changedObject = $event->getModel()) {
+                $this->adminLogAppend(
+                    $this->resourceCode,
+                    AccessManager::UPDATE,
+                    \sprintf(
+                        '%s %s (ID %s) modified, new country added',
+                        ucfirst($this->objectName),
+                        $this->getObjectLabel($changedObject),
+                        $this->getObjectId($changedObject),
+                    ),
+                    $this->getObjectId($changedObject),
+                );
+            }
+
+            // Redirect to the success URL
+            return $this->generateSuccessRedirect($areaCountryForm);
+        } catch (FormValidationException $ex) {
+            // Form cannot be validated
+            $error_msg = $this->createStandardFormValidationErrorMessage($ex);
+        } catch (\Exception $ex) {
+            // Any other error
+            $error_msg = $ex->getMessage();
+        }
+
+        $this->setupFormErrorContext(
+            $this->getTranslator()->trans('%obj modification', ['%obj' => $this->objectName]),
+            $error_msg,
+            $areaCountryForm,
+        );
+
+        // At this point, the form has errors, and should be redisplayed.
+        return $this->renderEditionTemplate();
+    }
+
+    /**
+     * delete several countries from a shipping zone.
+     */
+    public function removeCountries(EventDispatcherInterface $eventDispatcher): RedirectResponse|Response|null
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $areaDeleteCountriesForm = $this->createForm(AdminForm::AREA_DELETE_COUNTRY);
+
+        try {
+            $form = $this->validateForm($areaDeleteCountriesForm);
+
+            $data = $form->getData();
+            $area = $this->findAreaOrFail($form->get('area_id')->getData());
+
+            foreach ($data['country_id'] as $countryId) {
+                $country = explode('-', (string) $countryId);
+                $this->removeOneCountryFromArea($eventDispatcher, $area, $country[0], $country[1]);
+            }
+
+            // Redirect to the success URL
+            return $this->generateSuccessRedirect($areaDeleteCountriesForm);
+        } catch (FormValidationException $ex) {
+            // Form cannot be validated
+            $error_msg = $this->createStandardFormValidationErrorMessage($ex);
+        } catch (\Exception $ex) {
+            // Any other error
+            $error_msg = $ex->getMessage();
+        }
+
+        $this->setupFormErrorContext(
+            $this->getTranslator()->trans('Failed to delete selected countries'),
+            $error_msg,
+            $areaDeleteCountriesForm,
+        );
+
+        // At this point, the form has errors, and should be redisplayed.
+        return $this->renderEditionTemplate();
+    }
+
+    protected function removeOneCountryFromArea(EventDispatcherInterface $eventDispatcher, Area $area, $countryId, $stateId): void
+    {
+        if (0 === (int) $stateId) {
+            $stateId = null;
+        }
+
+        $removeCountryEvent = new AreaRemoveCountryEvent($area, [$countryId], $stateId);
+
+        $eventDispatcher->dispatch($removeCountryEvent, TheliaEvents::AREA_REMOVE_COUNTRY);
+
+        if (null !== $changedObject = $removeCountryEvent->getModel()) {
+            $this->adminLogAppend(
+                $this->resourceCode,
+                AccessManager::UPDATE,
+                \sprintf(
+                    '%s %s (ID %s) removed country ID %s from shipping zone ID %s',
+                    ucfirst($this->objectName),
+                    $this->getObjectLabel($changedObject),
+                    $this->getObjectId($changedObject),
+                    $countryId,
+                    $area->getId(),
+                ),
+                $this->getObjectId($changedObject),
+            );
+        }
+    }
+
+    public function removeCountry(EventDispatcherInterface $eventDispatcher): Response
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $this->removeOneCountryFromArea(
+            $eventDispatcher,
+            $this->findAreaOrFail($this->getRequest()->get('area_id', 0)),
+            $this->getRequest()->get('country_id', 0),
+            $this->getRequest()->get('state_id'),
+        );
+
+        return $this->redirectToEditionTemplate();
+    }
+
+    protected function findAreaOrFail($areaId): Area
+    {
+        $area = AreaQuery::create()
+            ->filterById($areaId)
+            ->findOne();
+
+        if (null === $area) {
+            throw new ElementNotFoundException($this->getTranslator()->trans('Area not found'));
+        }
+
+        return $area;
+    }
+}

--- a/Controller/Admin/AttributeAvController.php
+++ b/Controller/Admin/AttributeAvController.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\Attribute\AttributeAvCreateEvent;
+use Thelia\Core\Event\Attribute\AttributeAvDeleteEvent;
+use Thelia\Core\Event\Attribute\AttributeAvUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Model\AttributeAv;
+use Thelia\Model\AttributeAvQuery;
+
+/**
+ * Manages attributes-av.
+ *
+ * @author Franck Allimant <franck@cqfdev.fr>
+ */
+class AttributeAvController extends AbstractCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'attributeav',
+            'manual',
+            'order',
+            AdminResources::ATTRIBUTE,
+            TheliaEvents::ATTRIBUTE_AV_CREATE,
+            TheliaEvents::ATTRIBUTE_AV_UPDATE,
+            TheliaEvents::ATTRIBUTE_AV_DELETE,
+            null, // No visibility toggle
+            TheliaEvents::ATTRIBUTE_AV_UPDATE_POSITION,
+        );
+    }
+
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::ATTRIBUTE_AV_CREATION);
+    }
+
+    protected function getUpdateForm(): null
+    {
+        return null;
+    }
+
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $createEvent = new AttributeAvCreateEvent();
+
+        $createEvent
+            ->setAttributeId((int) $formData['attribute_id'])
+            ->setTitle($formData['title'])
+            ->setLocale($formData['locale']);
+
+        return $createEvent;
+    }
+
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $changeEvent = new AttributeAvUpdateEvent((int) $formData['id']);
+
+        // Create and dispatch the change event
+        $changeEvent
+            ->setLocale($formData['locale'])
+            ->setTitle($formData['title'])
+            ->setChapo($formData['chapo'])
+            ->setDescription($formData['description'])
+            ->setPostscriptum($formData['postscriptum']);
+
+        return $changeEvent;
+    }
+
+    protected function createUpdatePositionEvent($positionChangeMode, $positionValue): UpdatePositionEvent
+    {
+        return new UpdatePositionEvent(
+            (int) $this->getRequest()->get('attributeav_id'),
+            $positionChangeMode,
+            $positionValue,
+        );
+    }
+
+    protected function getDeleteEvent(): AttributeAvDeleteEvent
+    {
+        return new AttributeAvDeleteEvent((int) $this->getRequest()->get('attributeav_id'));
+    }
+
+    protected function eventContainsObject($event): bool
+    {
+        return $event->hasAttributeAv();
+    }
+
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        throw new \LogicException('Attribute Av. modification is not yet implemented');
+    }
+
+    protected function getObjectFromEvent($event): mixed
+    {
+        return $event->hasAttributeAv() ? $event->getAttributeAv() : null;
+    }
+
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        $attributeAv = AttributeAvQuery::create()
+            ->findOneById($this->getRequest()->get('attributeav_id', 0));
+
+        if (null !== $attributeAv) {
+            $attributeAv->setLocale($this->getCurrentEditionLocale());
+        }
+
+        return $attributeAv;
+    }
+
+    /**
+     * @param AttributeAv $object
+     */
+    protected function getObjectLabel(ActiveRecordInterface $object): ?string
+    {
+        return $object->getTitle();
+    }
+
+    /**
+     * @param AttributeAv $object
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    protected function getViewArguments(): array
+    {
+        return [
+            'attribute_id' => $this->getRequest()->get('attribute_id'),
+            'order' => $this->getCurrentListOrder(),
+        ];
+    }
+
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        // We always return to the attribute edition form
+        return $this->render(
+            'attribute-edit',
+            $this->getViewArguments(),
+        );
+    }
+
+    protected function renderEditionTemplate(): Response
+    {
+        // We always return to the attribute edition form
+        return $this->render('attribute-edit', $this->getViewArguments());
+    }
+
+    protected function redirectToEditionTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.configuration.attributes.update',
+            $this->getViewArguments(),
+        );
+    }
+
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.configuration.attributes.update',
+            $this->getViewArguments(),
+        );
+    }
+}

--- a/Controller/Admin/AttributeController.php
+++ b/Controller/Admin/AttributeController.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Propel\Runtime\Event\ActiveRecordEvent;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\Attribute\AttributeAvUpdateEvent;
+use Thelia\Core\Event\Attribute\AttributeCreateEvent;
+use Thelia\Core\Event\Attribute\AttributeDeleteEvent;
+use Thelia\Core\Event\Attribute\AttributeEvent;
+use Thelia\Core\Event\Attribute\AttributeUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Model\Attribute;
+use Thelia\Model\AttributeQuery;
+
+/**
+ * Manages attributes.
+ *
+ * @author Franck Allimant <franck@cqfdev.fr>
+ */
+class AttributeController extends AbstractCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'attribute',
+            'manual',
+            'order',
+            AdminResources::ATTRIBUTE,
+            TheliaEvents::ATTRIBUTE_CREATE,
+            TheliaEvents::ATTRIBUTE_UPDATE,
+            TheliaEvents::ATTRIBUTE_DELETE,
+            null, // No visibility toggle
+            TheliaEvents::ATTRIBUTE_UPDATE_POSITION,
+        );
+    }
+
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::ATTRIBUTE_CREATION);
+    }
+
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::ATTRIBUTE_MODIFICATION);
+    }
+
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $createEvent = new AttributeCreateEvent();
+
+        $createEvent
+            ->setTitle($formData['title'])
+            ->setLocale($formData['locale'])
+            ->setAddToAllTemplates($formData['add_to_all']);
+
+        return $createEvent;
+    }
+
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $changeEvent = new AttributeUpdateEvent((int) $formData['id']);
+
+        $changeEvent
+            ->setLocale($formData['locale'])
+            ->setTitle($formData['title'])
+            ->setChapo($formData['chapo'])
+            ->setDescription($formData['description'])
+            ->setPostscriptum($formData['postscriptum']);
+
+        return $changeEvent;
+    }
+
+    /**
+     * Process the attributes values (fix it in future version to integrate it in the attribute form as a collection).
+     */
+    protected function performAdditionalUpdateAction(EventDispatcherInterface $eventDispatcher, ActionEvent|ActiveRecordEvent|null $updateEvent): null
+    {
+        $attr_values = $this->getRequest()->get('attribute_values');
+
+        if (null !== $attr_values) {
+            foreach ($attr_values as $id => $value) {
+                $event = new AttributeAvUpdateEvent((int) $id);
+
+                $event->setTitle($value);
+                $event->setLocale($this->getCurrentEditionLocale());
+
+                $eventDispatcher->dispatch($event, TheliaEvents::ATTRIBUTE_AV_UPDATE);
+            }
+        }
+
+        return null;
+    }
+
+    protected function createUpdatePositionEvent(int $positionChangeMode, ?int $positionValue = null): UpdatePositionEvent
+    {
+        return new UpdatePositionEvent(
+            (int) $this->getRequest()->get('attribute_id'),
+            $positionChangeMode,
+            $positionValue,
+        );
+    }
+
+    protected function getDeleteEvent(): AttributeDeleteEvent
+    {
+        return new AttributeDeleteEvent((int) $this->getRequest()->get('attribute_id'));
+    }
+
+    protected function eventContainsObject($event): bool
+    {
+        return $event->hasAttribute();
+    }
+
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        $data = [
+            'id' => $object->getId(),
+            'locale' => $object->getLocale(),
+            'title' => $object->getTitle(),
+            'chapo' => $object->getChapo(),
+            'description' => $object->getDescription(),
+            'postscriptum' => $object->getPostscriptum(),
+        ];
+
+        // Setup the object form
+        return $this->createForm(AdminForm::ATTRIBUTE_MODIFICATION, FormType::class, $data);
+    }
+
+    protected function getObjectFromEvent($event): mixed
+    {
+        return $event->hasAttribute() ? $event->getAttribute() : null;
+    }
+
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        $attribute = AttributeQuery::create()
+            ->findOneById($this->getRequest()->get('attribute_id', 0));
+
+        if (null !== $attribute) {
+            $attribute->setLocale($this->getCurrentEditionLocale());
+        }
+
+        return $attribute;
+    }
+
+    /**
+     * @param Attribute $object
+     */
+    protected function getObjectLabel(ActiveRecordInterface $object): ?string
+    {
+        return $object->getTitle();
+    }
+
+    /**
+     * @param Attribute $object
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        return $this->render('attributes', ['order' => $currentOrder]);
+    }
+
+    protected function renderEditionTemplate(): Response
+    {
+        return $this->render(
+            'attribute-edit',
+            [
+                'attribute_id' => $this->getRequest()->get('attribute_id'),
+                'attributeav_order' => $this->getAttributeAvListOrder(),
+            ],
+        );
+    }
+
+    protected function redirectToEditionTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.configuration.attributes.update',
+            [
+                'attribute_id' => $this->getRequest()->get('attribute_id'),
+                'attributeav_order' => $this->getAttributeAvListOrder(),
+            ],
+        );
+    }
+
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute('admin.configuration.attributes.default');
+    }
+
+    /**
+     * Get the Attribute value list order.
+     *
+     * @return string the current list order
+     */
+    protected function getAttributeAvListOrder(): ?string
+    {
+        return $this->getListOrderFromSession(
+            'attributeav',
+            'attributeav_order',
+            'manual',
+        );
+    }
+
+    /**
+     * Add or Remove from all product templates.
+     */
+    protected function addRemoveFromAllTemplates(EventDispatcherInterface $eventDispatcher, ?string $eventType): Response
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        try {
+            if (($object = $this->getExistingObject()) instanceof ActiveRecordInterface) {
+                $event = new AttributeEvent($object);
+
+                $eventDispatcher->dispatch($event, $eventType);
+            }
+        } catch (\Exception $exception) {
+            // Any error
+            return $this->errorPage($exception);
+        }
+
+        return $this->redirectToListTemplate();
+    }
+
+    /**
+     * Remove from all product templates.
+     */
+    public function removeFromAllTemplates(EventDispatcherInterface $eventDispatcher): Response
+    {
+        return $this->addRemoveFromAllTemplates($eventDispatcher, TheliaEvents::ATTRIBUTE_REMOVE_FROM_ALL_TEMPLATES);
+    }
+
+    /**
+     * Add to all product templates.
+     */
+    public function addToAllTemplates(EventDispatcherInterface $eventDispatcher): Response
+    {
+        return $this->addRemoveFromAllTemplates($eventDispatcher, TheliaEvents::ATTRIBUTE_ADD_TO_ALL_TEMPLATES);
+    }
+}

--- a/Controller/Admin/BrandController.php
+++ b/Controller/Admin/BrandController.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\Event;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\Brand\BrandCreateEvent;
+use Thelia\Core\Event\Brand\BrandDeleteEvent;
+use Thelia\Core\Event\Brand\BrandToggleVisibilityEvent;
+use Thelia\Core\Event\Brand\BrandUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Brand\BrandModificationForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Model\Brand;
+use Thelia\Model\BrandQuery;
+
+/**
+ * Class BrandController.
+ *
+ * @author  Franck Allimant <franck@cqfdev.fr>
+ */
+class BrandController extends AbstractSeoCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'brand',
+            'manual',
+            'order',
+            AdminResources::BRAND,
+            TheliaEvents::BRAND_CREATE,
+            TheliaEvents::BRAND_UPDATE,
+            TheliaEvents::BRAND_DELETE,
+            TheliaEvents::BRAND_TOGGLE_VISIBILITY,
+            TheliaEvents::BRAND_UPDATE_POSITION,
+            TheliaEvents::BRAND_UPDATE_SEO,
+        );
+    }
+
+    /**
+     * Return the creation form for this object.
+     */
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::BRAND_CREATION);
+    }
+
+    /**
+     * Return the update form for this object.
+     */
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::BRAND_MODIFICATION);
+    }
+
+    /**
+     * Hydrate the update form for this object, before passing it to the update template.
+     *
+     * @param Brand $object
+     *
+     * @return BrandModificationForm $object
+     */
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        // Hydrate the "SEO" tab form
+        $this->hydrateSeoForm($parserContext, $object);
+
+        // Prepare the data that will hydrate the form
+        $data = [
+            'id' => $object->getId(),
+            'locale' => $object->getLocale(),
+            'title' => $object->getTitle(),
+            'chapo' => $object->getChapo(),
+            'description' => $object->getDescription(),
+            'postscriptum' => $object->getPostscriptum(),
+            'visible' => (bool) $object->getVisible(),
+            'logo_image_id' => $object->getLogoImageId(),
+        ];
+
+        // Setup the object form
+        return $this->createForm(AdminForm::BRAND_MODIFICATION, FormType::class, $data);
+    }
+
+    /**
+     * Creates the creation event with the provided form data.
+     */
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $brandCreateEvent = new BrandCreateEvent();
+
+        $brandCreateEvent
+            ->setLocale($formData['locale'])
+            ->setTitle($formData['title'])
+            ->setVisible($formData['visible']);
+
+        return $brandCreateEvent;
+    }
+
+    /**
+     * Creates the update event with the provided form data.
+     */
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $brandUpdateEvent = new BrandUpdateEvent((int) $formData['id']);
+
+        $brandUpdateEvent
+            ->setLogoImageId((int) $formData['logo_image_id'])
+            ->setVisible($formData['visible'])
+            ->setLocale($formData['locale'])
+            ->setTitle($formData['title'])
+            ->setChapo($formData['chapo'])
+            ->setDescription($formData['description'])
+            ->setPostscriptum($formData['postscriptum']);
+
+        return $brandUpdateEvent;
+    }
+
+    /**
+     * Creates the delete event with the provided form data.
+     */
+    protected function getDeleteEvent(): BrandDeleteEvent
+    {
+        return new BrandDeleteEvent((int) $this->getRequest()->get('brand_id'));
+    }
+
+    /**
+     * Return true if the event contains the object, e.g. the action has updated the object in the event.
+     */
+    protected function eventContainsObject(Event $event): bool
+    {
+        return $event->hasBrand();
+    }
+
+    /**
+     * Get the created object from an event.
+     *
+     * @param $event \Thelia\Core\Event\Brand\BrandEvent
+     */
+    protected function getObjectFromEvent($event): ?Brand
+    {
+        return $event->getBrand();
+    }
+
+    /**
+     * Load an existing object from the database.
+     *
+     * @return Brand
+     */
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        $brand = BrandQuery::create()
+            ->findOneById($this->getRequest()->get('brand_id', 0));
+
+        if (null !== $brand) {
+            $brand->setLocale($this->getCurrentEditionLocale());
+        }
+
+        return $brand;
+    }
+
+    /**
+     * Returns the object label form the object event (name, title, etc.).
+     *
+     * @param Brand $object
+     *
+     * @return string brand title
+     */
+    protected function getObjectLabel(ActiveRecordInterface $object): ?string
+    {
+        return $object->getTitle();
+    }
+
+    /**
+     * Returns the object ID from the object.
+     *
+     * @param Brand $object
+     *
+     * @return int brand id
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    /**
+     * Render the main list template.
+     */
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        $this->getListOrderFromSession('brand', 'order', 'manual');
+
+        return $this->render('brands', [
+            'order' => $currentOrder,
+        ]);
+    }
+
+    protected function getEditionArguments(): array
+    {
+        return [
+            'brand_id' => $this->getRequest()->get('brand_id', 0),
+            'current_tab' => $this->getRequest()->get('current_tab', 'general'),
+        ];
+    }
+
+    /**
+     * Render the edition template.
+     */
+    protected function renderEditionTemplate(): Response
+    {
+        return $this->render('brand-edit', $this->getEditionArguments());
+    }
+
+    /**
+     * Redirect to the edition template.
+     */
+    protected function redirectToEditionTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.brand.update',
+            [],
+            $this->getEditionArguments(),
+        );
+    }
+
+    /**
+     * Redirect to the list template.
+     */
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute('admin.brand.default');
+    }
+
+    /**
+     * @return BrandToggleVisibilityEvent|void
+     */
+    protected function createToggleVisibilityEvent(): BrandToggleVisibilityEvent
+    {
+        return new BrandToggleVisibilityEvent($this->getExistingObject());
+    }
+
+    protected function createUpdatePositionEvent(int $positionChangeMode, ?int $positionValue = null): UpdatePositionEvent
+    {
+        return new UpdatePositionEvent(
+            (int) $this->getRequest()->get('brand_id'),
+            $positionChangeMode,
+            $positionValue,
+        );
+    }
+}

--- a/Controller/Admin/CategoryController.php
+++ b/Controller/Admin/CategoryController.php
@@ -1,0 +1,399 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Propel\Runtime\Event\ActiveRecordEvent;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\Category\CategoryAddContentEvent;
+use Thelia\Core\Event\Category\CategoryCreateEvent;
+use Thelia\Core\Event\Category\CategoryDeleteContentEvent;
+use Thelia\Core\Event\Category\CategoryDeleteEvent;
+use Thelia\Core\Event\Category\CategoryToggleVisibilityEvent;
+use Thelia\Core\Event\Category\CategoryUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Model\Category;
+use Thelia\Model\CategoryAssociatedContentQuery;
+use Thelia\Model\CategoryQuery;
+use Thelia\Model\ContentQuery;
+use Thelia\Model\FolderQuery;
+
+/**
+ * Manages categories.
+ *
+ * @author Franck Allimant <franck@cqfdev.fr>
+ */
+class CategoryController extends AbstractSeoCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'category',
+            'manual',
+            'category_order',
+            AdminResources::CATEGORY,
+            TheliaEvents::CATEGORY_CREATE,
+            TheliaEvents::CATEGORY_UPDATE,
+            TheliaEvents::CATEGORY_DELETE,
+            TheliaEvents::CATEGORY_TOGGLE_VISIBILITY,
+            TheliaEvents::CATEGORY_UPDATE_POSITION,
+            TheliaEvents::CATEGORY_UPDATE_SEO,
+        );
+    }
+
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::CATEGORY_CREATION);
+    }
+
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::CATEGORY_MODIFICATION);
+    }
+
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $createEvent = new CategoryCreateEvent();
+
+        $createEvent
+            ->setTitle($formData['title'])
+            ->setLocale($formData['locale'])
+            ->setParent($formData['parent'])
+            ->setVisible($formData['visible']);
+
+        return $createEvent;
+    }
+
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $changeEvent = new CategoryUpdateEvent($formData['id']);
+
+        // Create and dispatch the change event
+        $changeEvent
+            ->setLocale($formData['locale'])
+            ->setTitle($formData['title'])
+            ->setChapo($formData['chapo'])
+            ->setDescription($formData['description'])
+            ->setPostscriptum($formData['postscriptum'])
+            ->setVisible($formData['visible'])
+            ->setParent($formData['parent'])
+            ->setDefaultTemplateId((int) $formData['default_template_id']);
+
+        return $changeEvent;
+    }
+
+    protected function createUpdatePositionEvent(int $positionChangeMode, ?int $positionValue = null): UpdatePositionEvent
+    {
+        return new UpdatePositionEvent(
+            (int) $this->getRequest()->get('category_id'),
+            $positionChangeMode,
+            $positionValue,
+        );
+    }
+
+    protected function getDeleteEvent(): CategoryDeleteEvent
+    {
+        return new CategoryDeleteEvent($this->getRequest()->get('category_id', 0));
+    }
+
+    protected function eventContainsObject($event): bool
+    {
+        return $event->hasCategory();
+    }
+
+    /**
+     * @param Category $object
+     */
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        // Hydrate the "SEO" tab form
+        $this->hydrateSeoForm($parserContext, $object);
+
+        // The "General" tab form
+        $data = [
+            'id' => $object->getId(),
+            'locale' => $object->getLocale(),
+            'title' => $object->getTitle(),
+            'chapo' => $object->getChapo(),
+            'description' => $object->getDescription(),
+            'postscriptum' => $object->getPostscriptum(),
+            'visible' => $object->getVisible(),
+            'parent' => $object->getParent(),
+            'default_template_id' => $object->getDefaultTemplateId(),
+        ];
+
+        // Setup the object form
+        return $this->createForm(AdminForm::CATEGORY_MODIFICATION, FormType::class, $data);
+    }
+
+    protected function getObjectFromEvent($event): mixed
+    {
+        return $event->hasCategory() ? $event->getCategory() : null;
+    }
+
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        $category = CategoryQuery::create()
+            ->findOneById($this->getRequest()->get('category_id', 0));
+
+        if (null !== $category) {
+            $category->setLocale($this->getCurrentEditionLocale());
+        }
+
+        return $category;
+    }
+
+    protected function getObjectLabel(ActiveRecordInterface $object): string
+    {
+        \assert($object instanceof Category);
+
+        return (string) $object->getTitle();
+    }
+
+    /**
+     * @param Category $object
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    protected function getEditionArguments(): array
+    {
+        return [
+            'category_id' => $this->getRequest()->get('category_id', 0),
+            'folder_id' => $this->getRequest()->get('folder_id', 0),
+            'current_tab' => $this->getRequest()->get('current_tab', 'general'),
+            'page' => $this->getRequest()->get('page', 1),
+        ];
+    }
+
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        // Get product order
+        $product_order = $this->getListOrderFromSession('product', 'product_order', 'manual');
+
+        return $this->render(
+            'categories',
+            [
+                'category_order' => $currentOrder,
+                'product_order' => $product_order,
+                'category_id' => $this->getRequest()->get('category_id', 0),
+                'page' => $this->getRequest()->get('page', 1),
+            ],
+        );
+    }
+
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.categories.default',
+            [
+                'category_id' => $this->getRequest()->get('category_id', 0),
+                'page' => $this->getRequest()->get('page', 1),
+            ],
+        );
+    }
+
+    protected function redirectToListTemplateWithId($category_id)
+    {
+        $response = null;
+
+        if ($category_id > 0) {
+            $response = $this->generateRedirectFromRoute(
+                'admin.categories.default',
+                ['category_id' => $category_id],
+            );
+        } else {
+            $response = $this->generateRedirectFromRoute('admin.catalog');
+        }
+
+        return $response;
+    }
+
+    protected function renderEditionTemplate(): Response
+    {
+        return $this->render('category-edit', $this->getEditionArguments());
+    }
+
+    protected function redirectToEditionTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.categories.update',
+            $this->getEditionArguments(),
+        );
+    }
+
+    /**
+     * Online status toggle category.
+     */
+    public function setToggleVisibilityAction(
+        EventDispatcherInterface $eventDispatcher,
+    ): Response {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $event = new CategoryToggleVisibilityEvent($this->getExistingObject());
+
+        try {
+            $eventDispatcher->dispatch($event, TheliaEvents::CATEGORY_TOGGLE_VISIBILITY);
+        } catch (\Exception $exception) {
+            // Any error
+            return $this->errorPage($exception);
+        }
+
+        // Ajax response -> no action
+        return $this->nullResponse();
+    }
+
+    protected function performAdditionalDeleteAction(ActionEvent|ActiveRecordEvent|null $deleteEvent): ?Response
+    {
+        // Redirect to parent category list
+        $category_id = $deleteEvent->getCategory()?->getParent();
+
+        return $this->redirectToListTemplateWithId($category_id ?? 0);
+    }
+
+    protected function performAdditionalUpdateAction(EventDispatcherInterface $eventDispatcher, ActionEvent|ActiveRecordEvent|null $updateEvent): ?Response
+    {
+        $response = null;
+
+        if ('stay' !== $this->getRequest()->get('save_mode')) {
+            // Redirect to parent category list
+            $category_id = $updateEvent->getCategory()->getParent();
+            $response = $this->redirectToListTemplateWithId($category_id);
+        }
+
+        return $response;
+    }
+
+    protected function performAdditionalUpdatePositionAction(ActionEvent $positionChangeEvent): ?Response
+    {
+        $category = CategoryQuery::create()->findPk($positionChangeEvent->getObjectId());
+        $response = null;
+
+        if (null !== $category) {
+            // Redirect to parent category list
+            $category_id = $category->getParent();
+            $response = $this->redirectToListTemplateWithId($category_id);
+        }
+
+        return $response;
+    }
+
+    public function getAvailableRelatedContentAction($categoryId, $folderId): Response
+    {
+        $result = [];
+
+        $folders = FolderQuery::create()->filterById($folderId)->find();
+
+        if (null !== $folders) {
+            $list = ContentQuery::create()
+                ->joinWithI18n($this->getCurrentEditionLocale())
+                ->filterByFolder($folders, Criteria::IN)
+                ->filterById(
+                    CategoryAssociatedContentQuery::create()->select('content_id')->findByCategoryId($categoryId),
+                    Criteria::NOT_IN,
+                )
+                ->find();
+
+            if (null !== $list) {
+                foreach ($list as $item) {
+                    $result[] = ['id' => $item->getId(), 'title' => $item->getTitle()];
+                }
+            }
+        }
+
+        return $this->jsonResponse(json_encode($result));
+    }
+
+    public function addRelatedContentAction(EventDispatcherInterface $eventDispatcher): Response
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $content_id = (int) $this->getRequest()->get('content_id');
+
+        if ($content_id > 0) {
+            $event = new CategoryAddContentEvent(
+                $this->getExistingObject(),
+                $content_id,
+            );
+
+            try {
+                $eventDispatcher->dispatch($event, TheliaEvents::CATEGORY_ADD_CONTENT);
+            } catch (\Exception $ex) {
+                // Any error
+                return $this->errorPage($ex);
+            }
+        }
+
+        return $this->redirectToEditionTemplate();
+    }
+
+    /**
+     * Add category pictures.
+     */
+    public function addRelatedPictureAction(): Response
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        return $this->redirectToEditionTemplate();
+    }
+
+    public function deleteRelatedContentAction(EventDispatcherInterface $eventDispatcher): Response
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $content_id = (int) $this->getRequest()->get('content_id');
+
+        if ($content_id > 0) {
+            $event = new CategoryDeleteContentEvent(
+                $this->getExistingObject(),
+                $content_id,
+            );
+
+            try {
+                $eventDispatcher->dispatch($event, TheliaEvents::CATEGORY_REMOVE_CONTENT);
+            } catch (\Exception $ex) {
+                // Any error
+                return $this->errorPage($ex);
+            }
+        }
+
+        return $this->redirectToEditionTemplate();
+    }
+}

--- a/Controller/Admin/ChoiceFilterController.php
+++ b/Controller/Admin/ChoiceFilterController.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\Exception\PropelException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\ChoiceFilter;
+use Thelia\Model\ChoiceFilterQuery;
+use Thelia\Tools\URL;
+
+/**
+ * @author Gilles Bourgeat <gbourgeat@openstudio.fr>
+ */
+class ChoiceFilterController extends BaseAdminController
+{
+    /**
+     * @throws PropelException
+     */
+    #[Route(
+        '/admin/choicefilter/save',
+        name: 'choicefilter.save',
+        methods: ['POST'],
+    )]
+    public function saveAction(Request $request): Response
+    {
+        $data = $request->get('ChoiceFilter');
+
+        if (!empty($data['template_id'])) {
+            $templateId = (int) $data['template_id'];
+            ChoiceFilterQuery::create()
+                ->filterByTemplateId($templateId)
+                ->delete();
+
+            $choiceFilterBase = (new ChoiceFilter())
+                ->setTemplateId($templateId);
+
+            $parameters = [
+                'template_id' => $templateId,
+            ];
+            $redirectUrl = '/admin/configuration/templates/update';
+        } elseif (!empty($data['category_id'])) {
+            $categoryId = (int) $data['category_id'];
+            ChoiceFilterQuery::create()
+                ->filterByCategoryId($categoryId)
+                ->delete();
+
+            $choiceFilterBase = (new ChoiceFilter())
+                ->setCategoryId($categoryId);
+
+            $parameters = [
+                'category_id' => $categoryId,
+            ];
+            $redirectUrl = '/admin/categories/update?category_id='.$categoryId.'&current_tab=associations#choice-filter';
+        } else {
+            throw new \RuntimeException('Missing parameter');
+        }
+
+        foreach ($data['filter'] as $filter) {
+            $choiceFilter = clone $choiceFilterBase;
+
+            $choiceFilter
+                ->setVisible((int) $filter['visible'])
+                ->setPosition((int) $filter['position'])
+                ->setType($filter['display_type']);
+
+            if ('attribute' === $filter['type']) {
+                $choiceFilter
+                    ->setAttributeId((int) $filter['id']);
+            } elseif ('feature' === $filter['type']) {
+                $choiceFilter
+                    ->setFeatureId((int) $filter['id']);
+            } else {
+                $choiceFilter
+                    ->setOtherId((int) $filter['id']);
+            }
+
+            $choiceFilter->save();
+        }
+
+        $this->getSession()->getFlashBag()->add('choice-filter-success', Translator::getInstance()->trans('Configuration saved successfully'));
+
+        return $this->generateRedirect(
+            URL::getInstance()->absoluteUrl($redirectUrl, $parameters),
+        );
+    }
+
+    /**
+     * @throws PropelException
+     */
+    #[Route(
+        '/admin/choicefilter/clear',
+        name: 'choicefilter.clear',
+        methods: ['POST'],
+    )]
+    public function clearAction(Request $request): Response
+    {
+        $data = $request->get('ChoiceFilter');
+
+        if (!empty($data['template_id'])) {
+            $templateId = (int) $data['template_id'];
+            ChoiceFilterQuery::create()
+                ->filterByTemplateId($templateId)
+                ->delete();
+
+            $parameters = [
+                'template_id' => $templateId,
+            ];
+            $redirectUrl = '/admin/configuration/templates/update';
+        } elseif (!empty($data['category_id'])) {
+            $categoryId = (int) $data['category_id'];
+            ChoiceFilterQuery::create()
+                ->filterByCategoryId($categoryId)
+                ->delete();
+
+            $parameters = [
+                'category_id' => $categoryId,
+            ];
+            $redirectUrl = '/admin/categories/update?category_id='.$categoryId.'&current_tab=associations#choice-filter';
+        } else {
+            throw new \RuntimeException('Missing parameter');
+        }
+
+        $this->getSession()->getFlashBag()->add('choice-filter-success', Translator::getInstance()->trans('Configuration saved successfully'));
+
+        return $this->generateRedirect(
+            URL::getInstance()->absoluteUrl($redirectUrl, $parameters),
+        );
+    }
+}

--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Cache\ConfigCacheService;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\Config\ConfigCreateEvent;
+use Thelia\Core\Event\Config\ConfigDeleteEvent;
+use Thelia\Core\Event\Config\ConfigUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Model\Config;
+use Thelia\Model\ConfigQuery;
+
+/**
+ * Manages variables.
+ *
+ * @author Franck Allimant <franck@cqfdev.fr>
+ */
+class ConfigController extends AbstractCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'variable',
+            'name',
+            'order',
+            AdminResources::CONFIG,
+            TheliaEvents::CONFIG_CREATE,
+            TheliaEvents::CONFIG_UPDATE,
+            TheliaEvents::CONFIG_DELETE, // no position change
+        );
+    }
+
+    /**
+     * The default action is displaying the list.
+     *
+     * @return Response the response
+     */
+    public function defaultAction(?ConfigCacheService $configCacheService = null): Response
+    {
+        // Force reinit config cache
+        if ($configCacheService instanceof ConfigCacheService) {
+            $configCacheService->initCacheConfigs(true);
+        }
+
+        return parent::defaultAction();
+    }
+
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::CONFIG_CREATION);
+    }
+
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::CONFIG_MODIFICATION);
+    }
+
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $createEvent = new ConfigCreateEvent();
+
+        $createEvent
+            ->setEventName($formData['name'])
+            ->setValue($formData['value'])
+            ->setLocale($formData['locale'])
+            ->setTitle($formData['title'])
+            ->setHidden($formData['hidden'])
+            ->setSecured($formData['secured']);
+
+        return $createEvent;
+    }
+
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $changeEvent = new ConfigUpdateEvent((int) $formData['id']);
+
+        $changeEvent
+            ->setEventName($formData['name'])
+            ->setValue($formData['value'])
+            ->setHidden($formData['hidden'])
+            ->setSecured($formData['secured'])
+            ->setLocale($formData['locale'])
+            ->setTitle($formData['title'])
+            ->setChapo($formData['chapo'])
+            ->setDescription($formData['description'])
+            ->setPostscriptum($formData['postscriptum']);
+
+        return $changeEvent;
+    }
+
+    protected function getDeleteEvent(): ConfigDeleteEvent
+    {
+        return new ConfigDeleteEvent((int) $this->getRequest()->get('variable_id'));
+    }
+
+    protected function eventContainsObject($event): bool
+    {
+        return $event->hasConfig();
+    }
+
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        // Prepare the data that will hydrate the form
+        $data = [
+            'id' => $object->getId(),
+            'name' => $object->getName(),
+            'value' => $object->getValue(),
+            'hidden' => $object->getHidden(),
+            'secured' => $object->getSecured(),
+            'locale' => $object->getLocale(),
+            'title' => $object->getTitle(),
+            'chapo' => $object->getChapo(),
+            'description' => $object->getDescription(),
+            'postscriptum' => $object->getPostscriptum(),
+        ];
+
+        // Setup the object form
+        return $this->createForm(AdminForm::CONFIG_MODIFICATION, FormType::class, $data);
+    }
+
+    protected function getObjectFromEvent($event): mixed
+    {
+        return $event->hasConfig() ? $event->getConfig() : null;
+    }
+
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        $config = ConfigQuery::create()
+            ->findOneById($this->getRequest()->get('variable_id'));
+
+        if (null !== $config) {
+            $config->setLocale($this->getCurrentEditionLocale());
+        }
+
+        return $config;
+    }
+
+    /**
+     * @param Config $object
+     */
+    protected function getObjectLabel(ActiveRecordInterface $object): ?string
+    {
+        return $object->getName();
+    }
+
+    /**
+     * @param Config $object
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        return $this->render('variables', ['order' => $currentOrder]);
+    }
+
+    protected function renderEditionTemplate(): Response
+    {
+        return $this->render('variable-edit', ['variable_id' => $this->getRequest()->get('variable_id')]);
+    }
+
+    protected function redirectToEditionTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.configuration.variables.update',
+            ['variable_id' => $this->getRequest()->get('variable_id')],
+        );
+    }
+
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute('admin.configuration.variables.default');
+    }
+
+    /**
+     * Change values modified directly from the variable list.
+     *
+     * @return Response the response
+     */
+    public function changeValuesAction(EventDispatcherInterface $dispatcher): Response|RedirectResponse
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $variables = $this->getRequest()->get('variable', []);
+
+        // Process all changed variables
+        foreach ($variables as $id => $value) {
+            $event = new ConfigUpdateEvent((int) $id);
+            $event->setValue($value);
+
+            $dispatcher->dispatch($event, TheliaEvents::CONFIG_SETVALUE);
+        }
+
+        return $this->generateRedirectFromRoute('admin.configuration.variables.default');
+    }
+}

--- a/Controller/Admin/ConfigStoreController.php
+++ b/Controller/Admin/ConfigStoreController.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Form\Exception\FormValidationException;
+use Thelia\Model\ConfigQuery;
+
+/**
+ * Class ConfigStoreController.
+ *
+ * @author Christophe Laffont <claffont@openstudio.fr>
+ */
+class ConfigStoreController extends BaseAdminController
+{
+    protected function renderTemplate(): Response
+    {
+        return $this->render('config-store');
+    }
+
+    public function defaultAction()
+    {
+        if (($response = $this->checkAuth(AdminResources::STORE, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        // The form is self-hydrated
+        $configStoreForm = $this->createForm(AdminForm::CONFIG_STORE);
+
+        $this->getParserContext()->addForm($configStoreForm);
+
+        return $this->renderTemplate();
+    }
+
+    protected function getAndWriteStoreMediaFileInConfig($form, $inputName, $configKey, string $storeMediaUploadDir): void
+    {
+        $file = $form->get($inputName)->getData();
+
+        if (null !== $file) {
+            // Delete the old file
+            $fs = new Filesystem();
+            $oldFileName = ConfigQuery::read($configKey);
+
+            if (null !== $oldFileName) {
+                $oldFilePath = $storeMediaUploadDir.DS.$oldFileName;
+
+                if ($fs->exists($oldFilePath)) {
+                    $fs->remove($oldFilePath);
+                }
+            }
+
+            // Write the new file
+            $newFileName = uniqid().'-'.$file->getClientOriginalName();
+            $file->move($storeMediaUploadDir, $newFileName);
+            ConfigQuery::write($configKey, $newFileName, false);
+        }
+    }
+
+    public function saveAction(): Response|RedirectResponse|null
+    {
+        if (($response = $this->checkAuth(AdminResources::STORE, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $error_msg = false;
+        $response = null;
+        $configStoreForm = $this->createForm(AdminForm::CONFIG_STORE);
+
+        $exception = null;
+
+        try {
+            $form = $this->validateForm($configStoreForm);
+
+            $storeMediaUploadDir = ConfigQuery::read('images_library_path');
+
+            if (null === $storeMediaUploadDir) {
+                $storeMediaUploadDir = THELIA_LOCAL_DIR.'media'.DS.'images';
+            } else {
+                $storeMediaUploadDir = THELIA_ROOT.$storeMediaUploadDir;
+            }
+
+            $storeMediaUploadDir .= DS.'store';
+
+            // List of medias that can be uploaded through this form.
+            //  [Name of the form input] => [Key in the config table]
+            $storeMediaList = [
+                'favicon_file' => 'favicon_file',
+                'logo_file' => 'logo_file',
+                'banner_file' => 'banner_file',
+            ];
+
+            foreach ($storeMediaList as $input_name => $config_key) {
+                $this->getAndWriteStoreMediaFileInConfig($form, $input_name, $config_key, $storeMediaUploadDir);
+            }
+
+            $data = $form->getData();
+
+            // Update store
+            foreach ($data as $name => $value) {
+                if (!\array_key_exists($name, $storeMediaList) && !$configStoreForm->isTemplateDefinedHiddenFieldName($name)) {
+                    ConfigQuery::write($name, $value ?? '', false);
+                }
+            }
+
+            $this->adminLogAppend(AdminResources::STORE, AccessManager::UPDATE, 'Store configuration changed');
+
+            if ('stay' === $this->getRequest()->get('save_mode')) {
+                $response = $this->generateRedirectFromRoute('admin.configuration.store.default');
+            } else {
+                $response = $this->generateSuccessRedirect($configStoreForm);
+            }
+        } catch (FormValidationException $exception) {
+            $error_msg = $exception->getMessage();
+        }
+
+        if (false !== $error_msg) {
+            $this->setupFormErrorContext(
+                $this->getTranslator()->trans('Store configuration failed.'),
+                $error_msg,
+                $configStoreForm,
+                $exception,
+            );
+
+            $response = $this->renderTemplate();
+        }
+
+        return $response;
+    }
+}

--- a/Controller/Admin/ConfigurationController.php
+++ b/Controller/Admin/ConfigurationController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Symfony\Component\HttpFoundation\Response;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+
+/**
+ * Class ConfigurationController.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class ConfigurationController extends BaseAdminController
+{
+    public function indexAction()
+    {
+        if (($response = $this->checkAuth([AdminResources::CONFIG], [], [AccessManager::VIEW])) instanceof Response) {
+            return $response;
+        }
+
+        return $this->render('configuration');
+    }
+}

--- a/Controller/Admin/ContentController.php
+++ b/Controller/Admin/ContentController.php
@@ -1,0 +1,402 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Propel\Runtime\Event\ActiveRecordEvent;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\Content\ContentAddFolderEvent;
+use Thelia\Core\Event\Content\ContentCreateEvent;
+use Thelia\Core\Event\Content\ContentDeleteEvent;
+use Thelia\Core\Event\Content\ContentRemoveFolderEvent;
+use Thelia\Core\Event\Content\ContentToggleVisibilityEvent;
+use Thelia\Core\Event\Content\ContentUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Form\BaseForm;
+use Thelia\Form\ContentModificationForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Model\Content;
+use Thelia\Model\ContentQuery;
+
+/**
+ * Class ContentController.
+ *
+ * @author manuel raynaud <manu@raynaud.io>
+ */
+class ContentController extends AbstractSeoCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'content',
+            'manual',
+            'content_order',
+            AdminResources::CONTENT,
+            TheliaEvents::CONTENT_CREATE,
+            TheliaEvents::CONTENT_UPDATE,
+            TheliaEvents::CONTENT_DELETE,
+            TheliaEvents::CONTENT_TOGGLE_VISIBILITY,
+            TheliaEvents::CONTENT_UPDATE_POSITION,
+            TheliaEvents::CONTENT_UPDATE_SEO,
+        );
+    }
+
+    /**
+     * controller adding content to additional folder.
+     *
+     * @return mixed|Response
+     */
+    public function addAdditionalFolderAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $folder_id = (int) $this->getRequest()->request->get('additional_folder_id');
+
+        if ($folder_id > 0) {
+            $event = new ContentAddFolderEvent(
+                $this->getExistingObject(),
+                $folder_id,
+            );
+
+            try {
+                $eventDispatcher->dispatch($event, TheliaEvents::CONTENT_ADD_FOLDER);
+            } catch (\Exception $e) {
+                return $this->errorPage($e);
+            }
+        }
+
+        return $this->redirectToEditionTemplate();
+    }
+
+    /**
+     * controller removing additional folder to a content.
+     *
+     * @return mixed|Response
+     */
+    public function removeAdditionalFolderAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $folder_id = (int) $this->getRequest()->request->get('additional_folder_id');
+
+        if ($folder_id > 0) {
+            $event = new ContentRemoveFolderEvent(
+                $this->getExistingObject(),
+                $folder_id,
+            );
+
+            try {
+                $eventDispatcher->dispatch($event, TheliaEvents::CONTENT_REMOVE_FOLDER);
+            } catch (\Exception $e) {
+                return $this->errorPage($e);
+            }
+        }
+
+        return $this->redirectToEditionTemplate();
+    }
+
+    /**
+     * Return the creation form for this object.
+     */
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::CONTENT_CREATION);
+    }
+
+    /**
+     * Return the update form for this object.
+     */
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::CONTENT_MODIFICATION);
+    }
+
+    /**
+     * Hydrate the update form for this object, before passing it to the update template.
+     *
+     * @param Content $object
+     *
+     * @return ContentModificationForm
+     */
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        // Hydrate the "SEO" tab form
+        $this->hydrateSeoForm($parserContext, $object);
+
+        // Prepare the data that will hydrate the form
+        $data = [
+            'id' => $object->getId(),
+            'locale' => $object->getLocale(),
+            'title' => $object->getTitle(),
+            'chapo' => $object->getChapo(),
+            'description' => $object->getDescription(),
+            'postscriptum' => $object->getPostscriptum(),
+            'visible' => $object->getVisible(),
+        ];
+
+        // Setup the object form
+        return $this->createForm(AdminForm::CONTENT_MODIFICATION, FormType::class, $data);
+    }
+
+    /**
+     * Creates the creation event with the provided form data.
+     */
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $contentCreateEvent = new ContentCreateEvent();
+
+        $contentCreateEvent
+            ->setLocale($formData['locale'])
+            ->setDefaultFolder($formData['default_folder'])
+            ->setTitle($formData['title'])
+            ->setVisible($formData['visible']);
+
+        return $contentCreateEvent;
+    }
+
+    /**
+     * Creates the update event with the provided form data.
+     */
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $contentUpdateEvent = new ContentUpdateEvent($formData['id']);
+
+        $contentUpdateEvent
+            ->setLocale($formData['locale'])
+            ->setTitle($formData['title'])
+            ->setChapo($formData['chapo'])
+            ->setDescription($formData['description'])
+            ->setPostscriptum($formData['postscriptum'])
+            ->setVisible($formData['visible'])
+            ->setDefaultFolder($formData['default_folder']);
+
+        return $contentUpdateEvent;
+    }
+
+    /**
+     * Creates the delete event with the provided form data.
+     */
+    protected function getDeleteEvent(): ContentDeleteEvent
+    {
+        return new ContentDeleteEvent($this->getRequest()->get('content_id'));
+    }
+
+    /**
+     * Return true if the event contains the object, e.g. the action has updated the object in the event.
+     */
+    protected function eventContainsObject(Event $event): bool
+    {
+        return $event->hasContent();
+    }
+
+    /**
+     * Get the created object from an event.
+     *
+     * @param $event \Thelia\Core\Event\Content\ContentEvent
+     *
+     * @return Content|null
+     */
+    protected function getObjectFromEvent($event): mixed
+    {
+        return $event->getContent();
+    }
+
+    /**
+     * Load an existing object from the database.
+     *
+     * @return Content
+     */
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        $content = ContentQuery::create()
+            ->findOneById($this->getRequest()->get('content_id', 0));
+
+        if (null !== $content) {
+            $content->setLocale($this->getCurrentEditionLocale());
+        }
+
+        return $content;
+    }
+
+    /**
+     * Returns the object label form the object event (name, title, etc.).
+     *
+     * @param Content $object
+     *
+     * @return string content title
+     */
+    protected function getObjectLabel(ActiveRecordInterface $object): ?string
+    {
+        return $object->getTitle();
+    }
+
+    /**
+     * Returns the object ID from the object.
+     *
+     * @param Content $object
+     *
+     * @return int content id
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    protected function getFolderId()
+    {
+        $folderId = $this->getRequest()->get('folder_id');
+
+        if (null === $folderId) {
+            $content = $this->getExistingObject();
+
+            if ($content instanceof ActiveRecordInterface) {
+                $folderId = $content->getDefaultFolderId();
+            }
+        }
+
+        return $folderId ?: 0;
+    }
+
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        $this->getListOrderFromSession('content', 'content_order', 'manual');
+
+        return $this->render(
+            'folders',
+            [
+                'content_order' => $currentOrder,
+                'parent' => $this->getFolderId(),
+            ],
+        );
+    }
+
+    protected function getEditionArguments(): array
+    {
+        return [
+            'content_id' => $this->getRequest()->get('content_id', 0),
+            'current_tab' => $this->getRequest()->get('current_tab', 'general'),
+            'folder_id' => $this->getFolderId(),
+        ];
+    }
+
+    /**
+     * Render the edition template.
+     */
+    protected function renderEditionTemplate(): Response
+    {
+        return $this->render('content-edit', $this->getEditionArguments());
+    }
+
+    /**
+     * Redirect to the edition template.
+     */
+    protected function redirectToEditionTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.content.update',
+            [],
+            $this->getEditionArguments(),
+        );
+    }
+
+    /**
+     * Redirect to the list template.
+     */
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.content.default',
+            ['parent' => $this->getFolderId()],
+        );
+    }
+
+    /**
+     * @return Response|void
+     */
+    protected function performAdditionalUpdateAction(EventDispatcherInterface $eventDispatcher, ActionEvent|ActiveRecordEvent|null $updateEvent): ?Response
+    {
+        if ('stay' !== $this->getRequest()->get('save_mode')) {
+            return $this->generateRedirectFromRoute(
+                'admin.folders.default',
+                ['parent' => $this->getFolderId()],
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * Put in this method post object delete processing if required.
+     */
+    protected function performAdditionalDeleteAction(ActionEvent|ActiveRecordEvent|null $deleteEvent): ?Response
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.folders.default',
+            ['parent' => $deleteEvent->getDefaultFolderId()],
+        );
+    }
+
+    /**
+     * @param $positionChangeEvent ActionEvent
+     */
+    protected function performAdditionalUpdatePositionAction(ActionEvent $positionChangeEvent): ?Response
+    {
+        if (null !== $content = ContentQuery::create()->findPk($positionChangeEvent->getObjectId())) {
+            // Redirect to parent category list
+            return $this->generateRedirectFromRoute(
+                'admin.folders.default',
+                ['parent' => $positionChangeEvent->getReferrerId()],
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * @return UpdatePositionEvent|void
+     */
+    protected function createUpdatePositionEvent(int $positionChangeMode, ?int $positionValue = null): UpdatePositionEvent
+    {
+        return new UpdatePositionEvent(
+            (int) $this->getRequest()->get('content_id'),
+            $positionChangeMode,
+            $positionValue,
+            (int) $this->getRequest()->get('folder_id'),
+        );
+    }
+
+    /**
+     * @return ContentToggleVisibilityEvent|void
+     */
+    protected function createToggleVisibilityEvent(): ContentToggleVisibilityEvent
+    {
+        return new ContentToggleVisibilityEvent($this->getExistingObject());
+    }
+}

--- a/Controller/Admin/CountryController.php
+++ b/Controller/Admin/CountryController.php
@@ -1,0 +1,339 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\Country\CountryCreateEvent;
+use Thelia\Core\Event\Country\CountryDeleteEvent;
+use Thelia\Core\Event\Country\CountryToggleDefaultEvent;
+use Thelia\Core\Event\Country\CountryToggleVisibilityEvent;
+use Thelia\Core\Event\Country\CountryUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Log\Tlog;
+use Thelia\Model\Country;
+use Thelia\Model\CountryQuery;
+use Thelia\Model\State;
+use Thelia\Model\StateQuery;
+
+/**
+ * Class CustomerController.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class CountryController extends AbstractCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'country',
+            'manual',
+            'country_order',
+            AdminResources::COUNTRY,
+            TheliaEvents::COUNTRY_CREATE,
+            TheliaEvents::COUNTRY_UPDATE,
+            TheliaEvents::COUNTRY_DELETE,
+            TheliaEvents::COUNTRY_TOGGLE_VISIBILITY,
+        );
+    }
+
+    /**
+     * Return the creation form for this object.
+     */
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::COUNTRY_CREATION);
+    }
+
+    /**
+     * Return the update form for this object.
+     */
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::COUNTRY_MODIFICATION);
+    }
+
+    /**
+     * Hydrate the update form for this object, before passing it to the update template.
+     *
+     * @param Country $object
+     */
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        $data = [
+            'id' => $object->getId(),
+            'locale' => $object->getLocale(),
+            'visible' => (bool) $object->getVisible(),
+            'title' => $object->getTitle(),
+            'chapo' => $object->getChapo(),
+            'description' => $object->getDescription(),
+            'postscriptum' => $object->getPostscriptum(),
+            'isocode' => $object->getIsocode(),
+            'isoalpha2' => $object->getIsoalpha2(),
+            'isoalpha3' => $object->getIsoalpha3(),
+            'has_states' => (bool) $object->getHasStates(),
+            'need_zip_code' => (bool) $object->getNeedZipCode(),
+            'zip_code_format' => $object->getZipCodeFormat(),
+        ];
+
+        return $this->createForm(AdminForm::COUNTRY_MODIFICATION, FormType::class, $data);
+    }
+
+    /**
+     * Creates the creation event with the provided form data.
+     *
+     * @return CountryCreateEvent
+     */
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $event = new CountryCreateEvent();
+
+        return $this->hydrateEvent($event, $formData);
+    }
+
+    /**
+     * Creates the update event with the provided form data.
+     *
+     * @return CountryUpdateEvent
+     */
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $event = new CountryUpdateEvent((int) $formData['id']);
+
+        $event = $this->hydrateEvent($event, $formData);
+
+        $event
+            ->setChapo($formData['chapo'])
+            ->setDescription($formData['description'])
+            ->setPostscriptum($formData['postscriptum'])
+            ->setNeedZipCode($formData['need_zip_code'])
+            ->setZipCodeFormat($formData['zip_code_format']);
+
+        return $event;
+    }
+
+    protected function hydrateEvent($event, array $formData)
+    {
+        $event
+            ->setLocale($formData['locale'])
+            ->setVisible($formData['visible'])
+            ->setTitle($formData['title'])
+            ->setIsocode($formData['isocode'])
+            ->setIsoAlpha2($formData['isoalpha2'])
+            ->setIsoAlpha3($formData['isoalpha3'])
+            ->setHasStates($formData['has_states']);
+
+        return $event;
+    }
+
+    /**
+     * Creates the delete event with the provided form data.
+     */
+    protected function getDeleteEvent(): CountryDeleteEvent
+    {
+        return new CountryDeleteEvent($this->getRequest()->get('country_id'));
+    }
+
+    /**
+     * Return true if the event contains the object, e.g. the action has updated the object in the event.
+     */
+    protected function eventContainsObject(Event $event): bool
+    {
+        return $event->hasCountry();
+    }
+
+    /**
+     * Get the created object from an event.
+     *
+     * @return Country
+     */
+    protected function getObjectFromEvent($event): mixed
+    {
+        return $event->getCountry();
+    }
+
+    /**
+     * Load an existing object from the database.
+     */
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        $country = CountryQuery::create()
+            ->findPk($this->getRequest()->get('country_id', 0));
+
+        if (null !== $country) {
+            $country->setLocale($this->getCurrentEditionLocale());
+        }
+
+        return $country;
+    }
+
+    /**
+     * Returns the object label form the object event (name, title, etc.).
+     *
+     * @param Country $object
+     */
+    protected function getObjectLabel(ActiveRecordInterface $object): ?string
+    {
+        return $object->getTitle();
+    }
+
+    /**
+     * Returns the object ID from the object.
+     *
+     * @param Country $object
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    /**
+     * Render the main list template.
+     */
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        return $this->render('countries', ['display_country' => 20]);
+    }
+
+    /**
+     * Render the edition template.
+     */
+    protected function renderEditionTemplate(): Response
+    {
+        return $this->render('country-edit', $this->getEditionArgument());
+    }
+
+    protected function getEditionArgument(): array
+    {
+        return [
+            'country_id' => $this->getRequest()->get('country_id', 0),
+        ];
+    }
+
+    /**
+     * Redirect to the edition template.
+     */
+    protected function redirectToEditionTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.configuration.countries.update',
+            [],
+            [
+                'country_id' => $this->getRequest()->get('country_id', 0),
+            ],
+        );
+    }
+
+    /**
+     * Redirect to the list template.
+     */
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute('admin.configuration.countries.default');
+    }
+
+    public function toggleDefaultAction(EventDispatcherInterface $eventDispatcher): Response
+    {
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        if (null !== $country_id = $this->getRequest()->get('country_id')) {
+            $toogleDefaultEvent = new CountryToggleDefaultEvent($country_id);
+
+            try {
+                $eventDispatcher->dispatch($toogleDefaultEvent, TheliaEvents::COUNTRY_TOGGLE_DEFAULT);
+
+                if ($toogleDefaultEvent->hasCountry()) {
+                    return $this->nullResponse();
+                }
+            } catch (\Exception $ex) {
+                Tlog::getInstance()->error($ex->getMessage());
+            }
+        }
+
+        return $this->nullResponse(500);
+    }
+
+    /**
+     * @return CountryToggleVisibilityEvent|void
+     */
+    protected function createToggleVisibilityEvent(): CountryToggleVisibilityEvent
+    {
+        return new CountryToggleVisibilityEvent($this->getExistingObject());
+    }
+
+    public function getDataAction($visible = true, $locale = null): Response
+    {
+        $response = $this->checkAuth($this->resourceCode, [], AccessManager::VIEW);
+
+        if ($response instanceof Response) {
+            return $response;
+        }
+
+        if (null === $locale) {
+            $locale = $this->getCurrentEditionLocale();
+        }
+
+        $responseData = [];
+
+        $countries = CountryQuery::create()
+            ->_if($visible)
+            ->filterByVisible(true)
+            ->_endif()
+            ->joinWithI18n($locale);
+
+        /** @var Country $country */
+        foreach ($countries as $country) {
+            $currentCountry = [
+                'id' => $country->getId(),
+                'title' => $country->getTitle(),
+                'hasStates' => $country->getHasStates(),
+                'states' => [],
+            ];
+
+            if ($country->getHasStates()) {
+                $states = StateQuery::create()
+                    ->filterByCountryId($country->getId())
+                    ->_if($visible)
+                    ->filterByVisible(true)
+                    ->_endif()
+                    ->joinWithI18n($locale);
+
+                /** @var State $state */
+                foreach ($states as $state) {
+                    $currentCountry['states'][] = [
+                        'id' => $state->getId(),
+                        'title' => $state->getTitle(),
+                    ];
+                }
+            }
+
+            $responseData[] = $currentCountry;
+        }
+
+        return $this->jsonResponse(json_encode($responseData));
+    }
+}

--- a/Controller/Admin/CouponController.php
+++ b/Controller/Admin/CouponController.php
@@ -1,0 +1,869 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Form;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Condition\ConditionCollection;
+use Thelia\Condition\ConditionFactory;
+use Thelia\Condition\Implementation\ConditionInterface;
+use Thelia\Core\Event\Coupon\CouponCreateOrUpdateEvent;
+use Thelia\Core\Event\Coupon\CouponDeleteEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Domain\Promotion\Coupon\CouponFactory;
+use Thelia\Domain\Promotion\Coupon\Service\CouponManager;
+use Thelia\Domain\Promotion\Coupon\Type\CouponInterface;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Form\Exception\FormValidationException;
+use Thelia\Log\Tlog;
+use Thelia\Model\Coupon;
+use Thelia\Model\CouponCountry;
+use Thelia\Model\CouponModule;
+use Thelia\Model\CouponQuery;
+use Thelia\Model\LangQuery;
+use Thelia\Tools\Rest\ResponseRest;
+use Thelia\Tools\URL;
+
+/**
+ * Control View and Action (Model) via Events.
+ *
+ * @author  Guillaume MOREL <gmorel@openstudio.fr>
+ */
+class CouponController extends BaseAdminController
+{
+    public function __construct(
+        protected CouponManager $couponManager,
+    ) {
+    }
+
+    /**
+     * Manage Coupons list display.
+     */
+    public function browseAction(): Response
+    {
+        if (($response = $this->checkAuth(AdminResources::COUPON, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        return $this->render('coupon-list', [
+            'coupon_order' => $this->getListOrderFromSession('coupon', 'coupon_order', 'code'),
+        ]);
+    }
+
+    /**
+     * Manage Coupons creation display.
+     */
+    public function createAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        if (($response = $this->checkAuth(AdminResources::COUPON, [], AccessManager::CREATE)) instanceof Response) {
+            return $response;
+        }
+
+        // Parameters given to the template
+        $args = [];
+
+        $eventToDispatch = TheliaEvents::COUPON_CREATE;
+
+        if ($this->getRequest()->isMethod('POST')) {
+            if (($response = $this->validateCreateOrUpdateForm(
+                $eventDispatcher,
+                $eventToDispatch,
+                'created',
+                'creation',
+            )) instanceof RedirectResponse) {
+                return $response;
+            }
+        } else {
+            // If no input for expirationDate, now + 2 months
+            $defaultDate = new \DateTime();
+            $args['nowDate'] = $defaultDate->format($this->getDefaultDateFormat());
+            $args['defaultDate'] = $defaultDate->modify('+2 month')->format($this->getDefaultDateFormat());
+        }
+
+        $args['dateFormat'] = $this->getDefaultDateFormat();
+        $args['availableCoupons'] = $this->getAvailableCoupons();
+        $args['urlAjaxAdminCouponDrawInputs'] = $this->getRoute(
+            'admin.coupon.draw.inputs.ajax',
+            ['couponServiceId' => 'couponServiceId'],
+        );
+        $args['formAction'] = 'admin/coupon/create';
+
+        // Setup empty data if form is already in parser context
+        $this->getParserContext()->addForm($this->createForm(
+            AdminForm::COUPON_CREATION,
+            FormType::class,
+            ['locale' => $this->getCurrentEditionLocale()]
+        ));
+
+        return $this->render(
+            'coupon-create',
+            $args,
+        );
+    }
+
+    /**
+     * Manage Coupons edition display.
+     *
+     * @param int $couponId Coupon id
+     */
+    public function updateAction(EventDispatcherInterface $eventDispatcher, int $couponId): Response|RedirectResponse
+    {
+        if (($response = $this->checkAuth(AdminResources::COUPON, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        /** @var Coupon $coupon */
+        $coupon = CouponQuery::create()->findPk($couponId);
+
+        if (null === $coupon) {
+            return $this->pageNotFound();
+        }
+
+        $coupon->setLocale($this->getCurrentEditionLocale());
+
+        /** @var CouponFactory $couponFactory */
+        $couponFactory = $this->container->get('thelia.coupon.factory');
+        $couponManager = $couponFactory->buildCouponFromModel($coupon);
+
+        // Parameters given to the template
+        $args = [];
+
+        $eventToDispatch = TheliaEvents::COUPON_UPDATE;
+
+        // Update
+        if ($this->getRequest()->isMethod('POST')) {
+            if (($response = $this->validateCreateOrUpdateForm(
+                $eventDispatcher,
+                $eventToDispatch,
+                'updated',
+                'update',
+                $coupon,
+            )) instanceof RedirectResponse) {
+                return $response;
+            }
+        } else {
+            // Display
+            // Prepare the data that will hydrate the form
+            /** @var ConditionFactory $conditionFactory */
+            $conditionFactory = $this->container->get('thelia.condition.factory');
+            $conditions = $conditionFactory->unserializeConditionCollection(
+                $coupon->getSerializedConditions(),
+            );
+            $freeShippingForCountries = [];
+            $freeShippingForModules = [];
+
+            /** @var CouponCountry $item */
+            foreach ($coupon->getFreeShippingForCountries() as $item) {
+                $freeShippingForCountries[] = $item->getCountryId();
+            }
+
+            /** @var CouponModule $item */
+            foreach ($coupon->getFreeShippingForModules() as $item) {
+                $freeShippingForModules[] = $item->getModuleId();
+            }
+
+            if ([] === $freeShippingForCountries) {
+                $freeShippingForCountries[] = 0;
+            }
+
+            if ([] === $freeShippingForModules) {
+                $freeShippingForModules[] = 0;
+            }
+
+            $data = [
+                'code' => $coupon->getCode(),
+                'title' => $coupon->getTitle(),
+                'amount' => $coupon->getAmount(),
+                'type' => $coupon->getType(),
+                'shortDescription' => $coupon->getShortDescription(),
+                'description' => $coupon->getDescription(),
+                'isEnabled' => $coupon->getIsEnabled(),
+                'startDate' => $coupon->getStartDate($this->getDefaultDateFormat()),
+                'expirationDate' => $coupon->getExpirationDate($this->getDefaultDateFormat()),
+                'isAvailableOnSpecialOffers' => $coupon->getIsAvailableOnSpecialOffers(),
+                'isCumulative' => $coupon->getIsCumulative(),
+                'isRemovingPostage' => $coupon->getIsRemovingPostage(),
+                'maxUsage' => $coupon->getMaxUsage(),
+                'conditions' => $conditions,
+                'locale' => $this->getCurrentEditionLocale(),
+                'freeShippingForCountries' => $freeShippingForCountries,
+                'freeShippingForModules' => $freeShippingForModules,
+                'perCustomerUsageCount' => $coupon->getPerCustomerUsageCount(),
+            ];
+
+            $args['conditions'] = $this->cleanConditionForTemplate($conditions);
+
+            // Setup the object form
+            $changeForm = $this->createForm(AdminForm::COUPON_CREATION, FormType::class, $data);
+
+            // Pass it to the parser
+            $this->getParserContext()->addForm($changeForm);
+        }
+
+        $args['couponCode'] = $coupon->getCode();
+        $args['couponType'] = $coupon->getType();
+        $args['availableCoupons'] = $this->getAvailableCoupons();
+        $args['couponInputsHtml'] = $couponManager->drawBackOfficeInputs();
+        $args['urlAjaxAdminCouponDrawInputs'] = $this->getRoute(
+            'admin.coupon.draw.inputs.ajax',
+            ['couponServiceId' => 'couponServiceId'],
+        );
+        $args['availableConditions'] = $this->getAvailableConditions();
+        $args['urlAjaxGetConditionInputFromServiceId'] = $this->getRoute(
+            'admin.coupon.draw.condition.read.inputs.ajax',
+            ['conditionId' => 'conditionId'],
+        );
+        $args['urlAjaxGetConditionInputFromConditionInterface'] = $this->getRoute(
+            'admin.coupon.draw.condition.update.inputs.ajax',
+            [
+                'couponId' => $couponId,
+                'conditionIndex' => 8888888,
+            ],
+        );
+
+        $args['urlAjaxSaveConditions'] = $this->getRoute(
+            'admin.coupon.condition.save',
+            ['couponId' => $couponId],
+        );
+        $args['urlAjaxDeleteConditions'] = $this->getRoute(
+            'admin.coupon.condition.delete',
+            [
+                'couponId' => $couponId,
+                'conditionIndex' => 8888888,
+            ],
+        );
+        $args['urlAjaxGetConditionSummaries'] = $this->getRoute(
+            'admin.coupon.draw.condition.summaries.ajax',
+            ['couponId' => $couponId],
+        );
+
+        $args['formAction'] = 'admin/coupon/update/'.$couponId;
+
+        $args['dateFormat'] = $this->getDefaultDateFormat();
+
+        $args['couponId'] = $couponId;
+
+        return $this->render('coupon-update', $args);
+    }
+
+    /**
+     * Manage Coupons read display.
+     *
+     * @param string $conditionId Condition service id
+     *
+     * @return Response
+     */
+    public function getConditionEmptyInputAjaxAction(string $conditionId): Response|false
+    {
+        if (($response = $this->checkAuth(AdminResources::COUPON, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        $this->checkXmlHttpRequest();
+
+        if ('' !== $conditionId && '0' !== $conditionId) {
+            /** @var ConditionFactory $conditionFactory */
+            $conditionFactory = $this->container->get('thelia.condition.factory');
+            $inputs = $conditionFactory->getInputsFromServiceId($conditionId);
+
+            if (!$this->container->has($conditionId)) {
+                return false;
+            }
+
+            if (null === $inputs) {
+                return $this->pageNotFound();
+            }
+
+            /** @var ConditionInterface $condition */
+            $condition = $this->container->get($conditionId);
+
+            $html = $condition->drawBackOfficeInputs();
+            $serviceId = $condition->getServiceId();
+        } else {
+            $html = '';
+            $serviceId = '';
+        }
+
+        return $this->render(
+            'coupon/condition-input-ajax',
+            [
+                'inputsDrawn' => $html,
+                'conditionServiceId' => $serviceId,
+                'conditionIndex' => '',
+            ],
+        );
+    }
+
+    /**
+     * Manage Coupons read display.
+     *
+     * @param int $couponId       Coupon id being updated
+     * @param int $conditionIndex Coupon Condition position in the collection
+     */
+    public function getConditionToUpdateInputAjaxAction(int $couponId, int $conditionIndex): Response
+    {
+        if (($response = $this->checkAuth(AdminResources::COUPON, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        $this->checkXmlHttpRequest();
+
+        $search = CouponQuery::create();
+        /** @var Coupon $coupon */
+        $coupon = $search->findOneById($couponId);
+
+        if (!$coupon) {
+            return $this->pageNotFound();
+        }
+
+        /** @var CouponFactory $couponFactory */
+        $couponFactory = $this->container->get('thelia.coupon.factory');
+        $couponManager = $couponFactory->buildCouponFromModel($coupon);
+
+        if (!$couponManager instanceof CouponInterface) {
+            return $this->pageNotFound();
+        }
+
+        $conditions = $couponManager->getConditions();
+
+        if (!isset($conditions[$conditionIndex])) {
+            return $this->pageNotFound();
+        }
+
+        /** @var ConditionInterface $condition */
+        $condition = $conditions[$conditionIndex];
+
+        /** @var ConditionFactory $conditionFactory */
+        $conditionFactory = $this->container->get('thelia.condition.factory');
+        $inputs = $conditionFactory->getInputsFromConditionInterface($condition);
+
+        if (null === $inputs) {
+            return $this->pageNotFound();
+        }
+
+        return $this->render(
+            'coupon/condition-input-ajax',
+            [
+                'inputsDrawn' => $condition->drawBackOfficeInputs(),
+                'conditionServiceId' => $condition->getServiceId(),
+                'conditionIndex' => $conditionIndex,
+            ],
+        );
+    }
+
+    /**
+     * Manage Coupons read display.
+     *
+     * @param int $couponId Coupon id
+     */
+    public function saveConditionsAction(EventDispatcherInterface $eventDispatcher, int $couponId): Response
+    {
+        if (($response = $this->checkAuth(AdminResources::COUPON, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $this->checkXmlHttpRequest();
+
+        $search = CouponQuery::create();
+        /** @var Coupon $coupon */
+        $coupon = $search->findOneById($couponId);
+
+        if (!$coupon) {
+            return $this->pageNotFound();
+        }
+
+        $conditionToSave = $this->buildConditionFromRequest();
+
+        /** @var CouponFactory $couponFactory */
+        $couponFactory = $this->container->get('thelia.coupon.factory');
+        $couponManager = $couponFactory->buildCouponFromModel($coupon);
+
+        if (!$couponManager instanceof CouponInterface) {
+            return $this->pageNotFound();
+        }
+
+        $conditions = $couponManager->getConditions();
+        $conditionIndex = $this->getRequest()->request->get('conditionIndex');
+
+        if (null !== $conditionIndex && $conditionIndex >= 0) {
+            // Update mode
+            $conditions[$conditionIndex] = $conditionToSave;
+        } else {
+            // Insert mode
+            $conditions[] = $conditionToSave;
+        }
+
+        $couponManager->setConditions($conditions);
+
+        $this->manageConditionUpdate($eventDispatcher, $coupon, $conditions);
+
+        return new Response();
+    }
+
+    /**
+     * Manage Coupons condition deleteion.
+     *
+     * @param int $couponId       Coupon id
+     * @param int $conditionIndex Coupon condition index in the collection
+     */
+    public function deleteConditionsAction(EventDispatcherInterface $eventDispatcher, int $couponId, int $conditionIndex): Response
+    {
+        if (($response = $this->checkAuth(AdminResources::COUPON, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $this->checkXmlHttpRequest();
+
+        $search = CouponQuery::create();
+        /** @var Coupon $coupon */
+        $coupon = $search->findOneById($couponId);
+
+        if (!$coupon) {
+            return $this->pageNotFound();
+        }
+
+        /** @var CouponFactory $couponFactory */
+        $couponFactory = $this->container->get('thelia.coupon.factory');
+        $couponManager = $couponFactory->buildCouponFromModel($coupon);
+
+        if (!$couponManager instanceof CouponInterface) {
+            return $this->pageNotFound();
+        }
+
+        $conditions = $couponManager->getConditions();
+        unset($conditions[$conditionIndex]);
+        $couponManager->setConditions($conditions);
+
+        $this->manageConditionUpdate($eventDispatcher, $coupon, $conditions);
+
+        return new Response();
+    }
+
+    /**
+     * Log error message.
+     *
+     * @param string     $action  Creation|Update|Delete
+     * @param string     $message Message to log
+     * @param \Exception $e       Exception to log
+     *
+     * @return $this
+     */
+    protected function logError(string $action, string $message, \Exception $e): static
+    {
+        Tlog::getInstance()->error(
+            \sprintf(
+                'Error during Coupon '.$action.' process : %s. Exception was %s',
+                $message,
+                $e->getMessage(),
+            ),
+        );
+
+        return $this;
+    }
+
+    /**
+     * Validate the CreateOrUpdate form.
+     *
+     * @param string $eventToDispatch Event which will activate actions
+     * @param string $log             created|edited
+     * @param string $action          creation|edition
+     * @param Coupon $model           Model if in update mode
+     *
+     * @return $this
+     */
+    protected function validateCreateOrUpdateForm(EventDispatcherInterface $eventDispatcher, ?string $eventToDispatch, string $log, string $action, ?Coupon $model = null): ?RedirectResponse
+    {
+        // Create the form from the request
+        $couponForm = $this->getForm($action, $model);
+        $response = null;
+        $message = false;
+
+        try {
+            // Check the form against conditions violations
+            $form = $this->validateForm($couponForm, 'POST');
+
+            $couponEvent = $this->feedCouponCreateOrUpdateEvent($form, $model);
+
+            // Dispatch Event to the Action
+            $eventDispatcher->dispatch(
+                $couponEvent,
+                $eventToDispatch,
+            );
+
+            $couponModel = $couponEvent->getCouponModel();
+            $this->adminLogAppend(
+                AdminResources::COUPON,
+                AccessManager::UPDATE,
+                \sprintf(
+                    'Coupon %s (ID %s) '.$log,
+                    $couponEvent->getTitle(),
+                    $couponModel->getId(),
+                ),
+                $couponModel->getId(),
+            );
+
+            if ('stay' === $this->getRequest()->get('save_mode')) {
+                $response = new RedirectResponse(str_replace(
+                    '{id}',
+                    (string) $couponEvent->getCouponModel()->getId(),
+                    $couponForm->getSuccessUrl(),
+                ));
+            } else {
+                // Redirect to the success URL
+                $response = new RedirectResponse(
+                    URL::getInstance()->absoluteUrl($this->getRoute('admin.coupon.list')),
+                );
+            }
+        } catch (FormValidationException $ex) {
+            // Invalid data entered
+            $message = $this->createStandardFormValidationErrorMessage($ex);
+        }
+
+        if (false !== $message) {
+            // Mark the form as with error
+            $couponForm->setErrorMessage($message);
+
+            // Send the form and the error to the parser
+            $this->getParserContext()
+                ->addForm($couponForm)
+                ->setGeneralError($message);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Get all available conditions.
+     */
+    protected function getAvailableConditions(): array
+    {
+        /** @var CouponManager $couponManager */
+        $couponManager = $this->container->get('thelia.coupon.manager');
+        $availableConditions = $couponManager->getAvailableConditions();
+        $cleanedConditions = [];
+
+        /** @var ConditionInterface $availableCondition */
+        foreach ($availableConditions as $availableCondition) {
+            $condition = [];
+            $condition['serviceId'] = $availableCondition->getServiceId();
+            $condition['name'] = $availableCondition->getName();
+            $condition['toolTip'] = $availableCondition->getToolTip();
+            $cleanedConditions[] = $condition;
+        }
+
+        return $cleanedConditions;
+    }
+
+    /**
+     * Get all available coupons.
+     */
+    protected function getAvailableCoupons(): array
+    {
+        $availableCoupons = $this->couponManager->getAvailableCoupons();
+        $cleanedCoupons = [];
+
+        /** @var CouponInterface $availableCoupon */
+        foreach ($availableCoupons as $availableCoupon) {
+            $condition = [];
+            $condition['serviceId'] = $availableCoupon->getServiceId();
+            $condition['name'] = $availableCoupon->getName();
+            $condition['toolTip'] = $availableCoupon->getToolTip();
+
+            $cleanedCoupons[] = $condition;
+        }
+
+        return $cleanedCoupons;
+    }
+
+    /**
+     * Clean condition for template.
+     *
+     * @param ConditionCollection $conditions Condition collection
+     */
+    protected function cleanConditionForTemplate(ConditionCollection $conditions): array
+    {
+        $cleanedConditions = [];
+
+        /** @var ConditionInterface $condition */
+        foreach ($conditions as $index => $condition) {
+            $temp = [
+                'serviceId' => $condition->getServiceId(),
+                'index' => $index,
+                'name' => $condition->getName(),
+                'toolTip' => $condition->getToolTip(),
+                'summary' => $condition->getSummary(),
+                'validators' => $condition->getValidators(),
+            ];
+            $cleanedConditions[] = $temp;
+        }
+
+        return $cleanedConditions;
+    }
+
+    /**
+     * Draw the input displayed in the BackOffice
+     * allowing Admin to set its Coupon effect.
+     *
+     * @param string $couponServiceId Coupon service id
+     */
+    public function getBackOfficeInputsAjaxAction(string $couponServiceId): Response
+    {
+        if (($response = $this->checkAuth(AdminResources::COUPON, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        if ('' !== $couponServiceId && '0' !== $couponServiceId) {
+            $this->checkXmlHttpRequest();
+
+            $couponManager = $this->container->get($couponServiceId);
+
+            if (!$couponManager instanceof CouponInterface) {
+                $this->pageNotFound();
+            }
+
+            $response = new ResponseRest([$couponManager->drawBackOfficeInputs()]);
+        } else {
+            // Return an empty response if the service ID is not defined
+            // Typically, when the user chooses "Please select a coupon type"
+            $response = new ResponseRest([]);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Draw the input displayed in the BackOffice
+     * allowing Admin to set its Coupon effect.
+     *
+     * @param int $couponId Coupon id
+     */
+    public function getBackOfficeConditionSummariesAjaxAction(int $couponId): Response
+    {
+        if (($response = $this->checkAuth(AdminResources::COUPON, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        $this->checkXmlHttpRequest();
+
+        /** @var Coupon $coupon */
+        $coupon = CouponQuery::create()->findPk($couponId);
+
+        if (null === $coupon) {
+            return $this->pageNotFound();
+        }
+
+        /** @var CouponFactory $couponFactory */
+        $couponFactory = $this->container->get('thelia.coupon.factory');
+        $couponManager = $couponFactory->buildCouponFromModel($coupon);
+
+        if (!$couponManager instanceof CouponInterface) {
+            return $this->pageNotFound();
+        }
+
+        $args = [];
+        $args['conditions'] = $this->cleanConditionForTemplate($couponManager->getConditions());
+
+        return $this->render('coupon/conditions', $args);
+    }
+
+    /**
+     * Feed the Coupon Create or Update event with the User inputs.
+     *
+     * @param Form   $form  Form containing user data
+     * @param Coupon $model Model if in update mode
+     */
+    protected function feedCouponCreateOrUpdateEvent(Form $form, ?Coupon $model = null): CouponCreateOrUpdateEvent
+    {
+        // Get the form field values
+        $data = $form->getData();
+        $serviceId = urldecode((string) $data['type']);
+
+        /** @var CouponInterface $coupon */
+        $coupon = $this->container->get($serviceId);
+
+        $couponEvent = new CouponCreateOrUpdateEvent(
+            $data['code'],
+            $serviceId,
+            $data['title'],
+            $coupon->getEffects($data),
+            $data['shortDescription'],
+            $data['description'],
+            $data['isEnabled'] === 'on',
+            \DateTime::createFromFormat($this->getDefaultDateFormat(), $data['expirationDate']) ?: new \DateTime(),
+            $data['isAvailableOnSpecialOffers'] === 'on',
+            $data['isCumulative'] === 'on',
+            $data['isRemovingPostage'] === 'on',
+            $data['maxUsage'] ? (int) $data['maxUsage'] : null,
+            $data['locale'],
+            $data['freeShippingForCountries'],
+            $data['freeShippingForModules'],
+            $data['perCustomerUsageCount'] === 'on',
+            empty($data['startDate']) ? null : (\DateTime::createFromFormat($this->getDefaultDateFormat(), $data['startDate']) ?: null),
+        );
+
+        // If Update mode
+        if (isset($model)) {
+            $couponEvent->setCouponModel($model);
+        }
+
+        return $couponEvent;
+    }
+
+    /**
+     * Build ConditionInterface from request.
+     */
+    protected function buildConditionFromRequest(): ConditionInterface
+    {
+        $request = $this->getRequest();
+        $post = $request->request->getIterator();
+        $serviceId = $request->request->get('categoryCondition');
+        $operators = [];
+        $values = [];
+
+        foreach ($post as $key => $input) {
+            if (isset($input['operator']) && isset($input['value'])) {
+                $operators[$key] = $input['operator'];
+                $values[$key] = $input['value'];
+            }
+        }
+
+        /** @var ConditionFactory $conditionFactory */
+        $conditionFactory = $this->container->get('thelia.condition.factory');
+
+        return $conditionFactory->build($serviceId, $operators, $values);
+    }
+
+    /**
+     * Manage how a Condition is updated.
+     *
+     * @param Coupon              $coupon     Coupon Model
+     * @param ConditionCollection $conditions Condition collection
+     */
+    protected function manageConditionUpdate(EventDispatcherInterface $eventDispatcher, Coupon $coupon, ConditionCollection $conditions): void
+    {
+        $couponEvent = new CouponCreateOrUpdateEvent(
+            $coupon->getCode(),
+            $coupon->getType(),
+            $coupon->getTitle(),
+            $coupon->getEffects(),
+            $coupon->getShortDescription(),
+            $coupon->getDescription(),
+            $coupon->getIsEnabled(),
+            $coupon->getExpirationDate(),
+            $coupon->getIsAvailableOnSpecialOffers(),
+            $coupon->getIsCumulative(),
+            $coupon->getIsRemovingPostage(),
+            $coupon->getMaxUsage(),
+            $coupon->getLocale(),
+            $coupon->getFreeShippingForCountries(),
+            $coupon->getFreeShippingForModules(),
+            $coupon->getPerCustomerUsageCount(),
+            $coupon->getStartDate(),
+        );
+        $couponEvent->setCouponModel($coupon);
+        $couponEvent->setConditions($conditions);
+
+        $eventToDispatch = TheliaEvents::COUPON_CONDITION_UPDATE;
+        // Dispatch Event to the Action
+        $eventDispatcher->dispatch(
+            $couponEvent,
+            $eventToDispatch,
+        );
+
+        $this->adminLogAppend(
+            AdminResources::COUPON,
+            AccessManager::UPDATE,
+            \sprintf(
+                'Coupon %s (ID %s) conditions updated',
+                $couponEvent->getCouponModel()->getTitle(),
+                $couponEvent->getCouponModel()->getType(),
+            ),
+            $couponEvent->getCouponModel()->getId(),
+        );
+    }
+
+    protected function getDefaultDateFormat()
+    {
+        return LangQuery::create()->findOneByByDefault(true)?->getDatetimeFormat() ?? 'Y-m-d H:i:s';
+    }
+
+    protected function getForm(string $action, ?Coupon $coupon): BaseForm
+    {
+        $data = [];
+
+        if ($coupon instanceof Coupon) {
+            $data['code'] = $coupon->getCode();
+        }
+
+        return $this->createForm(AdminForm::COUPON_CREATION, FormType::class, $data, [
+            'validation_groups' => ['Default', $action],
+        ]);
+    }
+
+    public function deleteAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth(AdminResources::COUPON, [], AccessManager::DELETE)) instanceof Response) {
+            return $response;
+        }
+
+        try {
+            // Check token
+            $this->getTokenProvider()->checkToken(
+                $this->getRequest()->query->get('_token'),
+            );
+
+            // Retrieve coupon
+            $couponId = $this->getRequest()->request->get('coupon_id');
+            $coupon = CouponQuery::create()->findPk($couponId);
+
+            if (null === $coupon) {
+                throw new \InvalidArgumentException(\sprintf('Coupon #%s not found', $couponId));
+            }
+
+            $deleteEvent = new CouponDeleteEvent($coupon);
+
+            $eventDispatcher->dispatch($deleteEvent, TheliaEvents::COUPON_DELETE);
+
+            if (($deletedObject = $deleteEvent->getCoupon()) instanceof Coupon) {
+                $this->adminLogAppend(
+                    AdminResources::COUPON,
+                    AccessManager::DELETE,
+                    \sprintf(
+                        'Coupon %s (ID %s) deleted',
+                        $deletedObject->getCode(),
+                        $deletedObject->getId(),
+                    ),
+                    $deletedObject->getId(),
+                );
+            }
+
+            return new RedirectResponse(
+                URL::getInstance()->absoluteUrl($this->getRoute('admin.coupon.list')),
+            );
+        } catch (\Exception $exception) {
+            $this->getParserContext()
+                ->setGeneralError($exception->getMessage());
+
+            return $this->browseAction();
+        }
+    }
+}

--- a/Controller/Admin/CurrencyController.php
+++ b/Controller/Admin/CurrencyController.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\Currency\CurrencyCreateEvent;
+use Thelia\Core\Event\Currency\CurrencyDeleteEvent;
+use Thelia\Core\Event\Currency\CurrencyUpdateEvent;
+use Thelia\Core\Event\Currency\CurrencyUpdateRateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Model\Currency;
+use Thelia\Model\CurrencyQuery;
+
+/**
+ * Manages currencies.
+ *
+ * @author Franck Allimant <franck@cqfdev.fr>
+ */
+class CurrencyController extends AbstractCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'currency',
+            'manual',
+            'order',
+            AdminResources::CURRENCY,
+            TheliaEvents::CURRENCY_CREATE,
+            TheliaEvents::CURRENCY_UPDATE,
+            TheliaEvents::CURRENCY_DELETE,
+            null, // No visibility toggle
+            TheliaEvents::CURRENCY_UPDATE_POSITION,
+        );
+    }
+
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::CURRENCY_CREATION);
+    }
+
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::CURRENCY_MODIFICATION);
+    }
+
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $createEvent = new CurrencyCreateEvent();
+
+        $createEvent
+            ->setCurrencyName($formData['name'])
+            ->setLocale($formData['locale'])
+            ->setSymbol($formData['symbol'])
+            ->setFormat($formData['format'])
+            ->setCode($formData['code'])
+            ->setRate((float) $formData['rate']);
+
+        return $createEvent;
+    }
+
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $changeEvent = new CurrencyUpdateEvent((int) $formData['id']);
+
+        $changeEvent
+            ->setCurrencyName($formData['name'])
+            ->setLocale($formData['locale'])
+            ->setSymbol($formData['symbol'])
+            ->setFormat($formData['format'])
+            ->setCode($formData['code'])
+            ->setRate((float) $formData['rate']);
+
+        return $changeEvent;
+    }
+
+    protected function createUpdatePositionEvent(int $positionChangeMode, ?int $positionValue = null): UpdatePositionEvent
+    {
+        return new UpdatePositionEvent(
+            (int) $this->getRequest()->get('currency_id'),
+            $positionChangeMode,
+            $positionValue,
+        );
+    }
+
+    protected function getDeleteEvent(): CurrencyDeleteEvent
+    {
+        return new CurrencyDeleteEvent((int) $this->getRequest()->get('currency_id'));
+    }
+
+    protected function eventContainsObject($event): bool
+    {
+        return $event->hasCurrency();
+    }
+
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        // Prepare the data that will hydrate the form
+        $data = [
+            'id' => $object->getId(),
+            'name' => $object->getName(),
+            'locale' => $object->getLocale(),
+            'code' => $object->getCode(),
+            'symbol' => $object->getSymbol(),
+            'format' => $object->getFormat(),
+            'rate' => $object->getRate(),
+        ];
+
+        // Setup the object form
+        return $this->createForm(AdminForm::CURRENCY_MODIFICATION, FormType::class, $data);
+    }
+
+    protected function getObjectFromEvent($event): mixed
+    {
+        return $event->hasCurrency() ? $event->getCurrency() : null;
+    }
+
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        $currency = CurrencyQuery::create()
+            ->findOneById($this->getRequest()->get('currency_id'));
+
+        if (null !== $currency) {
+            $currency->setLocale($this->getCurrentEditionLocale());
+        }
+
+        return $currency;
+    }
+
+    /**
+     * @param Currency $object
+     */
+    protected function getObjectLabel(ActiveRecordInterface $object): ?string
+    {
+        return $object->getName();
+    }
+
+    /**
+     * @param Currency $object
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        return $this->render('currencies', ['order' => $currentOrder]);
+    }
+
+    protected function renderEditionTemplate(): Response
+    {
+        return $this->render('currency-edit', ['currency_id' => $this->getRequest()->get('currency_id')]);
+    }
+
+    protected function redirectToEditionTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.configuration.currencies.update',
+            [
+                'currency_id' => $this->getRequest()->get('currency_id'),
+            ],
+        );
+    }
+
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute('admin.configuration.currencies.default');
+    }
+
+    /**
+     * Update currencies rates.
+     */
+    public function updateRatesAction(EventDispatcherInterface $eventDispatcher): Response
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        try {
+            $event = new CurrencyUpdateRateEvent();
+
+            $eventDispatcher->dispatch($event, TheliaEvents::CURRENCY_UPDATE_RATES);
+
+            if ($event->hasUndefinedRates()) {
+                return $this->render('currencies', [
+                    'undefined_rates' => $event->getUndefinedRates(),
+                ]);
+            }
+        } catch (\Exception $exception) {
+            // Any error
+            return $this->errorPage($exception);
+        }
+
+        return $this->redirectToListTemplate();
+    }
+
+    /**
+     * Sets the default currency.
+     */
+    public function setDefaultAction(EventDispatcherInterface $eventDispatcher): Response
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $changeEvent = new CurrencyUpdateEvent((int) $this->getRequest()->get('currency_id', 0));
+
+        // Create and dispatch the change event
+        $changeEvent->setIsDefault(1)->setVisible(1);
+
+        try {
+            $eventDispatcher->dispatch($changeEvent, TheliaEvents::CURRENCY_SET_DEFAULT);
+        } catch (\Exception $exception) {
+            // Any error
+            return $this->errorPage($exception);
+        }
+
+        return $this->redirectToListTemplate();
+    }
+
+    /**
+     * Sets if the currency is visible for Front.
+     */
+    public function setVisibleAction(EventDispatcherInterface $eventDispatcher): Response
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $changeEvent = new CurrencyUpdateEvent((int) $this->getRequest()->get('currency_id', 0));
+
+        // Create and dispatch the change event
+        $changeEvent->setVisible((int) $this->getRequest()->get('visible', 0));
+
+        try {
+            $eventDispatcher->dispatch($changeEvent, TheliaEvents::CURRENCY_SET_VISIBLE);
+        } catch (\Exception $exception) {
+            // Any error
+            return $this->errorPage($exception);
+        }
+
+        return $this->redirectToListTemplate();
+    }
+}

--- a/Controller/Admin/CustomerController.php
+++ b/Controller/Admin/CustomerController.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Propel\Runtime\Event\ActiveRecordEvent;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\Customer\CustomerCreateOrUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\HttpFoundation\Request;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Domain\Customer\Exception\CustomerException;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Model\Customer;
+use Thelia\Model\CustomerQuery;
+use Thelia\Model\Event\CustomerEvent;
+use Thelia\Tools\Password;
+use Thelia\Tools\TokenProvider;
+
+/**
+ * Class CustomerController.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class CustomerController extends AbstractCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'customer',
+            'lastname',
+            'customer_order',
+            AdminResources::CUSTOMER,
+            TheliaEvents::CUSTOMER_CREATEACCOUNT,
+            TheliaEvents::CUSTOMER_UPDATEACCOUNT,
+            TheliaEvents::CUSTOMER_DELETEACCOUNT,
+        );
+    }
+
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::CUSTOMER_CREATE);
+    }
+
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::CUSTOMER_UPDATE);
+    }
+
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $event = $this->createEventInstance($formData);
+
+        // Create a secure password
+        $event->setPassword(Password::generateRandom());
+
+        // We will notify the customer of account creation
+        $event->setNotifyCustomerOfAccountCreation(true);
+
+        return $event;
+    }
+
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $event = $this->createEventInstance($formData);
+
+        $event->setCustomer($this->getExistingObject());
+
+        // We allow customer email modification
+        $event->setEmailUpdateAllowed(true);
+
+        return $event;
+    }
+
+    protected function getDeleteEvent(): ActiveRecordEvent
+    {
+        return new CustomerEvent($this->getExistingObject());
+    }
+
+    protected function eventContainsObject($event): bool
+    {
+        if (method_exists($event, 'hasCustomer')) {
+            return $event->hasCustomer();
+        }
+
+        if (method_exists($event, 'getModel')) {
+            return null !== $event->getModel();
+        }
+
+        return false;
+    }
+
+    /**
+     * @param Customer $object
+     */
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        // Get default adress of the customer
+        $address = $object->getDefaultAddress();
+
+        // Prepare the data that will hydrate the form
+        $data = [
+            'id' => $object->getId(),
+            'firstname' => $object->getFirstname(),
+            'lastname' => $object->getLastname(),
+            'email' => $object->getEmail(),
+            'lang_id' => $object->getLangId(),
+            'discount' => $object->getDiscount(),
+            'reseller' => (bool) $object->getReseller(),
+        ];
+
+        if (null !== $address) {
+            $data['company'] = $address->getCompany();
+            $data['address1'] = $address->getAddress1();
+            $data['address2'] = $address->getAddress2();
+            $data['address3'] = $address->getAddress3();
+            $data['phone'] = $address->getPhone();
+            $data['cellphone'] = $address->getCellphone();
+            $data['zipcode'] = $address->getZipcode();
+            $data['city'] = $address->getCity();
+            $data['country'] = $address->getCountryId();
+            $data['state'] = $address->getStateId();
+        }
+
+        // A loop is used in the template
+        return $this->createForm(AdminForm::CUSTOMER_UPDATE, FormType::class, $data);
+    }
+
+    protected function getObjectFromEvent($event): mixed
+    {
+        if (method_exists($event, 'hasCustomer') && $event->hasCustomer()) {
+            return $event->getCustomer();
+        }
+
+        if (method_exists($event, 'getModel')) {
+            return $event->getModel();
+        }
+
+        return null;
+    }
+
+    private function createEventInstance(array $data): CustomerCreateOrUpdateEvent
+    {
+        // Use current language if it is not defined in the form
+        if (empty($data['lang_id'])) {
+            $data['lang_id'] = $this->getSession()->getLang()?->getId();
+        }
+
+        return new CustomerCreateOrUpdateEvent(
+            $data['title'] ? (int) $data['title'] : null,
+            $data['firstname'],
+            $data['lastname'],
+            $data['address1'],
+            $data['address2'] ?? '',
+            $data['address3'] ?? '',
+            $data['phone'],
+            isset($data['cellphone']) ? (string) $data['cellphone'] : null,
+            $data['zipcode'],
+            $data['city'],
+            isset($data['country']) ? (string) $data['country'] : null,
+            $data['email'] ?? null,
+            empty($data['password']) ? null : $data['password'],
+            $data['lang_id'],
+            $data['reseller'] ?? false,
+            $data['sponsor'] ?? null,
+            isset($data['discount']) ? (float) $data['discount'] : null,
+            $data['company'] ?? null,
+            null,
+            isset($data['state']) ? (int) $data['state'] : null,
+        );
+    }
+
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        return CustomerQuery::create()->findPk($this->getRequest()->get('customer_id', 0));
+    }
+
+    protected function getObjectLabel(ActiveRecordInterface $object): string
+    {
+        return $object->getRef().'('.$object->getLastname().' '.$object->getFirstname().')';
+    }
+
+    /**
+     * @param Customer $object
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    protected function getEditionArguments(): array
+    {
+        return [
+            'customer_id' => $this->getRequest()->get('customer_id', 0),
+            'page' => $this->getRequest()->get('page', 1),
+            'page_order' => $this->getRequest()->get('page_order', 1),
+        ];
+    }
+
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        return $this->render(
+            'customers',
+            ['customer_order' => $currentOrder, 'page' => $this->getRequest()->get('page', 1)],
+        );
+    }
+
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.customers',
+            [
+                'page' => $this->getRequest()->get('page', 1),
+            ],
+        );
+    }
+
+    protected function renderEditionTemplate(): Response
+    {
+        return $this->render('customer-edit', $this->getEditionArguments());
+    }
+
+    protected function redirectToEditionTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.customer.update.view',
+            $this->getEditionArguments(),
+        );
+    }
+
+    public function deleteAction(
+        Request $request,
+        TokenProvider $tokenProvider,
+        EventDispatcherInterface $eventDispatcher,
+        ParserContext $parserContext,
+    ): Response {
+        $errorMsg = 'No error.';
+        $removalError = false;
+
+        try {
+            parent::deleteAction(
+                $request,
+                $tokenProvider,
+                $eventDispatcher,
+                $parserContext,
+            );
+        } catch (CustomerException $customerException) {
+            $errorMsg = $customerException->getMessage();
+
+            $removalError = true;
+        }
+
+        return $this->renderListTemplate($this->getCurrentListOrder());
+    }
+}

--- a/Controller/Admin/ExportController.php
+++ b/Controller/Admin/ExportController.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Archiver\ArchiverManager;
+use Thelia\Core\DependencyInjection\Compiler\RegisterArchiverPass;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Serializer\SerializerManager;
+use Thelia\Domain\DataTransfer\Exception\DataTransferNoDataFoundException;
+use Thelia\Domain\DataTransfer\Exporthandler;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Form\Exception\FormValidationException;
+use Thelia\Model\LangQuery;
+
+/**
+ * Class ExportController.
+ *
+ * @author Jérôme Billiras <jbilliras@openstudio.fr>
+ */
+class ExportController extends BaseAdminController
+{
+    /**
+     * Handle default action, that is, list available exports.
+     *
+     * @param string $_view View to render
+     */
+    public function indexAction(string $_view = 'export'): Response
+    {
+        $authResponse = $this->checkAuth([AdminResources::EXPORT], [], [AccessManager::VIEW]);
+
+        if ($authResponse instanceof Response) {
+            return $authResponse;
+        }
+
+        $this->getParserContext()
+            ->set('category_order', $this->getRequest()->query->get('category_order', 'manual'))
+            ->set('export_order', $this->getRequest()->query->get('export_order', 'manual'));
+
+        return $this->render($_view);
+    }
+
+    /**
+     * Handle export position change action.
+     */
+    public function changeExportPositionAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        $authResponse = $this->checkAuth([AdminResources::EXPORT], [], [AccessManager::UPDATE]);
+
+        if ($authResponse instanceof Response) {
+            return $authResponse;
+        }
+
+        $query = $this->getRequest()->query;
+
+        $eventDispatcher->dispatch(
+            new UpdatePositionEvent(
+                (int) $query->get('id'),
+                $this->matchPositionMode($query->get('mode')),
+                (int) $query->get('value'),
+            ),
+            TheliaEvents::EXPORT_CHANGE_POSITION,
+        );
+
+        return $this->generateRedirectFromRoute('export.list');
+    }
+
+    /**
+     * Handle export category position change action.
+     */
+    public function changeCategoryPositionAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        $authResponse = $this->checkAuth([AdminResources::EXPORT], [], [AccessManager::UPDATE]);
+
+        if ($authResponse instanceof Response) {
+            return $authResponse;
+        }
+
+        $query = $this->getRequest()->query;
+
+        $eventDispatcher->dispatch(
+            new UpdatePositionEvent(
+                (int) $query->get('id'),
+                $this->matchPositionMode($query->get('mode')),
+                (int) $query->get('value'),
+            ),
+            TheliaEvents::EXPORT_CATEGORY_CHANGE_POSITION,
+        );
+
+        return $this->generateRedirectFromRoute('export.list');
+    }
+
+    /**
+     * Match position mode string against position mode constant value.
+     *
+     * @param string|null $mode Position mode string
+     *
+     * @return int Position mode constant value
+     */
+    protected function matchPositionMode(?string $mode): int
+    {
+        if ('up' === $mode) {
+            return UpdatePositionEvent::POSITION_UP;
+        }
+
+        if ('down' === $mode) {
+            return UpdatePositionEvent::POSITION_DOWN;
+        }
+
+        return UpdatePositionEvent::POSITION_ABSOLUTE;
+    }
+
+    /**
+     * Display export configuration view.
+     *
+     * @param int $id An export identifier
+     */
+    public function configureAction(int $id): Response
+    {
+        /** @var Exporthandler $exportHandler */
+        $exportHandler = $this->container->get('thelia.export.handler');
+
+        $export = $exportHandler->getExport($id);
+
+        if (null === $export) {
+            return $this->pageNotFound();
+        }
+
+        // Render standard view or ajax one
+        $templateName = 'export-page';
+
+        if ($this->getRequest()->isXmlHttpRequest()) {
+            $templateName = 'ajax/export-modal';
+        }
+
+        return $this->render(
+            $templateName,
+            [
+                'exportId' => $id,
+                'hasImages' => $export->hasImages(),
+                'hasDocuments' => $export->hasDocuments(),
+                'useRange' => $export->useRangeDate(),
+            ],
+        );
+    }
+
+    /**
+     * Handle export action.
+     *
+     * @param int $id An export identifier
+     */
+    public function exportAction(
+        int $id,
+        SerializerManager $serializerManager,
+    ): Response|BinaryFileResponse {
+        /** @var Exporthandler $exportHandler */
+        $exportHandler = $this->container->get('thelia.export.handler');
+
+        $export = $exportHandler->getExport($id);
+
+        if (null === $export) {
+            return $this->pageNotFound();
+        }
+
+        $form = $this->createForm(AdminForm::EXPORT);
+
+        try {
+            $validatedForm = $this->validateForm($form);
+
+            set_time_limit(0);
+
+            $lang = (new LangQuery())->findPk($validatedForm->get('language')->getData());
+
+            /** @var SerializerManager $serializerManager */
+            $serializer = $serializerManager->get($validatedForm->get('serializer')->getData());
+
+            $archiver = null;
+
+            if ($validatedForm->get('do_compress')->getData()) {
+                /** @var ArchiverManager $archiverManager */
+                $archiverManager = $this->container->get(RegisterArchiverPass::MANAGER_SERVICE_ID);
+                $archiver = $archiverManager->get($validatedForm->get('archiver')->getData());
+            }
+
+            $rangeDate = null;
+
+            if ($validatedForm->get('range_date_start')->getData()
+                && $validatedForm->get('range_date_end')->getData()
+            ) {
+                $rangeDate = [
+                    'start' => $validatedForm->get('range_date_start')->getData(),
+                    'end' => $validatedForm->get('range_date_end')->getData(),
+                ];
+            }
+
+            $exportEvent = $exportHandler->export(
+                $export,
+                $serializer,
+                $archiver,
+                $lang,
+                $validatedForm->get('images')->getData(),
+                $validatedForm->get('documents')->getData(),
+                $rangeDate,
+            );
+
+            $contentType = $exportEvent->getSerializer()->getMimeType();
+            $fileExt = $exportEvent->getSerializer()->getExtension();
+
+            if (null !== $exportEvent->getArchiver()) {
+                $contentType = $exportEvent->getArchiver()->getMimeType();
+                $fileExt = $exportEvent->getArchiver()->getExtension();
+            }
+
+            $header = [
+                'Content-Type' => $contentType,
+                'Content-Disposition' => \sprintf(
+                    '%s; filename="%s.%s"',
+                    ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+                    $exportEvent->getExport()->getFileName(),
+                    $fileExt,
+                ),
+            ];
+
+            return new BinaryFileResponse($exportEvent->getFilePath(), Response::HTTP_OK, $header, false);
+        } catch (FormValidationException|DataTransferNoDataFoundException $e) {
+            $form->setErrorMessage($this->createStandardFormValidationErrorMessage($e));
+        }
+
+        $this->getParserContext()
+            ->addForm($form);
+
+        return $this->configureAction($id);
+    }
+}

--- a/Controller/Admin/FeatureAvController.php
+++ b/Controller/Admin/FeatureAvController.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\Feature\FeatureAvCreateEvent;
+use Thelia\Core\Event\Feature\FeatureAvDeleteEvent;
+use Thelia\Core\Event\Feature\FeatureAvUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Model\FeatureAv;
+use Thelia\Model\FeatureAvQuery;
+
+/**
+ * Manages features-av.
+ *
+ * @author Franck Allimant <franck@cqfdev.fr>
+ */
+class FeatureAvController extends AbstractCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'featureav',
+            'manual',
+            'featureav_order',
+            AdminResources::FEATURE,
+            TheliaEvents::FEATURE_AV_CREATE,
+            TheliaEvents::FEATURE_AV_UPDATE,
+            TheliaEvents::FEATURE_AV_DELETE,
+            null, // No visibility toggle
+            TheliaEvents::FEATURE_AV_UPDATE_POSITION,
+        );
+    }
+
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::FEATURE_AV_CREATION);
+    }
+
+    protected function getUpdateForm(): null
+    {
+        return null;
+    }
+
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $createEvent = new FeatureAvCreateEvent();
+
+        $createEvent
+            ->setFeatureId((int) $formData['feature_id'])
+            ->setTitle($formData['title'])
+            ->setLocale($formData['locale']);
+
+        return $createEvent;
+    }
+
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $changeEvent = new FeatureAvUpdateEvent((int) $formData['id']);
+
+        $changeEvent
+            ->setLocale($formData['locale'])
+            ->setTitle($formData['title'])
+            ->setChapo($formData['chapo'])
+            ->setDescription($formData['description'])
+            ->setPostscriptum($formData['postscriptum']);
+
+        return $changeEvent;
+    }
+
+    protected function createUpdatePositionEvent(int $positionChangeMode, ?int $positionValue = null): UpdatePositionEvent
+    {
+        return new UpdatePositionEvent(
+            (int) $this->getRequest()->get('featureav_id'),
+            $positionChangeMode,
+            $positionValue,
+        );
+    }
+
+    protected function getDeleteEvent(): FeatureAvDeleteEvent
+    {
+        return new FeatureAvDeleteEvent((int) $this->getRequest()->get('featureav_id'));
+    }
+
+    protected function eventContainsObject($event): bool
+    {
+        return $event->hasFeatureAv();
+    }
+
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        throw new \LogicException('Feature Av. modification is not yet implemented');
+    }
+
+    protected function getObjectFromEvent($event): mixed
+    {
+        return $event->hasFeatureAv() ? $event->getFeatureAv() : null;
+    }
+
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        $featureAv = FeatureAvQuery::create()
+            ->findOneById($this->getRequest()->get('featureav_id', 0));
+
+        if (null !== $featureAv) {
+            $featureAv->setLocale($this->getCurrentEditionLocale());
+        }
+
+        return $featureAv;
+    }
+
+    /**
+     * @param FeatureAv $object
+     */
+    protected function getObjectLabel(ActiveRecordInterface $object): ?string
+    {
+        return $object->getTitle();
+    }
+
+    /**
+     * @param FeatureAv $object
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    protected function getViewArguments(): array
+    {
+        return [
+            'feature_id' => $this->getRequest()->get('feature_id'),
+            'featureav_order' => $this->getCurrentListOrder(),
+        ];
+    }
+
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        // We always return to the feature edition form
+        return $this->render(
+            'feature-edit',
+            $this->getViewArguments(),
+        );
+    }
+
+    protected function renderEditionTemplate(): Response
+    {
+        // We always return to the feature edition form
+        return $this->render('feature-edit', $this->getViewArguments());
+    }
+
+    protected function redirectToEditionTemplate(): Response|RedirectResponse
+    {
+        // We always return to the feature edition form
+        return $this->generateRedirectFromRoute(
+            'admin.configuration.features.update',
+            $this->getViewArguments(),
+        );
+    }
+
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.configuration.features.update',
+            $this->getViewArguments(),
+        );
+    }
+}

--- a/Controller/Admin/FeatureController.php
+++ b/Controller/Admin/FeatureController.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Propel\Runtime\Event\ActiveRecordEvent;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\Feature\FeatureAvUpdateEvent;
+use Thelia\Core\Event\Feature\FeatureCreateEvent;
+use Thelia\Core\Event\Feature\FeatureDeleteEvent;
+use Thelia\Core\Event\Feature\FeatureEvent;
+use Thelia\Core\Event\Feature\FeatureUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Model\Feature;
+use Thelia\Model\FeatureQuery;
+
+/**
+ * Manages features.
+ *
+ * @author Franck Allimant <franck@cqfdev.fr>
+ */
+class FeatureController extends AbstractCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'feature',
+            'manual',
+            'order',
+            AdminResources::FEATURE,
+            TheliaEvents::FEATURE_CREATE,
+            TheliaEvents::FEATURE_UPDATE,
+            TheliaEvents::FEATURE_DELETE,
+            null, // No visibility toggle
+            TheliaEvents::FEATURE_UPDATE_POSITION,
+        );
+    }
+
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::FEATURE_CREATION);
+    }
+
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::FEATURE_MODIFICATION);
+    }
+
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $createEvent = new FeatureCreateEvent();
+
+        $createEvent
+            ->setTitle($formData['title'])
+            ->setLocale($formData['locale'])
+            ->setAddToAllTemplates($formData['add_to_all']);
+
+        return $createEvent;
+    }
+
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $changeEvent = new FeatureUpdateEvent((int) $formData['id']);
+
+        // Create and dispatch the change event
+        $changeEvent
+            ->setLocale($formData['locale'])
+            ->setTitle($formData['title'])
+            ->setChapo($formData['chapo'])
+            ->setDescription($formData['description'])
+            ->setPostscriptum($formData['postscriptum']);
+
+        return $changeEvent;
+    }
+
+    /**
+     * Process the features values (fix it in future version to integrate it in the feature form as a collection).
+     *
+     * @see AbstractCrudController::performAdditionalUpdateAction()
+     */
+    protected function performAdditionalUpdateAction(EventDispatcherInterface $eventDispatcher, ActionEvent|ActiveRecordEvent|null $updateEvent): null
+    {
+        $attr_values = $this->getRequest()->get('feature_values');
+
+        if (null !== $attr_values) {
+            foreach ($attr_values as $id => $value) {
+                $event = new FeatureAvUpdateEvent((int) $id);
+
+                $event->setTitle($value);
+                $event->setLocale($this->getCurrentEditionLocale());
+
+                $eventDispatcher->dispatch($event, TheliaEvents::FEATURE_AV_UPDATE);
+            }
+        }
+
+        return null;
+    }
+
+    protected function createUpdatePositionEvent(int $positionChangeMode, ?int $positionValue = null): UpdatePositionEvent
+    {
+        return new UpdatePositionEvent(
+            (int) $this->getRequest()->get('feature_id'),
+            $positionChangeMode,
+            $positionValue,
+        );
+    }
+
+    protected function getDeleteEvent(): FeatureDeleteEvent
+    {
+        return new FeatureDeleteEvent((int) $this->getRequest()->get('feature_id'));
+    }
+
+    protected function eventContainsObject($event): bool
+    {
+        return $event->hasFeature();
+    }
+
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        $data = [
+            'id' => $object->getId(),
+            'locale' => $object->getLocale(),
+            'title' => $object->getTitle(),
+            'chapo' => $object->getChapo(),
+            'description' => $object->getDescription(),
+            'postscriptum' => $object->getPostscriptum(),
+        ];
+
+        // Setup the object form
+        return $this->createForm(AdminForm::FEATURE_MODIFICATION, FormType::class, $data);
+    }
+
+    protected function getObjectFromEvent($event): mixed
+    {
+        return $event->hasFeature() ? $event->getFeature() : null;
+    }
+
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        $feature = FeatureQuery::create()
+            ->findOneById($this->getRequest()->get('feature_id', 0));
+
+        if (null !== $feature) {
+            $feature->setLocale($this->getCurrentEditionLocale());
+        }
+
+        return $feature;
+    }
+
+    /**
+     * @param Feature $object
+     */
+    protected function getObjectLabel(ActiveRecordInterface $object): ?string
+    {
+        return $object->getTitle();
+    }
+
+    /**
+     * @param Feature $object
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        return $this->render('features', ['order' => $currentOrder]);
+    }
+
+    protected function renderEditionTemplate(): Response
+    {
+        return $this->render(
+            'feature-edit',
+            [
+                'feature_id' => $this->getRequest()->get('feature_id'),
+                'featureav_order' => $this->getFeatureAvListOrder(),
+            ],
+        );
+    }
+
+    protected function redirectToEditionTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.configuration.features.update',
+            [
+                'feature_id' => $this->getRequest()->get('feature_id'),
+                'featureav_order' => $this->getFeatureAvListOrder(),
+            ],
+        );
+    }
+
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute('admin.configuration.features.default');
+    }
+
+    /**
+     * Get the Feature value list order.
+     *
+     * @return string the current list order
+     */
+    protected function getFeatureAvListOrder(): ?string
+    {
+        return $this->getListOrderFromSession(
+            'featureav',
+            'featureav_order',
+            'manual',
+        );
+    }
+
+    /**
+     * Add or Remove from all product templates.
+     */
+    protected function addRemoveFromAllTemplates(EventDispatcherInterface $eventDispatcher, string $eventType): Response
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        try {
+            if (($object = $this->getExistingObject()) instanceof ActiveRecordInterface) {
+                $event = new FeatureEvent($object);
+
+                $eventDispatcher->dispatch($event, $eventType);
+            }
+        } catch (\Exception $exception) {
+            // Any error
+            return $this->errorPage($exception);
+        }
+
+        return $this->redirectToListTemplate();
+    }
+
+    /**
+     * Remove from all product templates.
+     */
+    public function removeFromAllTemplates(EventDispatcherInterface $eventDispatcher): Response
+    {
+        return $this->addRemoveFromAllTemplates($eventDispatcher, TheliaEvents::FEATURE_REMOVE_FROM_ALL_TEMPLATES);
+    }
+
+    /**
+     * Add to all product templates.
+     */
+    public function addToAllTemplates(EventDispatcherInterface $eventDispatcher): Response
+    {
+        return $this->addRemoveFromAllTemplates($eventDispatcher, TheliaEvents::FEATURE_ADD_TO_ALL_TEMPLATES);
+    }
+}

--- a/Controller/Admin/FileController.php
+++ b/Controller/Admin/FileController.php
@@ -1,0 +1,557 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\File\Exception\ProcessFileException;
+use Thelia\Core\File\FileConfiguration;
+use Thelia\Core\File\FileManager;
+use Thelia\Core\File\Service\FileDeleteService;
+use Thelia\Core\File\Service\FilePositionService;
+use Thelia\Core\File\Service\FileProcessorService;
+use Thelia\Core\File\Service\FileUpdateService;
+use Thelia\Core\File\Service\FileVisibilityService;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Form\Exception\FormValidationException;
+use Thelia\Tools\Rest\ResponseRest;
+use Thelia\Tools\URL;
+
+/**
+ * Controller for file management (images and documents).
+ *
+ * @author  Guillaume MOREL <gmorel@openstudio.fr>
+ */
+class FileController extends BaseAdminController
+{
+    public const MODULE_RIGHT = 'thelia';
+
+    public function saveFileAjaxAction(
+        EventDispatcherInterface $eventDispatcher,
+        FileProcessorService $fileProcessorService,
+        int $parentId,
+        string $parentType,
+        string $objectType,
+        array $validMimeTypes = [],
+        array $extBlackList = [],
+    ): Response {
+        if (($response = $this->checkAuth($this->getAdminResources()->getResource($parentType, static::MODULE_RIGHT), [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $this->checkXmlHttpRequest();
+
+        if ($this->getRequest()->isMethod('POST')) {
+            /** @var UploadedFile $fileBeingUploaded */
+            $fileBeingUploaded = $this->getRequest()->files->get('file');
+
+            try {
+                $fileProcessorService->processFile(
+                    $eventDispatcher,
+                    $fileBeingUploaded,
+                    $parentId,
+                    $parentType,
+                    $objectType,
+                    $validMimeTypes,
+                    $extBlackList,
+                );
+            } catch (ProcessFileException $e) {
+                return new ResponseRest($e->getMessage(), 'text', $e->getCode());
+            }
+
+            return new ResponseRest(['status' => true, 'message' => '']);
+        }
+
+        return new Response('', Response::HTTP_NOT_FOUND);
+    }
+
+    public function saveImageAjaxAction(
+        EventDispatcherInterface $eventDispatcher,
+        FileProcessorService $fileProcessorService,
+        int $parentId,
+        string $parentType,
+    ): Response {
+        $config = FileConfiguration::getImageConfig();
+
+        return $this->saveFileAjaxAction(
+            $eventDispatcher,
+            $fileProcessorService,
+            $parentId,
+            $parentType,
+            $config['objectType'],
+            $config['validMimeTypes'],
+            $config['extBlackList'],
+        );
+    }
+
+    public function saveDocumentAjaxAction(
+        EventDispatcherInterface $eventDispatcher,
+        FileProcessorService $fileProcessorService,
+        int $parentId,
+        string $parentType,
+    ): Response {
+        $config = FileConfiguration::getDocumentConfig();
+
+        return $this->saveFileAjaxAction(
+            $eventDispatcher,
+            $fileProcessorService,
+            $parentId,
+            $parentType,
+            $config['objectType'],
+            $config['validMimeTypes'],
+            $config['extBlackList'],
+        );
+    }
+
+    public function getImageListAjaxAction(int $parentId, string $parentType): Response
+    {
+        $this->checkAuth($this->getAdminResources()->getResource($parentType, static::MODULE_RIGHT), [], AccessManager::UPDATE);
+        $this->checkXmlHttpRequest();
+
+        $successUrl = $this->getRequest()->get('successUrl');
+
+        $args = [
+            'imageType' => $parentType,
+            'parentId' => $parentId,
+            'successUrl' => $successUrl,
+        ];
+
+        return $this->render('includes/image-upload-list-ajax', $args);
+    }
+
+    public function getDocumentListAjaxAction(int $parentId, string $parentType): Response
+    {
+        $this->checkAuth($this->getAdminResources()->getResource($parentType, static::MODULE_RIGHT), [], AccessManager::UPDATE);
+        $this->checkXmlHttpRequest();
+        $args = ['documentType' => $parentType, 'parentId' => $parentId];
+
+        return $this->render('includes/document-upload-list-ajax', $args);
+    }
+
+    public function getImageFormAjaxAction(int $parentId, string $parentType): Response
+    {
+        $this->checkAuth($this->getAdminResources()->getResource($parentType, static::MODULE_RIGHT), [], AccessManager::UPDATE);
+        $this->checkXmlHttpRequest();
+        $successUrl = $this->getRequest()->get('successUrl');
+
+        $args = [
+            'imageType' => $parentType,
+            'parentId' => $parentId,
+            'successUrl' => $successUrl,
+        ];
+
+        return $this->render('includes/image-upload-form', $args);
+    }
+
+    public function getDocumentFormAjaxAction(int $parentId, string $parentType): Response
+    {
+        $this->checkAuth($this->getAdminResources()->getResource($parentType, static::MODULE_RIGHT), [], AccessManager::UPDATE);
+        $this->checkXmlHttpRequest();
+        $args = ['documentType' => $parentType, 'parentId' => $parentId];
+
+        return $this->render('includes/document-upload-form', $args);
+    }
+
+    public function viewImageAction(
+        int $imageId,
+        string $parentType,
+        FileManager $fileManager,
+    ): Response {
+        if (($response = $this->checkAuth($this->getAdminResources()->getResource($parentType, static::MODULE_RIGHT), [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $imageModel = $fileManager->getModelInstance('image', $parentType);
+
+        $image = $imageModel->getQueryInstance()->findPk($imageId);
+
+        $redirectUrl = $image->getRedirectionUrl();
+
+        return $this->render('image-edit', [
+            'imageId' => $imageId,
+            'imageType' => $parentType,
+            'redirectUrl' => $redirectUrl,
+            'formId' => $imageModel->getUpdateFormId(),
+            'breadcrumb' => $image->getBreadcrumb(
+                $this->getRouter($this->getCurrentRouter()),
+                'images',
+                $this->getCurrentEditionLocale(),
+            ),
+        ]);
+    }
+
+    public function viewDocumentAction(
+        int $documentId,
+        string $parentType,
+        FileManager $fileManager,
+    ): Response {
+        if (($response = $this->checkAuth($this->getAdminResources()->getResource($parentType, static::MODULE_RIGHT), [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $documentModel = $fileManager->getModelInstance('document', $parentType);
+
+        $document = $documentModel->getQueryInstance()->findPk($documentId);
+
+        $redirectUrl = $document->getRedirectionUrl();
+
+        return $this->render('document-edit', [
+            'documentId' => $documentId,
+            'documentType' => $parentType,
+            'redirectUrl' => $redirectUrl,
+            'formId' => $documentModel->getUpdateFormId(),
+            'breadcrumb' => $document->getBreadcrumb(
+                $this->getRouter($this->getCurrentRouter()),
+                'documents',
+                $this->getCurrentEditionLocale(),
+            ),
+        ]);
+    }
+
+    public function updateImageAction(
+        EventDispatcherInterface $eventDispatcher,
+        FileUpdateService $fileUpdateService,
+        int $imageId,
+        string $parentType,
+        FileManager $fileManager,
+    ): RedirectResponse|Response {
+        if (($response = $this->checkAuth($this->getAdminResources()->getResource($parentType, static::MODULE_RIGHT), [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $fileModelInstance = $fileManager->getModelInstance('image', $parentType);
+        $fileUpdateForm = $this->createForm($fileModelInstance->getUpdateFormId());
+
+        try {
+            $this->validateForm($fileUpdateForm);
+            $fileInstance = $fileUpdateService->updateFile(
+                $eventDispatcher,
+                $imageId,
+                $parentType,
+                'image',
+                TheliaEvents::IMAGE_UPDATE,
+                $fileUpdateForm,
+            );
+
+            $this->adminLogAppend(
+                $this->getAdminResources()->getResource($parentType, static::MODULE_RIGHT),
+                AccessManager::UPDATE,
+                \sprintf(
+                    '%s with Ref %s (ID %d) modified',
+                    ucfirst('image'),
+                    $fileInstance->getTitle(),
+                    $fileInstance->getId(),
+                ),
+                $fileInstance->getId(),
+            );
+
+            if ('close' === $this->getRequest()->get('save_mode')) {
+                return $this->generateRedirect(
+                    URL::getInstance()->absoluteUrl($fileInstance->getRedirectionUrl(), ['current_tab' => 'images']),
+                );
+            }
+
+            return $this->generateSuccessRedirect($fileUpdateForm);
+        } catch (FormValidationException $e) {
+            $message = \sprintf('Please check your input: %s', $e->getMessage());
+            $fileUpdateService->logUpdateError('image', $message);
+            $fileUpdateForm->setErrorMessage($message);
+
+            $this->getParserContext()
+                ->addForm($fileUpdateForm)
+                ->setGeneralError($message);
+        } catch (\Exception $e) {
+            $message = \sprintf('Sorry, an error occurred: %s', $e->getMessage().' '.$e->getFile());
+            $fileUpdateService->logUpdateError('image', $message);
+            $fileUpdateForm->setErrorMessage($message);
+
+            $this->getParserContext()
+                ->addForm($fileUpdateForm)
+                ->setGeneralError($message);
+        }
+        $image = $fileManager->getModelInstance('image', $parentType)->getQueryInstance()->findPk($imageId);
+
+        return $this->render('image-edit', [
+            'imageId' => $imageId,
+            'imageType' => $parentType,
+            'redirectUrl' => $image->getRedirectionUrl(),
+            'formId' => $fileModelInstance->getUpdateFormId(),
+            'breadcrumb' => $image->getBreadcrumb(
+                $this->getRouter($this->getCurrentRouter()),
+                'images',
+                $this->getCurrentEditionLocale(),
+            ),
+        ]);
+    }
+
+    public function updateDocumentAction(
+        EventDispatcherInterface $eventDispatcher,
+        FileUpdateService $fileUpdateService,
+        int $documentId,
+        string $parentType,
+        FileManager $fileManager,
+    ): RedirectResponse|Response {
+        if (($response = $this->checkAuth($this->getAdminResources()->getResource($parentType, static::MODULE_RIGHT), [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $fileModelInstance = $fileManager->getModelInstance('document', $parentType);
+        $fileUpdateForm = $this->createForm($fileModelInstance->getUpdateFormId());
+
+        try {
+            $fileInstance = $fileUpdateService->updateFile(
+                $eventDispatcher,
+                $documentId,
+                $parentType,
+                'document',
+                TheliaEvents::DOCUMENT_UPDATE,
+                $fileUpdateForm,
+            );
+
+            $this->adminLogAppend(
+                $this->getAdminResources()->getResource($parentType, static::MODULE_RIGHT),
+                AccessManager::UPDATE,
+                \sprintf(
+                    '%s with Ref %s (ID %d) modified',
+                    ucfirst('document'),
+                    $fileInstance->getTitle(),
+                    $fileInstance->getId(),
+                ),
+                $fileInstance->getId(),
+            );
+
+            if ('close' === $this->getRequest()->get('save_mode')) {
+                return $this->generateRedirect(
+                    URL::getInstance()->absoluteUrl($fileInstance->getRedirectionUrl(), ['current_tab' => 'documents']),
+                );
+            }
+
+            return $this->generateSuccessRedirect($fileUpdateForm);
+        } catch (FormValidationException $e) {
+            $message = \sprintf('Please check your input: %s', $e->getMessage());
+            $fileUpdateService->logUpdateError('document', $message);
+            $fileUpdateForm->setErrorMessage($message);
+
+            $this->getParserContext()
+                ->addForm($fileUpdateForm)
+                ->setGeneralError($message);
+        } catch (\Exception $e) {
+            $message = \sprintf('Sorry, an error occurred: %s', $e->getMessage().' '.$e->getFile());
+            $fileUpdateService->logUpdateError('document', $message);
+            $fileUpdateForm->setErrorMessage($message);
+
+            $this->getParserContext()
+                ->addForm($fileUpdateForm)
+                ->setGeneralError($message);
+        }
+
+        return $this->render('document-edit', [
+            'documentId' => $documentId,
+            'documentType' => $parentType,
+            'redirectUrl' => $fileManager->getModelInstance('document', $parentType)->getQueryInstance()->findPk($documentId)?->getRedirectionUrl(),
+            'formId' => $fileModelInstance->getUpdateFormId(),
+        ]);
+    }
+
+    public function deleteImageAction(
+        EventDispatcherInterface $eventDispatcher,
+        FileDeleteService $fileDeleteService,
+        int $imageId,
+        string $parentType,
+    ): Response {
+        $this->checkAuth($this->getAdminResources()->getResource($parentType, static::MODULE_RIGHT), [], AccessManager::UPDATE);
+        $this->checkXmlHttpRequest();
+
+        try {
+            $message = $fileDeleteService->deleteFile(
+                $eventDispatcher,
+                $imageId,
+                $parentType,
+                'image',
+                TheliaEvents::IMAGE_DELETE,
+            );
+
+            $this->adminLogAppend(
+                $this->getAdminResources()->getResource($parentType, static::MODULE_RIGHT),
+                AccessManager::UPDATE,
+                $message,
+            );
+        } catch (\Exception) {
+            return $this->pageNotFound();
+        }
+
+        return new Response($message);
+    }
+
+    public function deleteDocumentAction(
+        EventDispatcherInterface $eventDispatcher,
+        FileDeleteService $fileDeleteService,
+        int $documentId,
+        string $parentType,
+    ): Response {
+        $this->checkAuth($this->getAdminResources()->getResource($parentType, static::MODULE_RIGHT), [], AccessManager::UPDATE);
+        $this->checkXmlHttpRequest();
+
+        try {
+            $message = $fileDeleteService->deleteFile(
+                $eventDispatcher,
+                $documentId,
+                $parentType,
+                'document',
+                TheliaEvents::DOCUMENT_DELETE,
+            );
+
+            $this->adminLogAppend(
+                $this->getAdminResources()->getResource($parentType, static::MODULE_RIGHT),
+                AccessManager::UPDATE,
+                $message,
+            );
+        } catch (\Exception) {
+            return $this->pageNotFound();
+        }
+
+        return new Response($message);
+    }
+
+    public function updateImagePositionAction(
+        EventDispatcherInterface $eventDispatcher,
+        FilePositionService $filePositionService,
+        string $parentType,
+    ): Response {
+        $this->checkAuth($this->getAdminResources()->getResource($parentType, static::MODULE_RIGHT), [], AccessManager::UPDATE);
+        $this->checkXmlHttpRequest();
+
+        $imageId = (int) $this->getRequest()->request->get('image_id');
+        $position = (int) $this->getRequest()->request->get('position');
+
+        try {
+            $message = $filePositionService->updateFilePosition(
+                $eventDispatcher,
+                $parentType,
+                $imageId,
+                'image',
+                TheliaEvents::IMAGE_UPDATE_POSITION,
+                $position,
+            );
+        } catch (\Exception) {
+            return $this->pageNotFound();
+        }
+
+        return new Response($message);
+    }
+
+    public function updateDocumentPositionAction(
+        EventDispatcherInterface $eventDispatcher,
+        FilePositionService $filePositionService,
+        string $parentType,
+    ): Response {
+        $this->checkAuth($this->getAdminResources()->getResource($parentType, static::MODULE_RIGHT), [], AccessManager::UPDATE);
+        $this->checkXmlHttpRequest();
+
+        $documentId = (int) $this->getRequest()->request->get('document_id');
+        $position = (int) $this->getRequest()->request->get('position');
+
+        try {
+            $message = $filePositionService->updateFilePosition(
+                $eventDispatcher,
+                $parentType,
+                $documentId,
+                'document',
+                TheliaEvents::DOCUMENT_UPDATE_POSITION,
+                $position,
+            );
+        } catch (\Exception) {
+            return $this->pageNotFound();
+        }
+
+        return new Response($message);
+    }
+
+    public function toggleVisibilityImageAction(
+        EventDispatcherInterface $eventDispatcher,
+        FileVisibilityService $fileVisibilityService,
+        string $parentType,
+        int $documentId,
+    ): Response {
+        $this->checkAuth($this->getAdminResources()->getResource($parentType, static::MODULE_RIGHT), [], AccessManager::UPDATE);
+        $this->checkXmlHttpRequest();
+
+        try {
+            $message = $fileVisibilityService->toggleFileVisibility(
+                $eventDispatcher,
+                $documentId,
+                $parentType,
+                'image',
+                TheliaEvents::IMAGE_TOGGLE_VISIBILITY,
+            );
+        } catch (\Exception) {
+            return $this->pageNotFound();
+        }
+
+        return new Response($message);
+    }
+
+    public function toggleVisibilityDocumentAction(
+        EventDispatcherInterface $eventDispatcher,
+        FileVisibilityService $fileVisibilityService,
+        string $parentType,
+        int $documentId,
+    ): Response {
+        $this->checkAuth($this->getAdminResources()->getResource($parentType, static::MODULE_RIGHT), [], AccessManager::UPDATE);
+        $this->checkXmlHttpRequest();
+
+        try {
+            $message = $fileVisibilityService->toggleFileVisibility(
+                $eventDispatcher,
+                $documentId,
+                $parentType,
+                'document',
+                TheliaEvents::DOCUMENT_TOGGLE_VISIBILITY,
+            );
+        } catch (\Exception) {
+            return $this->pageNotFound();
+        }
+
+        return new Response($message);
+    }
+
+    public function updateImageTitleAction(
+        FileUpdateService $fileUpdateService,
+        int $imageId,
+        string $parentType,
+    ): RedirectResponse {
+        if (($response = $this->checkAuth($this->getAdminResources()->getResource($parentType, static::MODULE_RIGHT), [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $title = $this->getRequest()->request->get('title');
+        $locale = $this->getRequest()->request->get('locale');
+
+        $fileUpdateService->updateFileTitle(
+            $imageId,
+            $parentType,
+            'image',
+            $title,
+            $locale,
+        );
+
+        return $this->generateRedirect(
+            URL::getInstance()->absoluteUrl($this->getRequest()->request->get('success_url'), ['current_tab' => 'images']),
+        );
+    }
+}

--- a/Controller/Admin/FolderController.php
+++ b/Controller/Admin/FolderController.php
@@ -1,0 +1,325 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Propel\Runtime\Event\ActiveRecordEvent;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\Folder\FolderCreateEvent;
+use Thelia\Core\Event\Folder\FolderDeleteEvent;
+use Thelia\Core\Event\Folder\FolderToggleVisibilityEvent;
+use Thelia\Core\Event\Folder\FolderUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\HttpFoundation\Request;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Model\Folder;
+use Thelia\Model\FolderQuery;
+
+/**
+ * Class FolderController.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class FolderController extends AbstractSeoCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'folder',
+            'manual',
+            'folder_order',
+            AdminResources::FOLDER,
+            TheliaEvents::FOLDER_CREATE,
+            TheliaEvents::FOLDER_UPDATE,
+            TheliaEvents::FOLDER_DELETE,
+            TheliaEvents::FOLDER_TOGGLE_VISIBILITY,
+            TheliaEvents::FOLDER_UPDATE_POSITION,
+            TheliaEvents::FOLDER_UPDATE_SEO,
+        );
+    }
+
+    /**
+     * Return the creation form for this object.
+     */
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::FOLDER_CREATION);
+    }
+
+    /**
+     * Return the update form for this object.
+     */
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::FOLDER_MODIFICATION);
+    }
+
+    /**
+     * Hydrate the update form for this object, before passing it to the update template.
+     *
+     * @param Folder $object
+     */
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        // Hydrate the "SEO" tab form
+        $this->hydrateSeoForm($parserContext, $object);
+
+        // Prepare the data that will hydrate the form
+        $data = [
+            'id' => $object->getId(),
+            'locale' => $object->getLocale(),
+            'title' => $object->getTitle(),
+            'chapo' => $object->getChapo(),
+            'description' => $object->getDescription(),
+            'postscriptum' => $object->getPostscriptum(),
+            'visible' => $object->getVisible(),
+            'parent' => $object->getParent(),
+        ];
+
+        // Setup the object form
+        return $this->createForm(AdminForm::FOLDER_MODIFICATION, FormType::class, $data);
+    }
+
+    /**
+     * Creates the creation event with the provided form data.
+     */
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $creationEvent = new FolderCreateEvent();
+
+        $creationEvent
+            ->setLocale($formData['locale'])
+            ->setTitle($formData['title'])
+            ->setVisible($formData['visible'])
+            ->setParent($formData['parent']);
+
+        return $creationEvent;
+    }
+
+    /**
+     * Creates the update event with the provided form data.
+     */
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $updateEvent = new FolderUpdateEvent((int) $formData['id']);
+
+        $updateEvent
+            ->setLocale($formData['locale'])
+            ->setTitle($formData['title'])
+            ->setChapo($formData['chapo'])
+            ->setDescription($formData['description'])
+            ->setPostscriptum($formData['postscriptum'])
+            ->setVisible($formData['visible'])
+            ->setParent($formData['parent']);
+
+        return $updateEvent;
+    }
+
+    /**
+     * Creates the delete event with the provided form data.
+     */
+    protected function getDeleteEvent(): FolderDeleteEvent
+    {
+        return new FolderDeleteEvent((int) $this->getRequest()->get('folder_id'));
+    }
+
+    /**
+     * @return FolderToggleVisibilityEvent|void
+     */
+    protected function createToggleVisibilityEvent(): FolderToggleVisibilityEvent
+    {
+        return new FolderToggleVisibilityEvent($this->getExistingObject());
+    }
+
+    /**
+     * @return UpdatePositionEvent|void
+     */
+    protected function createUpdatePositionEvent(int $positionChangeMode, ?int $positionValue = null): UpdatePositionEvent
+    {
+        return new UpdatePositionEvent(
+            (int) $this->getRequest()->get('folder_id'),
+            $positionChangeMode,
+            $positionValue,
+        );
+    }
+
+    /**
+     * Return true if the event contains the object, e.g. the action has updated the object in the event.
+     */
+    protected function eventContainsObject(Event $event): bool
+    {
+        return $event->hasFolder();
+    }
+
+    /**
+     * Get the created object from an event.
+     *
+     * @param $event \Thelia\Core\Event\Folder\FolderEvent $event
+     *
+     * @return Folder|null
+     */
+    protected function getObjectFromEvent($event): mixed
+    {
+        return $event->hasFolder() ? $event->getFolder() : null;
+    }
+
+    /**
+     * Load an existing object from the database.
+     */
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        $folder = FolderQuery::create()
+            ->findOneById($this->getRequest()->get('folder_id', 0));
+
+        if (null !== $folder) {
+            $folder->setLocale($this->getCurrentEditionLocale());
+        }
+
+        return $folder;
+    }
+
+    /**
+     * Returns the object label form the object event (name, title, etc.).
+     *
+     * @param Folder $object
+     */
+    protected function getObjectLabel(ActiveRecordInterface $object): ?string
+    {
+        return $object->getTitle();
+    }
+
+    /**
+     * Returns the object ID from the object.
+     *
+     * @param Folder $object
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    /**
+     * Render the main list template.
+     */
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        // Get content order
+        $content_order = $this->getListOrderFromSession('content', 'content_order', 'manual');
+
+        return $this->render(
+            'folders',
+            [
+                'folder_order' => $currentOrder,
+                'content_order' => $content_order,
+                'parent' => $this->getRequest()->get('parent', 0),
+            ],
+        );
+    }
+
+    /**
+     * Render the edition template.
+     */
+    protected function renderEditionTemplate(): Response
+    {
+        return $this->render('folder-edit', $this->getEditionArguments());
+    }
+
+    protected function getEditionArguments(?Request $request = null): array
+    {
+        if (!$request instanceof Request) {
+            $request = $this->getRequest();
+        }
+
+        return [
+            'folder_id' => $request->get('folder_id', 0),
+            'current_tab' => $request->get('current_tab', 'general'),
+        ];
+    }
+
+    /**
+     * @return Response|void
+     */
+    protected function performAdditionalUpdateAction(EventDispatcherInterface $eventDispatcher, ActionEvent|ActiveRecordEvent|null $updateEvent): ?Response
+    {
+        if ('stay' !== $this->getRequest()->get('save_mode')) {
+            return $this->generateRedirectFromRoute(
+                'admin.folders.default',
+                ['parent' => $updateEvent->getFolder()->getParent()],
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * Put in this method post object delete processing if required.
+     *
+     * @param ActionEvent $deleteEvent the delete event
+     *
+     * @return Response a response, or null to continue normal processing
+     */
+    protected function performAdditionalDeleteAction(ActionEvent|ActiveRecordEvent|null $deleteEvent): ?Response
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.folders.default',
+            ['parent' => $deleteEvent->getFolder()->getParent()],
+        );
+    }
+
+    /**
+     * @param $positionChangeEvent ActionEvent
+     */
+    protected function performAdditionalUpdatePositionAction(ActionEvent $positionChangeEvent): ?Response
+    {
+        $folder = FolderQuery::create()->findPk($positionChangeEvent->getObjectId());
+
+        if (null !== $folder) {
+            return $this->generateRedirectFromRoute(
+                'admin.folders.default',
+                ['parent' => $folder->getParent()],
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * Redirect to the edition template.
+     */
+    protected function redirectToEditionTemplate(?Request $request = null): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute('admin.folders.update', [], $this->getEditionArguments($request));
+    }
+
+    /**
+     * Redirect to the list template.
+     */
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.folders.default',
+            ['parent' => $this->getRequest()->get('parent', 0)],
+        );
+    }
+}

--- a/Controller/Admin/HookController.php
+++ b/Controller/Admin/HookController.php
@@ -1,0 +1,480 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\Hook\HookCreateAllEvent;
+use Thelia\Core\Event\Hook\HookCreateEvent;
+use Thelia\Core\Event\Hook\HookDeactivationEvent;
+use Thelia\Core\Event\Hook\HookDeleteEvent;
+use Thelia\Core\Event\Hook\HookToggleActivationEvent;
+use Thelia\Core\Event\Hook\HookToggleNativeEvent;
+use Thelia\Core\Event\Hook\HookUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Core\Template\TemplateDefinition;
+use Thelia\Core\Translation\Translator;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Form\HookModificationForm;
+use Thelia\Log\Tlog;
+use Thelia\Model\Hook;
+use Thelia\Model\HookQuery;
+use Thelia\Model\Lang;
+
+/**
+ * Class HookController.
+ *
+ * @author  Julien Chanséaume <jchanseaume@openstudio.fr>
+ */
+class HookController extends AbstractCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'hook',
+            'id',
+            'order',
+            AdminResources::HOOK,
+            TheliaEvents::HOOK_CREATE,
+            TheliaEvents::HOOK_UPDATE,
+            TheliaEvents::HOOK_DELETE,
+        );
+    }
+
+    public function indexAction(): Response
+    {
+        if (($response = $this->checkAuth(AdminResources::HOOK, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        return $this->renderList();
+    }
+
+    public function discoverAction(): Response|JsonResponse
+    {
+        if (($response = $this->checkAuth(AdminResources::HOOK, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        $templateType = (int) $this->getRequest()->get('template_type', TemplateDefinition::FRONT_OFFICE);
+
+        $json_data = [];
+
+        try {
+            // parse the current template
+            $hookHelper = $this->container->get('thelia.hookHelper');
+            $hooks = $hookHelper->parseActiveTemplate($templateType);
+
+            // official hook
+            $allHooks = $this->getAllHooks($templateType);
+
+            // diff
+            $newHooks = [];
+            $existingHooks = [];
+
+            foreach ($hooks as $hook) {
+                if (\array_key_exists($hook['code'], $allHooks)) {
+                    $existingHooks[] = $hook['code'];
+                } else {
+                    $newHooks[] = $hook;
+                }
+            }
+
+            foreach ($existingHooks as $code) {
+                unset($allHooks[$code]);
+            }
+
+            $json_data = [
+                'success' => true,
+                'new' => $newHooks,
+                'missing' => $allHooks,
+            ];
+
+            $response = new JsonResponse($json_data);
+        } catch (\Exception $exception) {
+            $response = new JsonResponse(['error' => $exception->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        return $response;
+    }
+
+    public function discoverSaveAction(EventDispatcherInterface $eventDispatcher): Response|JsonResponse
+    {
+        if (($response = $this->checkAuth(AdminResources::HOOK, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $errors = [];
+
+        $templateType = $this->getRequest()->request->get('templateType');
+
+        // new hooks in the template
+        if (null !== $newHooks = $this->getRequest()->request->get('new')) {
+            foreach ($newHooks as $hook) {
+                $event = $this->getDiscoverCreationEvent($hook, $templateType);
+
+                $eventDispatcher->dispatch($event, TheliaEvents::HOOK_CREATE_ALL);
+
+                if (!$event->hasHook()) {
+                    $errors[] = \sprintf(
+                        Translator::getInstance()->trans('Failed to create new hook %s'),
+                        $hook['code'],
+                    );
+                }
+            }
+        }
+
+        // missing official hooks
+        if (null !== $missingHooks = $this->getRequest()->request->get('missing')) {
+            foreach ($missingHooks as $hookId) {
+                $event = new HookDeactivationEvent($hookId);
+
+                $eventDispatcher->dispatch($event, TheliaEvents::HOOK_DEACTIVATION);
+
+                if (!$event->hasHook()) {
+                    $errors[] = \sprintf(
+                        Translator::getInstance()->trans('Failed to deactivate hook with id %s'),
+                        $hookId,
+                    );
+                }
+            }
+        }
+
+        $json_data = [
+            'success' => true,
+        ];
+
+        if ([] !== $errors) {
+            $response = new JsonResponse(['error' => $errors], Response::HTTP_INTERNAL_SERVER_ERROR);
+        } else {
+            $response = new JsonResponse($json_data);
+        }
+
+        return $response;
+    }
+
+    protected function getDiscoverCreationEvent(array $data, int $type): HookCreateAllEvent
+    {
+        $event = new HookCreateAllEvent();
+
+        $event
+            ->setLocale(Lang::getDefaultLanguage()->getLocale())
+            ->setType($type)
+            ->setCode($data['code'])
+            ->setNative(false)
+            ->setActive(true)
+            ->setTitle(('' !== $data['title']) ? $data['title'] : $data['code'])
+            ->setByModule($data['module'])
+            ->setBlock($data['block'])
+            ->setChapo('')
+            ->setDescription('');
+
+        return $event;
+    }
+
+    protected function getDeactivationEvent($code, $type): ?HookDeactivationEvent
+    {
+        $event = null;
+
+        $hook_id = HookQuery::create()
+            ->filterByActivate(true, Criteria::EQUAL)
+            ->filterByType($type, Criteria::EQUAL)
+            ->filterByCode($code, Criteria::EQUAL)
+            ->select('Id')
+            ->findOne();
+
+        if (null !== $hook_id) {
+            $event = new HookDeactivationEvent($hook_id);
+        }
+
+        return $event;
+    }
+
+    /**
+     * @return array{id: mixed, code: mixed, native: mixed, activate: mixed, title: mixed}[]
+     */
+    protected function getAllHooks($templateType): array
+    {
+        // get the all hooks
+        $hooks = HookQuery::create()
+            ->filterByType($templateType, Criteria::EQUAL)
+            ->find();
+
+        $ret = [];
+
+        /** @var Hook $hook */
+        foreach ($hooks as $hook) {
+            $ret[$hook->getCode()] = [
+                'id' => $hook->getId(),
+                'code' => $hook->getCode(),
+                'native' => $hook->getNative(),
+                'activate' => $hook->getActivate(),
+                'title' => $hook->getTitle(),
+            ];
+        }
+
+        return $ret;
+    }
+
+    /**
+     * Return the creation form for this object.
+     */
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::HOOK_CREATION);
+    }
+
+    /**
+     * Return the update form for this object.
+     */
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::HOOK_MODIFICATION);
+    }
+
+    /**
+     * Hydrate the update form for this object, before passing it to the update template.
+     *
+     * @param Hook $object
+     *
+     * @return HookModificationForm
+     */
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        $data = [
+            'id' => $object->getId(),
+            'code' => $object->getCode(),
+            'type' => $object->getType(),
+            'native' => $object->getNative(),
+            'by_module' => $object->getByModule(),
+            'block' => $object->getBlock(),
+            'active' => $object->getActivate(),
+            'locale' => $object->getLocale(),
+            'title' => $object->getTitle(),
+            'chapo' => $object->getChapo(),
+            'description' => $object->getDescription(),
+        ];
+
+        return $this->createForm(AdminForm::HOOK_MODIFICATION, FormType::class, $data);
+    }
+
+    /**
+     * Creates the creation event with the provided form data.
+     */
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $event = new HookCreateEvent();
+
+        return $this->hydrateEvent($event, $formData);
+    }
+
+    /**
+     * Creates the update event with the provided form data.
+     */
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $event = new HookUpdateEvent((int) $formData['id']);
+
+        return $this->hydrateEvent($event, $formData, true);
+    }
+
+    protected function hydrateEvent($event, array $formData, $update = false)
+    {
+        $event
+            ->setLocale($formData['locale'])
+            ->setType($formData['type'])
+            ->setCode($formData['code'])
+            ->setNative($formData['native'])
+            ->setActive($formData['active'])
+            ->setTitle($formData['title']);
+
+        if ($update) {
+            $event
+                ->setByModule($formData['by_module'])
+                ->setBlock($formData['block'])
+                ->setChapo($formData['chapo'])
+                ->setDescription($formData['description']);
+        }
+
+        return $event;
+    }
+
+    /**
+     * Creates the delete event with the provided form data.
+     */
+    protected function getDeleteEvent(): HookDeleteEvent
+    {
+        return new HookDeleteEvent($this->getRequest()->get('hook_id'));
+    }
+
+    /**
+     * Return true if the event contains the object, e.g. the action has updated the object in the event.
+     */
+    protected function eventContainsObject(Event $event): bool
+    {
+        return $event->hasHook();
+    }
+
+    /**
+     * Get the created object from an event.
+     */
+    protected function getObjectFromEvent(Event $event): mixed
+    {
+        return $event->getHook();
+    }
+
+    /**
+     * Load an existing object from the database.
+     */
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        $hook = HookQuery::create()
+            ->findPk($this->getRequest()->get('hook_id', 0));
+
+        if (null !== $hook) {
+            $hook->setLocale($this->getCurrentEditionLocale());
+        }
+
+        return $hook;
+    }
+
+    /**
+     * Returns the object label form the object event (name, title, etc.).
+     *
+     * @param Hook $object
+     */
+    protected function getObjectLabel(ActiveRecordInterface $object): ?string
+    {
+        return $object->getTitle();
+    }
+
+    /**
+     * Returns the object ID from the object.
+     *
+     * @param Hook $object
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    /**
+     * Render the main list template.
+     */
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        return $this->render('hooks', ['order' => $currentOrder]);
+    }
+
+    /**
+     * Render the edition template.
+     */
+    protected function renderEditionTemplate(): Response
+    {
+        return $this->render('hook-edit', $this->getEditionArgument());
+    }
+
+    protected function getEditionArgument(): array
+    {
+        return [
+            'hook_id' => $this->getRequest()->get('hook_id', 0),
+        ];
+    }
+
+    /**
+     * Redirect to the edition template.
+     */
+    protected function redirectToEditionTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.hook.update',
+            [],
+            [
+                'hook_id' => $this->getRequest()->get('hook_id', 0),
+            ],
+        );
+    }
+
+    /**
+     * Redirect to the list template.
+     */
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute('admin.hook');
+    }
+
+    public function toggleNativeAction(EventDispatcherInterface $eventDispatcher): Response
+    {
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $content = null;
+
+        if (null !== $hook_id = $this->getRequest()->get('hook_id')) {
+            $toggleDefaultEvent = new HookToggleNativeEvent($hook_id);
+
+            try {
+                $eventDispatcher->dispatch($toggleDefaultEvent, TheliaEvents::HOOK_TOGGLE_NATIVE);
+
+                if ($toggleDefaultEvent->hasHook()) {
+                    return $this->nullResponse();
+                }
+            } catch (\Exception $ex) {
+                $content = $ex->getMessage();
+                Tlog::getInstance()->debug($content);
+            }
+        }
+
+        return $this->nullResponse(500);
+    }
+
+    public function toggleActivationAction(EventDispatcherInterface $eventDispatcher): Response
+    {
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $content = null;
+
+        if (null !== $hook_id = $this->getRequest()->get('hook_id')) {
+            $toggleDefaultEvent = new HookToggleActivationEvent($hook_id);
+
+            try {
+                $eventDispatcher->dispatch($toggleDefaultEvent, TheliaEvents::HOOK_TOGGLE_ACTIVATION);
+
+                if ($toggleDefaultEvent->hasHook()) {
+                    return $this->nullResponse();
+                }
+            } catch (\Exception $ex) {
+                $content = $ex->getMessage();
+                Tlog::getInstance()->debug($content);
+            }
+        }
+
+        return $this->nullResponse(500);
+    }
+}

--- a/Controller/Admin/ImportController.php
+++ b/Controller/Admin/ImportController.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Archiver\AbstractArchiver;
+use Thelia\Core\Archiver\ArchiverManager;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Serializer\AbstractSerializer;
+use Thelia\Core\Serializer\SerializerManager;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Form\Exception\FormValidationException;
+use Thelia\Model\LangQuery;
+use Thelia\Service\DataTransfer\Importhandler;
+
+/**
+ * Class ImportController.
+ *
+ * @author Jérôme Billiras <jbilliras@openstudio.fr>
+ */
+class ImportController extends BaseAdminController
+{
+    /**
+     * Handle default action, that is, list available imports.
+     *
+     * @param string $_view View to render
+     */
+    public function indexAction(string $_view = 'import'): Response
+    {
+        $authResponse = $this->checkAuth([AdminResources::IMPORT], [], [AccessManager::VIEW]);
+
+        if ($authResponse instanceof Response) {
+            return $authResponse;
+        }
+
+        $this->getParserContext()
+            ->set('category_order', $this->getRequest()->query->get('category_order', 'manual'))
+            ->set('import_order', $this->getRequest()->query->get('import_order', 'manual'));
+
+        return $this->render($_view);
+    }
+
+    /**
+     * Handle import position change action.
+     */
+    public function changeImportPositionAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        $authResponse = $this->checkAuth([AdminResources::IMPORT], [], [AccessManager::UPDATE]);
+
+        if ($authResponse instanceof Response) {
+            return $authResponse;
+        }
+
+        $query = $this->getRequest()->query;
+
+        $eventDispatcher->dispatch(
+            new UpdatePositionEvent(
+                (int) $query->get('id'),
+                $this->matchPositionMode($query->get('mode')),
+                (int) $query->get('value'),
+            ),
+            TheliaEvents::IMPORT_CHANGE_POSITION,
+        );
+
+        return $this->generateRedirectFromRoute('import.list');
+    }
+
+    /**
+     * Handle import category position change action.
+     */
+    public function changeCategoryPositionAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        $authResponse = $this->checkAuth([AdminResources::IMPORT], [], [AccessManager::UPDATE]);
+
+        if ($authResponse instanceof Response) {
+            return $authResponse;
+        }
+
+        $query = $this->getRequest()->query;
+
+        $eventDispatcher->dispatch(
+            new UpdatePositionEvent(
+                (int) $query->get('id'),
+                $this->matchPositionMode($query->get('mode')),
+                (int) $query->get('value'),
+            ),
+            TheliaEvents::IMPORT_CATEGORY_CHANGE_POSITION,
+        );
+
+        return $this->generateRedirectFromRoute('import.list');
+    }
+
+    /**
+     * Match position mode string against position mode constant value.
+     *
+     * @param string|null $mode Position mode string
+     *
+     * @return int Position mode constant value
+     */
+    protected function matchPositionMode(?string $mode): int
+    {
+        if ('up' === $mode) {
+            return UpdatePositionEvent::POSITION_UP;
+        }
+
+        if ('down' === $mode) {
+            return UpdatePositionEvent::POSITION_DOWN;
+        }
+
+        return UpdatePositionEvent::POSITION_ABSOLUTE;
+    }
+
+    /**
+     * Display import configuration view.
+     *
+     * @param int $id An import identifier
+     */
+    public function configureAction(
+        int $id,
+        SerializerManager $serializerManager,
+        ArchiverManager $archiverManager,
+    ): Response {
+        /** @var Importhandler $importHandler */
+        $importHandler = $this->container->get('thelia.import.handler');
+
+        $import = $importHandler->getImport($id);
+
+        if (null === $import) {
+            return $this->pageNotFound();
+        }
+
+        $extensions = [];
+        $mimeTypes = [];
+
+        /** @var AbstractSerializer $serializer */
+        foreach ($serializerManager->getSerializers() as $serializer) {
+            $extensions[] = $serializer->getExtension();
+            $mimeTypes[] = $serializer->getMimeType();
+        }
+
+        /** @var AbstractArchiver $archiver */
+        foreach ($archiverManager->getArchivers(true) as $archiver) {
+            $extensions[] = $archiver->getExtension();
+            $mimeTypes[] = $archiver->getMimeType();
+        }
+
+        // Render standard view or ajax one
+        $templateName = 'import-page';
+
+        if ($this->getRequest()->isXmlHttpRequest()) {
+            $templateName = 'ajax/import-modal';
+        }
+
+        return $this->render(
+            $templateName,
+            [
+                'importId' => $id,
+                'ALLOWED_MIME_TYPES' => implode(', ', $mimeTypes),
+                'ALLOWED_EXTENSIONS' => implode(', ', $extensions),
+            ],
+        );
+    }
+
+    /**
+     * Handle import action.
+     *
+     * @param int $id An import identifier
+     */
+    public function importAction(
+        int $id,
+        SerializerManager $serializerManager,
+        ArchiverManager $archiverManager,
+    ): Response|RedirectResponse {
+        /** @var Importhandler $importHandler */
+        $importHandler = $this->container->get('thelia.import.handler');
+
+        $import = $importHandler->getImport($id);
+
+        if (null === $import) {
+            return $this->pageNotFound();
+        }
+
+        $form = $this->createForm(AdminForm::IMPORT);
+
+        try {
+            $validatedForm = $this->validateForm($form);
+
+            /** @var UploadedFile $file */
+            $file = $validatedForm->get('file_upload')->getData();
+            $file = $file->move(
+                THELIA_CACHE_DIR.'import'.DS.(new \DateTime())->format('Ymd'),
+                uniqid().'-'.$file->getClientOriginalName(),
+            );
+
+            $lang = (new LangQuery())->findPk($validatedForm->get('language')->getData());
+
+            $importEvent = $importHandler->import($import, $file, $lang);
+
+            if (\count($importEvent->getErrors()) > 0) {
+                $this->getSession()->getFlashBag()->add(
+                    'thelia.import.error',
+                    $this->getTranslator()->trans(
+                        'Error(s) in import&nbsp;:<br />%errors',
+                        [
+                            '%errors' => implode('<br />', $importEvent->getErrors()),
+                        ],
+                    ),
+                );
+            }
+
+            $this->getSession()->getFlashBag()->add(
+                'thelia.import.success',
+                $this->getTranslator()->trans(
+                    'Import successfully done, %count row(s) have been changed',
+                    [
+                        '%count' => $importEvent->getImport()->getImportedRows(),
+                    ],
+                ),
+            );
+
+            return $this->generateRedirectFromRoute('import.view', [], ['id' => $id]);
+        } catch (FormValidationException $e) {
+            $form->setErrorMessage($this->createStandardFormValidationErrorMessage($e));
+        } catch (\Exception $e) {
+            $this->getParserContext()->setGeneralError($e->getMessage());
+        }
+
+        $this->getParserContext()
+            ->addForm($form);
+
+        return $this->configureAction($id, $serializerManager, $archiverManager);
+    }
+}

--- a/Controller/Admin/LangController.php
+++ b/Controller/Admin/LangController.php
@@ -1,0 +1,455 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Form;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\Lang\LangCreateEvent;
+use Thelia\Core\Event\Lang\LangDefaultBehaviorEvent;
+use Thelia\Core\Event\Lang\LangDeleteEvent;
+use Thelia\Core\Event\Lang\LangEvent;
+use Thelia\Core\Event\Lang\LangToggleActiveEvent;
+use Thelia\Core\Event\Lang\LangToggleDefaultEvent;
+use Thelia\Core\Event\Lang\LangToggleVisibleEvent;
+use Thelia\Core\Event\Lang\LangUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Form\Exception\FormValidationException;
+use Thelia\Form\Lang\LangUrlEvent;
+use Thelia\Form\Lang\LangUrlForm;
+use Thelia\Log\Tlog;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\Lang;
+use Thelia\Model\LangQuery;
+
+/**
+ * Class LangController.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class LangController extends BaseAdminController
+{
+    public function defaultAction()
+    {
+        if (($response = $this->checkAuth(AdminResources::LANGUAGE, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        return $this->renderDefault();
+    }
+
+    public function renderDefault(array $param = [], int $status = 200): Response
+    {
+        $data = [];
+
+        foreach (LangQuery::create()->find() as $lang) {
+            $data[LangUrlForm::LANG_PREFIX.$lang->getId()] = $lang->getUrl();
+        }
+
+        $langUrlForm = $this->createForm(AdminForm::LANG_URL, FormType::class, $data);
+        $this->getParserContext()->addForm($langUrlForm);
+
+        return $this->render('languages', array_merge($param, [
+            'lang_without_translation' => ConfigQuery::getDefaultLangWhenNoTranslationAvailable(),
+            'one_domain_per_lang' => ConfigQuery::isMultiDomainActivated(),
+        ]), $status);
+    }
+
+    public function updateAction($lang_id)
+    {
+        if (($response = $this->checkAuth(AdminResources::LANGUAGE, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $this->checkXmlHttpRequest();
+
+        $lang = LangQuery::create()->findPk($lang_id);
+
+        if (null === $lang) {
+            throw new \InvalidArgumentException(\sprintf('Language #%s not found', $lang_id));
+        }
+
+        $langForm = $this->createForm(AdminForm::LANG_UPDATE, FormType::class, [
+            'id' => $lang->getId(),
+            'title' => $lang->getTitle(),
+            'code' => $lang->getCode(),
+            'locale' => $lang->getLocale(),
+            'date_time_format' => $lang->getDateTimeFormat(),
+            'date_format' => $lang->getDateFormat(),
+            'time_format' => $lang->getTimeFormat(),
+            'decimal_separator' => $lang->getDecimalSeparator(),
+            'thousands_separator' => $lang->getThousandsSeparator(),
+            'decimals' => $lang->getDecimals(),
+        ]);
+
+        $this->getParserContext()->addForm($langForm);
+
+        return $this->render('ajax/language-update-modal', [
+            'lang_id' => $lang_id,
+        ]);
+    }
+
+    public function processUpdateAction(EventDispatcherInterface $eventDispatcher, int $lang_id): Response|RedirectResponse|null
+    {
+        if (($response = $this->checkAuth(AdminResources::LANGUAGE, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $error_msg = false;
+
+        $langForm = $this->createForm(AdminForm::LANG_UPDATE);
+
+        try {
+            $form = $this->validateForm($langForm);
+
+            $event = new LangUpdateEvent((int) $form->get('id')->getData());
+            $event = $this->hydrateEvent($event, $form);
+
+            $eventDispatcher->dispatch($event, TheliaEvents::LANG_UPDATE);
+
+            if (false === $event->hasLang()) {
+                throw new \LogicException($this->getTranslator()->trans('No %obj was updated.', ['%obj', 'Lang']));
+            }
+
+            /** @var Lang $changedObject */
+            $changedObject = $event->getLang();
+            $this->adminLogAppend(
+                AdminResources::LANGUAGE,
+                AccessManager::UPDATE,
+                \sprintf(
+                    '%s %s (ID %s) modified',
+                    'Lang',
+                    $changedObject->getTitle(),
+                    $changedObject->getId(),
+                ),
+                $changedObject->getId(),
+            );
+
+            $response = $this->generateRedirectFromRoute('admin.configuration.languages');
+        } catch (\Exception $exception) {
+            $error_msg = $this->getTranslator()->trans('Failed to update language definition: %ex', ['%ex' => $exception->getMessage()]);
+            Tlog::getInstance()->addError('Failed to update language definition', $exception->getMessage());
+        }
+
+        if (false !== $error_msg) {
+            $response = $this->renderDefault(['error_message' => $error_msg]);
+        }
+
+        return $response;
+    }
+
+    protected function hydrateEvent(LangCreateEvent $event, Form $form): LangCreateEvent
+    {
+        return $event
+            ->setTitle($form->get('title')->getData())
+            ->setCode($form->get('code')->getData())
+            ->setLocale($form->get('locale')->getData())
+            ->setDateTimeFormat($form->get('date_time_format')->getData())
+            ->setDateFormat($form->get('date_format')->getData())
+            ->setTimeFormat($form->get('time_format')->getData())
+            ->setDecimalSeparator($form->get('decimal_separator')->getData())
+            ->setThousandsSeparator($form->get('thousands_separator')->getData())
+            ->setDecimals($form->get('decimals')->getData());
+    }
+
+    public function toggleDefaultAction(EventDispatcherInterface $eventDispatcher, int $lang_id): Response|JsonResponse|RedirectResponse
+    {
+        return $this->toggleLangDispatch(
+            $eventDispatcher,
+            TheliaEvents::LANG_TOGGLEDEFAULT,
+            new LangToggleDefaultEvent($lang_id),
+        );
+    }
+
+    public function toggleActiveAction(EventDispatcherInterface $eventDispatcher, int $lang_id): Response|JsonResponse|RedirectResponse
+    {
+        return $this->toggleLangDispatch(
+            $eventDispatcher,
+            TheliaEvents::LANG_TOGGLEACTIVE,
+            new LangToggleActiveEvent($lang_id),
+        );
+    }
+
+    public function toggleVisibleAction(EventDispatcherInterface $eventDispatcher, int $lang_id): Response|JsonResponse|RedirectResponse
+    {
+        return $this->toggleLangDispatch(
+            $eventDispatcher,
+            TheliaEvents::LANG_TOGGLEVISIBLE,
+            new LangToggleVisibleEvent($lang_id),
+        );
+    }
+
+    public function addAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse|null
+    {
+        if (($response = $this->checkAuth(AdminResources::LANGUAGE, [], AccessManager::CREATE)) instanceof Response) {
+            return $response;
+        }
+
+        $createForm = $this->createForm(AdminForm::LANG_CREATE);
+
+        $error_msg = false;
+        $ex = null;
+
+        try {
+            $form = $this->validateForm($createForm);
+
+            $createEvent = new LangCreateEvent();
+            $createEvent = $this->hydrateEvent($createEvent, $form);
+
+            $eventDispatcher->dispatch($createEvent, TheliaEvents::LANG_CREATE);
+
+            if (false === $createEvent->hasLang()) {
+                throw new \LogicException($this->getTranslator()->trans('No %obj was updated.', ['%obj', 'Lang']));
+            }
+
+            /** @var Lang $createdObject */
+            $createdObject = $createEvent->getLang();
+            $this->adminLogAppend(
+                AdminResources::LANGUAGE,
+                AccessManager::CREATE,
+                \sprintf(
+                    '%s %s (ID %s) created',
+                    'Lang',
+                    $createdObject->getTitle(),
+                    $createdObject->getId(),
+                ),
+                $createdObject->getId(),
+            );
+
+            $response = $this->generateRedirectFromRoute('admin.configuration.languages');
+        } catch (FormValidationException $ex) {
+            // Form cannot be validated
+            $error_msg = $this->createStandardFormValidationErrorMessage($ex);
+        } catch (\Exception $ex) {
+            // Any other error
+            $error_msg = $ex->getMessage();
+        }
+
+        if (false !== $error_msg) {
+            $this->setupFormErrorContext(
+                $this->getTranslator()->trans('%obj creation', ['%obj' => 'Lang']),
+                $error_msg,
+                $createForm,
+                $ex,
+            );
+
+            // At this point, the form has error, and should be redisplayed.
+            $response = $this->renderDefault();
+        }
+
+        return $response;
+    }
+
+    public function deleteAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse|null
+    {
+        if (($response = $this->checkAuth(AdminResources::LANGUAGE, [], AccessManager::DELETE)) instanceof Response) {
+            return $response;
+        }
+
+        $error_msg = false;
+
+        try {
+            $this->getTokenProvider()->checkToken(
+                $this->getRequest()->query->get('_token'),
+            );
+
+            $deleteEvent = new LangDeleteEvent((int) $this->getRequest()->get('language_id', 0));
+
+            $eventDispatcher->dispatch($deleteEvent, TheliaEvents::LANG_DELETE);
+
+            $response = $this->generateRedirectFromRoute('admin.configuration.languages');
+        } catch (\Exception $exception) {
+            Tlog::getInstance()->error(\sprintf('error during language removal with message : %s', $exception->getMessage()));
+            $error_msg = $exception->getMessage();
+        }
+
+        if (false !== $error_msg) {
+            $response = $this->renderDefault([
+                'error_message' => $error_msg,
+            ]);
+        }
+
+        return $response;
+    }
+
+    public function defaultBehaviorAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse|null
+    {
+        if (($response = $this->checkAuth(AdminResources::LANGUAGE, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $error_msg = false;
+        $ex = null;
+
+        $behaviorForm = $this->createForm(AdminForm::LANG_DEFAULT_BEHAVIOR);
+
+        try {
+            $form = $this->validateForm($behaviorForm);
+
+            $event = new LangDefaultBehaviorEvent($form->get('behavior')->getData());
+
+            $eventDispatcher->dispatch($event, TheliaEvents::LANG_DEFAULTBEHAVIOR);
+
+            $response = $this->generateRedirectFromRoute('admin.configuration.languages');
+        } catch (FormValidationException $ex) {
+            // Form cannot be validated
+            $error_msg = $this->createStandardFormValidationErrorMessage($ex);
+        } catch (\Exception $ex) {
+            // Any other error
+            $error_msg = $ex->getMessage();
+        }
+
+        if (false !== $error_msg) {
+            $this->setupFormErrorContext(
+                $this->getTranslator()->trans('%obj creation', ['%obj' => 'Lang']),
+                $error_msg,
+                $behaviorForm,
+                $ex,
+            );
+
+            // At this point, the form has error, and should be redisplayed.
+            $response = $this->renderDefault();
+        }
+
+        return $response;
+    }
+
+    public function domainAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse|null
+    {
+        if (($response = $this->checkAuth(AdminResources::LANGUAGE, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $error_msg = false;
+        $ex = null;
+        $langUrlForm = $this->createForm(AdminForm::LANG_URL);
+
+        try {
+            $form = $this->validateForm($langUrlForm);
+
+            $data = $form->getData();
+            $event = new LangUrlEvent();
+
+            foreach ($data as $key => $value) {
+                if (str_contains((string) $key, LangUrlForm::LANG_PREFIX)) {
+                    $event->addUrl(substr((string) $key, \strlen(LangUrlForm::LANG_PREFIX)), $value);
+                }
+            }
+
+            $eventDispatcher->dispatch($event, TheliaEvents::LANG_URL);
+
+            $response = $this->generateRedirectFromRoute('admin.configuration.languages');
+        } catch (FormValidationException $ex) {
+            // Form cannot be validated
+            $error_msg = $this->createStandardFormValidationErrorMessage($ex);
+        } catch (\Exception $ex) {
+            // Any other error
+            $error_msg = $ex->getMessage();
+        }
+
+        if (false !== $error_msg) {
+            $this->setupFormErrorContext(
+                $this->getTranslator()->trans('%obj creation', ['%obj' => 'Lang']),
+                $error_msg,
+                $langUrlForm,
+                $ex,
+            );
+
+            // At this point, the form has error, and should be redisplayed.
+            $response = $this->renderDefault();
+        }
+
+        return $response;
+    }
+
+    public function activateDomainAction(): Response|RedirectResponse
+    {
+        return $this->domainActivation(1);
+    }
+
+    public function deactivateDomainAction(): Response|RedirectResponse
+    {
+        return $this->domainActivation(0);
+    }
+
+    private function domainActivation(int $activate): Response|RedirectResponse
+    {
+        if (($response = $this->checkAuth(AdminResources::LANGUAGE, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        ConfigQuery::create()
+            ->filterByName('one_domain_foreach_lang')
+            ->update(['Value' => $activate], null, true);
+
+        return $this->generateRedirectFromRoute('admin.configuration.languages');
+    }
+
+    protected function toggleLangDispatch(EventDispatcherInterface $eventDispatcher, ?string $eventName, LangEvent $event): Response|JsonResponse|RedirectResponse
+    {
+        if (($response = $this->checkAuth(AdminResources::LANGUAGE, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $errorMessage = null;
+
+        $this->getTokenProvider()->checkToken(
+            $this->getRequest()->query->get('_token'),
+        );
+
+        try {
+            $eventDispatcher->dispatch($event, $eventName);
+
+            if (false === $event->hasLang()) {
+                throw new \LogicException($this->getTranslator()->trans('No %obj was updated.', ['%obj', 'Lang']));
+            }
+
+            $changedObject = $event->getLang();
+            $this->adminLogAppend(
+                AdminResources::LANGUAGE,
+                AccessManager::UPDATE,
+                \sprintf(
+                    '%s %s (ID %s) modified',
+                    'Lang',
+                    $changedObject->getTitle(),
+                    $changedObject->getId(),
+                ),
+                $changedObject->getId(),
+            );
+        } catch (\Exception $exception) {
+            Tlog::getInstance()->error(\sprintf('Error on changing languages with message : %s', $exception->getMessage()));
+            $errorMessage = $exception->getMessage();
+        }
+
+        if ($this->getRequest()->isXmlHttpRequest()) {
+            return new JsonResponse(
+                null !== $errorMessage ? ['message' => $errorMessage] : [],
+                null !== $errorMessage ? 500 : 200,
+            );
+        }
+
+        if (null !== $errorMessage) {
+            return $this->renderDefault(['error_message' => $errorMessage], 500);
+        }
+
+        return $this->generateRedirectFromRoute('admin.configuration.languages');
+    }
+}

--- a/Controller/Admin/LanguageController.php
+++ b/Controller/Admin/LanguageController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Symfony\Component\HttpFoundation\Response;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+
+/**
+ * Class LanguageController.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class LanguageController extends BaseAdminController
+{
+    public function defaultAction()
+    {
+        if (($response = $this->checkAuth(AdminResources::LANGUAGE, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        return $this->render('languages');
+    }
+}

--- a/Controller/Admin/MailingSystemController.php
+++ b/Controller/Admin/MailingSystemController.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\MailingSystem\MailingSystemEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\HttpFoundation\JsonResponse;
+use Thelia\Core\HttpFoundation\Request;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Translation\Translator;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Form\Exception\FormValidationException;
+use Thelia\Mailer\MailerFactory;
+use Thelia\Model\ConfigQuery;
+
+class MailingSystemController extends BaseAdminController
+{
+    public const RESOURCE_CODE = 'admin.configuration.mailing-system';
+
+    public function defaultAction()
+    {
+        if (($response = $this->checkAuth(self::RESOURCE_CODE, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        // Hydrate the form abd pass it to the parser
+        $data = [
+            'enabled' => (bool) ConfigQuery::isSmtpEnable(),
+            'host' => ConfigQuery::getSmtpHost(),
+            'port' => ConfigQuery::getSmtpPort(),
+            'encryption' => ConfigQuery::getSmtpEncryption(),
+            'username' => ConfigQuery::getSmtpUsername(),
+            'password' => ConfigQuery::getSmtpPassword(),
+            'authmode' => ConfigQuery::getSmtpAuthMode(),
+            'timeout' => ConfigQuery::getSmtpTimeout(),
+            'sourceip' => ConfigQuery::getSmtpSourceIp(),
+        ];
+
+        // Setup the object form
+        $form = $this->createForm(AdminForm::MAILING_SYSTEM_MODIFICATION, FormType::class, $data);
+
+        // Pass it to the parser
+        $this->getParserContext()->addForm($form);
+
+        // Render the edition template.
+        return $this->render('mailing-system', ['editDisabled' => ConfigQuery::isSmtpInEnv()]);
+    }
+
+    public function updateAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse|null
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth(self::RESOURCE_CODE, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $error_msg = false;
+        $ex = null;
+
+        // Create the form from the request
+        $form = $this->createForm(AdminForm::MAILING_SYSTEM_MODIFICATION);
+
+        try {
+            // Check the form against constraints violations
+            $formData = $this->validateForm($form, 'POST');
+
+            // Get the form field values
+            $event = new MailingSystemEvent();
+            $event->setEnabled($formData->get('enabled')->getData());
+            $event->setHost($formData->get('host')->getData());
+            $event->setPort($formData->get('port')->getData());
+            $event->setEncryption($formData->get('encryption')->getData());
+            $event->setUsername($formData->get('username')->getData());
+            $event->setPassword($formData->get('password')->getData());
+            $event->setAuthMode($formData->get('authmode')->getData());
+            $event->setTimeout($formData->get('timeout')->getData());
+            $event->setSourceIp($formData->get('sourceip')->getData());
+
+            $eventDispatcher->dispatch($event, TheliaEvents::MAILING_SYSTEM_UPDATE);
+
+            // Redirect to the success URL
+            $response = $this->generateRedirectFromRoute('admin.configuration.mailing-system.view');
+        } catch (FormValidationException $ex) {
+            // Form cannot be validated
+            $error_msg = $this->createStandardFormValidationErrorMessage($ex);
+        } catch (\Exception $ex) {
+            // Any other error
+            $error_msg = $ex->getMessage();
+        }
+
+        if (false !== $error_msg) {
+            $this->setupFormErrorContext(
+                $this->getTranslator()->trans('mailing system modification'),
+                $error_msg,
+                $form,
+                $ex,
+            );
+
+            // At this point, the form has errors, and should be redisplayed.
+            $response = $this->render('mailing-system');
+        }
+
+        return $response;
+    }
+
+    public function testAction(Request $request, MailerFactory $mailer): Response|JsonResponse
+    {
+        $translator = Translator::getInstance();
+
+        // Check current user authorization
+        if (($response = $this->checkAuth(self::RESOURCE_CODE, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $contactEmail = ConfigQuery::read('store_email');
+        $storeName = ConfigQuery::read('store_name', 'Thelia');
+
+        $json_data = [
+            'success' => false,
+            'message' => '',
+        ];
+
+        if ($contactEmail) {
+            $emailTest = $request->get('email', $contactEmail);
+
+            $message = $translator->trans('Email test from : %store%', ['%store%' => $storeName]);
+
+            $htmlMessage = \sprintf('<p>%s</p>', $message);
+
+            try {
+                $mailer->sendSimpleEmailMessage(
+                    [$contactEmail => $storeName],
+                    [$emailTest => $storeName],
+                    $message,
+                    $message,
+                    $htmlMessage,
+                );
+                $json_data['success'] = true;
+                $json_data['message'] = $translator->trans('Your configuration seems to be ok. Checked out your mailbox : %email%', ['%email%' => $emailTest]);
+            } catch (\Exception $ex) {
+                $json_data['message'] = $ex->getMessage();
+            }
+        } else {
+            $json_data['message'] = $translator->trans('You have to configure your store email first !');
+        }
+
+        return new JsonResponse($json_data);
+    }
+}

--- a/Controller/Admin/MessageController.php
+++ b/Controller/Admin/MessageController.php
@@ -1,0 +1,346 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\Message\MessageCreateEvent;
+use Thelia\Core\Event\Message\MessageDeleteEvent;
+use Thelia\Core\Event\Message\MessageUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Core\Template\TemplateDefinition;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\Message;
+use Thelia\Model\MessageQuery;
+use Thelia\Model\Module;
+use Thelia\Model\ModuleQuery;
+
+/**
+ * Manages messages sent by mail.
+ *
+ * @author Franck Allimant <franck@cqfdev.fr>
+ */
+class MessageController extends AbstractCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'message',
+            null, // no sort order change
+            null, // no sort order change
+            AdminResources::MESSAGE,
+            TheliaEvents::MESSAGE_CREATE,
+            TheliaEvents::MESSAGE_UPDATE,
+            TheliaEvents::MESSAGE_DELETE,  // No position update
+        );
+    }
+
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::MESSAGE_CREATION);
+    }
+
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::MESSAGE_MODIFICATION);
+    }
+
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $createEvent = new MessageCreateEvent();
+
+        $createEvent
+            ->setMessageName($formData['name'])
+            ->setLocale($formData['locale'])
+            ->setTitle($formData['title'])
+            ->setSecured((bool) $formData['secured']);
+
+        return $createEvent;
+    }
+
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $changeEvent = new MessageUpdateEvent((int) $formData['id']);
+
+        // Create and dispatch the change event
+        $changeEvent
+            ->setMessageName($formData['name'])
+            ->setSecured($formData['secured'])
+            ->setLocale($formData['locale'])
+            ->setTitle($formData['title'])
+            ->setSubject($formData['subject'])
+            ->setHtmlLayoutFileName($formData['html_layout_file_name'])
+            ->setHtmlTemplateFileName($formData['html_template_file_name'])
+            ->setTextLayoutFileName($formData['text_layout_file_name'])
+            ->setTextTemplateFileName($formData['text_template_file_name'])
+            ->setHtmlMessage($formData['html_message'])
+            ->setTextMessage($formData['text_message']);
+
+        return $changeEvent;
+    }
+
+    protected function getDeleteEvent(): MessageDeleteEvent
+    {
+        return new MessageDeleteEvent((int) $this->getRequest()->get('message_id'));
+    }
+
+    protected function eventContainsObject($event): bool
+    {
+        return $event->hasMessage();
+    }
+
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        // Prepare the data that will hydrate the form
+        $data = [
+            'id' => $object->getId(),
+            'name' => $object->getName(),
+            'secured' => (bool) $object->getSecured(),
+            'locale' => $object->getLocale(),
+            'title' => $object->getTitle(),
+            'subject' => $object->getSubject(),
+            'html_message' => $object->getHtmlMessage(),
+            'text_message' => $object->getTextMessage(),
+
+            'html_layout_file_name' => $object->getHtmlLayoutFileName(),
+            'html_template_file_name' => $object->getHtmlTemplateFileName(),
+            'text_layout_file_name' => $object->getTextLayoutFileName(),
+            'text_template_file_name' => $object->getTextTemplateFileName(),
+        ];
+
+        // Setup the object form
+        return $this->createForm(AdminForm::MESSAGE_MODIFICATION, FormType::class, $data);
+    }
+
+    protected function getObjectFromEvent($event): mixed
+    {
+        return $event->hasMessage() ? $event->getMessage() : null;
+    }
+
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        $message = MessageQuery::create()
+            ->findOneById($this->getRequest()->get('message_id', 0));
+
+        if (null !== $message) {
+            $message->setLocale($this->getCurrentEditionLocale());
+        }
+
+        return $message;
+    }
+
+    /**
+     * @param Message $object
+     */
+    protected function getObjectLabel(ActiveRecordInterface $object): ?string
+    {
+        return $object->getName();
+    }
+
+    /**
+     * @param Message $object
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    protected function renderListTemplate(?string $currentOrder): Response
+    {
+        return $this->render('messages');
+    }
+
+    /**
+     * @return list
+     */
+    protected function listDirectoryContent(string $requiredExtension): array
+    {
+        $list = [];
+
+        $mailTemplate = $this->getTemplateHelper()->getActiveMailTemplate();
+
+        $finder = Finder::create()->files()->in($mailTemplate->getAbsolutePath());
+
+        // Also add parent template files, if any.
+        /** @var TemplateDefinition $parentTemplate */
+        foreach ($mailTemplate->getParentList() as $parentTemplate) {
+            $finder->in($parentTemplate->getAbsolutePath());
+        }
+
+        $finder->ignoreDotFiles(true)->sortByName()->name('*.'.$requiredExtension);
+
+        /** @var SplFileInfo $file */
+        foreach ($finder as $file) {
+            $list[] = $file->getRelativePathname();
+        }
+
+        // Add modules templates
+        $modules = ModuleQuery::getActivated();
+
+        /** @var Module $module */
+        foreach ($modules as $module) {
+            $dir = $module->getAbsoluteTemplateBasePath().DS.TemplateDefinition::EMAIL_SUBDIR.DS.'default';
+
+            if (file_exists($dir)) {
+                $finder = Finder::create()
+                    ->files()
+                    ->in($dir)
+                    ->ignoreDotFiles(true)
+                    ->sortByName()
+                    ->name('*.'.$requiredExtension);
+
+                foreach ($finder as $file) {
+                    $fileName = $file->getBasename();
+
+                    if (!\in_array($fileName, $list, true)) {
+                        $list[] = $fileName;
+                    }
+                }
+            }
+        }
+
+        return $list;
+    }
+
+    protected function renderEditionTemplate(): Response
+    {
+        return $this->render('message-edit', [
+            'message_id' => $this->getRequest()->get('message_id'),
+            'layout_list' => $this->listDirectoryContent('tpl'),
+            'html_template_list' => $this->listDirectoryContent('html'),
+            'text_template_list' => $this->listDirectoryContent('txt'),
+        ]);
+    }
+
+    protected function redirectToEditionTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.configuration.messages.update',
+            [
+                'message_id' => $this->getRequest()->get('message_id'),
+            ],
+        );
+    }
+
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute('admin.configuration.messages.default');
+    }
+
+    public function previewAction($messageId, $html = true)
+    {
+        if (($response = $this->checkAuth(AdminResources::MESSAGE, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        if (null === $message = MessageQuery::create()->findPk($messageId)) {
+            $this->pageNotFound();
+        }
+
+        $parser = $this->getParser($this->getTemplateHelper()->getActiveMailTemplate()->getPath());
+        $parser->setTemplateDefinition($this->getTemplateHelper()->getActiveMailTemplate());
+
+        foreach ($this->getRequest()->query->all() as $key => $value) {
+            $parser->assign($key, $value);
+        }
+
+        try {
+            if ($html) {
+                $content = $message->setLocale($this->getCurrentEditionLocale())->getHtmlMessageBody($parser);
+            } else {
+                $content = $message->setLocale($this->getCurrentEditionLocale())->getTextMessageBody($parser);
+            }
+        } catch (\InvalidArgumentException|\ErrorException $exception) {
+            return new Response($this->getTranslator()->trans(
+                "You probably didn't inject the missing variable to preview the HTML. Error is : %err",
+                ['%err' => $exception->getMessage()],
+            ), Response::HTTP_OK);
+        } catch (\Exception $exception) {
+            return new Response($this->getTranslator()->trans(
+                'Something goes wrong, error is : %err',
+                ['%err' => $exception->getMessage()],
+            ), Response::HTTP_OK);
+        }
+
+        return new Response($content);
+    }
+
+    public function previewAsHtmlAction($messageId)
+    {
+        return $this->previewAction($messageId);
+    }
+
+    public function previewAsTextAction($messageId)
+    {
+        $response = $this->previewAction($messageId, false);
+        $response->headers->add(['Content-Type' => 'text/plain']);
+
+        return $response;
+    }
+
+    public function sendSampleByEmailAction($messageId)
+    {
+        if (($response = $this->checkAuth(AdminResources::MESSAGE, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        if (null !== $message = MessageQuery::create()->findPk($messageId)) {
+            // Ajax submission: prevent CRSF control, as page is not refreshed
+            $baseForm = $this->createForm(AdminForm::MESSAGE_SEND_SAMPLE, FormType::class, [], ['csrf_protection' => false]);
+
+            try {
+                $form = $this->validateForm($baseForm, 'POST');
+
+                $data = $form->getData();
+
+                $messageParameters = array_map(static fn ($value) => $value, $this->getRequest()->request->all());
+
+                $this->getMailer()->sendEmailMessage(
+                    $message->getName(),
+                    [ConfigQuery::getStoreEmail() => ConfigQuery::getStoreName()],
+                    [$data['recipient_email'] => $data['recipient_email']],
+                    $messageParameters,
+                    $this->getCurrentEditionLocale(),
+                );
+
+                return new Response(
+                    $this->getTranslator()->trans(
+                        'The message has been successfully sent to %recipient.',
+                        ['%recipient' => $data['recipient_email']],
+                    ),
+                );
+            } catch (\Exception $ex) {
+                return new Response(
+                    $this->getTranslator()->trans(
+                        'Something goes wrong, the message was not sent to recipient. Error is : %err',
+                        ['%err' => $ex->getMessage()],
+                    ),
+                );
+            }
+        } else {
+            return $this->pageNotFound();
+        }
+    }
+}

--- a/Controller/Admin/ModuleController.php
+++ b/Controller/Admin/ModuleController.php
@@ -1,0 +1,487 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Michelf\MarkdownExtra;
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Symfony\Component\Config\Definition\Exception\Exception;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\Module\ModuleDeleteEvent;
+use Thelia\Core\Event\Module\ModuleEvent;
+use Thelia\Core\Event\Module\ModuleInstallEvent;
+use Thelia\Core\Event\Module\ModuleToggleActivationEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\HttpFoundation\JsonResponse;
+use Thelia\Core\HttpFoundation\Request;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Core\Translation\Translator;
+use Thelia\Domain\Module\Exception\InvalidModuleException;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Form\Exception\FormValidationException;
+use Thelia\Form\ModuleInstallForm;
+use Thelia\Log\Tlog;
+use Thelia\Model\Module;
+use Thelia\Model\ModuleQuery;
+use Thelia\Module\ModuleManagement;
+use Thelia\Tools\TokenProvider;
+
+/**
+ * Class ModuleController.
+ *
+ * @author  Manuel Raynaud <manu@raynaud.io>
+ */
+class ModuleController extends AbstractCrudController
+{
+    protected $moduleErrors = [];
+
+    public function __construct(
+        protected ModuleManagement $moduleManagement,
+    ) {
+        parent::__construct(
+            'module',
+            'manual',
+            'module_order',
+            AdminResources::MODULE,
+            null,
+            TheliaEvents::MODULE_UPDATE,
+            null,
+            null,
+            TheliaEvents::MODULE_UPDATE_POSITION,
+        );
+    }
+
+    protected function getCreationForm(): null
+    {
+        return null;
+    }
+
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::MODULE_MODIFICATION);
+    }
+
+    protected function getCreationEvent(array $formData): ?ActionEvent
+    {
+        return null;
+    }
+
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $event = new ModuleEvent();
+
+        $event->setLocale($formData['locale']);
+        $event->setId((int) $formData['id']);
+        $event->setTitle($formData['title']);
+        $event->setChapo($formData['chapo']);
+        $event->setDescription($formData['description']);
+        $event->setPostscriptum($formData['postscriptum']);
+
+        return $event;
+    }
+
+    protected function getDeleteEvent(): null
+    {
+        return null;
+    }
+
+    protected function createUpdatePositionEvent(int $positionChangeMode, ?int $positionValue = null): UpdatePositionEvent
+    {
+        return new UpdatePositionEvent(
+            (int) $this->getRequest()->get('module_id'),
+            $positionChangeMode,
+            $positionValue,
+        );
+    }
+
+    protected function eventContainsObject($event): bool
+    {
+        return $event->hasModule();
+    }
+
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        if (!$object instanceof Module) {
+            throw new \InvalidArgumentException('Object must be an instance of Module');
+        }
+        $object->setLocale($this->getCurrentEditionLocale());
+        $data = [
+            'id' => $object->getId(),
+            'locale' => $object->getLocale(),
+            'title' => $object->getTitle(),
+            'chapo' => $object->getChapo(),
+            'description' => $object->getDescription(),
+            'postscriptum' => $object->getPostscriptum(),
+        ];
+
+        // Setup the object form
+        return $this->createForm(AdminForm::MODULE_MODIFICATION, FormType::class, $data);
+    }
+
+    protected function getObjectFromEvent($event): mixed
+    {
+        return $event->hasModule() ? $event->getModule() : null;
+    }
+
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        $module = ModuleQuery::create()
+            ->findOneById($this->getRequest()->get('module_id', 0));
+
+        if (null !== $module) {
+            $module->setLocale($this->getCurrentEditionLocale());
+        }
+
+        return $module;
+    }
+
+    /**
+     * @param Module $object
+     */
+    protected function getObjectLabel(ActiveRecordInterface $object): ?string
+    {
+        return $object->getTitle();
+    }
+
+    /**
+     * @param Module $object
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    protected function getViewArguments(): array
+    {
+        return [];
+    }
+
+    protected function getRouteArguments($module_id = null): array
+    {
+        $request = $this->getRequest();
+
+        return [
+            'module_id' => $module_id ?? $request->get('module_id'),
+            'current_tab' => $request->get('current_tab', 'general'),
+        ];
+    }
+
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        // We always return to the feature edition form
+        return $this->render(
+            'modules',
+            [
+                'module_order' => $currentOrder,
+                'module_errors' => $this->moduleErrors,
+            ],
+        );
+    }
+
+    protected function renderEditionTemplate(): Response
+    {
+        // We always return to the feature edition form
+        return $this->render('module-edit', array_merge($this->getViewArguments(), $this->getRouteArguments()));
+    }
+
+    protected function redirectToEditionTemplate($request = null, $country = null): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.module.update',
+            $this->getViewArguments(),
+            $this->getRouteArguments(),
+        );
+    }
+
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute('admin.module');
+    }
+
+    public function indexAction(): Response
+    {
+        if (($response = $this->checkAuth(AdminResources::MODULE, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        try {
+            $this->moduleManagement->updateModules($this->getContainer());
+        } catch (InvalidModuleException $ex) {
+            $this->moduleErrors = $ex->getErrors();
+        } catch (Exception $ex) {
+            Tlog::getInstance()->addError('Failed to get modules list:', $ex);
+        }
+
+        return $this->renderList();
+    }
+
+    public function configureAction($module_code)
+    {
+        $module = ModuleQuery::create()->findOneByCode($module_code);
+
+        if (null === $module) {
+            throw new \InvalidArgumentException(\sprintf('Module `%s` does not exists', $module_code));
+        }
+
+        if (($response = $this->checkAuth([], $module_code, AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        return $this->render(
+            'module-configure',
+            [
+                'module_code' => $module_code,
+            ],
+        );
+    }
+
+    public function toggleActivationAction(EventDispatcherInterface $eventDispatcher, $module_id): Response
+    {
+        if (($response = $this->checkAuth(AdminResources::MODULE, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $message = null;
+
+        try {
+            $event = new ModuleToggleActivationEvent((int) $module_id);
+            $eventDispatcher->dispatch($event, TheliaEvents::MODULE_TOGGLE_ACTIVATION);
+
+            if (!$event->getModule() instanceof Module) {
+                throw new \LogicException($this->getTranslator()->trans('No %obj was updated.', ['%obj' => 'Module']));
+            }
+        } catch (\Exception $exception) {
+            $message = $exception->getMessage();
+
+            Tlog::getInstance()->addError('Failed to activate/deactivate module:', $exception);
+        }
+
+        if ($this->getRequest()->isXmlHttpRequest()) {
+            $response = $message ? $this->jsonResponse(json_encode([
+                'error' => $message,
+            ]), 500) : $this->nullResponse();
+        } else {
+            $response = $this->generateRedirectFromRoute('admin.module');
+        }
+
+        return $response;
+    }
+
+    public function deleteAction(
+        Request $request,
+        TokenProvider $tokenProvider,
+        EventDispatcherInterface $eventDispatcher,
+        ParserContext $parserContext,
+    ): Response {
+        if (($response = $this->checkAuth(AdminResources::MODULE, [], AccessManager::DELETE)) instanceof Response) {
+            return $response;
+        }
+
+        $message = false;
+
+        try {
+            $tokenProvider->checkToken(
+                $request->query->get('_token'),
+            );
+
+            $module_id = (int) $request->get('module_id');
+
+            $deleteEvent = new ModuleDeleteEvent($module_id);
+
+            $deleteEvent->setDeleteData('1' === $request->get('delete-module-data', '0'));
+
+            $eventDispatcher->dispatch($deleteEvent, TheliaEvents::MODULE_DELETE);
+
+            if (false === $deleteEvent->hasModule()) {
+                throw new \LogicException(Translator::getInstance()->trans('No %obj was updated.', ['%obj' => 'Module']));
+            }
+        } catch (\Exception $exception) {
+            $message = $exception->getMessage();
+
+            Tlog::getInstance()->addError('Error during module removal', $exception);
+        }
+
+        if (false !== $message) {
+            $response = $this->render('modules', [
+                'error_message' => $message,
+            ]);
+        } else {
+            $response = $this->generateRedirectFromRoute('admin.module');
+        }
+
+        return $response;
+    }
+
+    public function installAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        if (($response = $this->checkAuth(AdminResources::MODULE, [], AccessManager::CREATE)) instanceof Response) {
+            return $response;
+        }
+
+        $newModule = null;
+        $moduleDefinition = null;
+
+        /** @var ModuleInstallForm $moduleInstall */
+        $moduleInstall = $this->createForm(AdminForm::MODULE_INSTALL);
+
+        try {
+            $this->validateForm($moduleInstall, 'post');
+
+            $moduleDefinition = $moduleInstall->getModuleDefinition();
+            $modulePath = $moduleInstall->getModulePath();
+
+            $moduleInstallEvent = new ModuleInstallEvent();
+            $moduleInstallEvent
+                ->setModulePath($modulePath)
+                ->setModuleDefinition($moduleDefinition);
+
+            $eventDispatcher->dispatch($moduleInstallEvent, TheliaEvents::MODULE_INSTALL);
+
+            $newModule = $moduleInstallEvent->getModule();
+
+            $this->getSession()->getFlashBag()->add(
+                'module-installed',
+                $this->getTranslator()->trans(
+                    'The module %module has been installed successfully.',
+                    ['%module' => $moduleDefinition->getCode()],
+                ),
+            );
+
+            return $this->generateRedirectFromRoute('admin.module');
+        } catch (FormValidationException $e) {
+            $message = $e->getMessage();
+        } catch (\Exception $e) {
+            $message = $this->getTranslator()->trans('Sorry, an error occured: %s', ['%s' => $e->getMessage()]);
+        }
+
+        Tlog::getInstance()->error(\sprintf('Error during module installation process. Exception was %s', $message));
+
+        $moduleInstall->setErrorMessage($message);
+
+        $this->getParserContext()
+            ->addForm($moduleInstall)
+            ->setGeneralError($message);
+
+        return $this->render('modules');
+    }
+
+    public function informationAction($module_id): Response|JsonResponse
+    {
+        if (($response = $this->checkAuth(AdminResources::MODULE, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        $status = 200;
+
+        if (null !== $module = ModuleQuery::create()->findPk($module_id)) {
+            $title = $module->setLocale($this->getSession()->getLang()->getLocale())->getTitle();
+
+            // Get the module descriptor
+            $moduleDescriptor = $module->getAbsoluteConfigPath().DS.'module.xml';
+
+            if (false !== $xmlData = @simplexml_load_string(file_get_contents($moduleDescriptor))) {
+                // Transform the pseudo-array into a real array
+                $arrayData = json_decode(json_encode((array) $xmlData, \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR);
+
+                $content = $this->renderRaw('ajax/module-information', [
+                    'moduleId' => $module_id,
+                    'moduleData' => $arrayData,
+                ]);
+            } else {
+                $status = 500;
+
+                $content = $this->getTranslator()->trans(
+                    'Failed to load descriptor (module.xml) for module ID "%id".',
+                    ['%id' => $module_id],
+                );
+            }
+        } else {
+            $status = 404;
+
+            $title = $this->getTranslator()->trans('Error occured.');
+            $content = $this->getTranslator()->trans('Module ID "%id" was not found.', ['%id' => $module_id]);
+        }
+
+        return new JsonResponse(['title' => $title, 'body' => $content], $status);
+    }
+
+    public function documentationAction($module_id): Response|JsonResponse
+    {
+        if (($response = $this->checkAuth(AdminResources::MODULE, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        $status = 200;
+
+        $content = null;
+
+        if (null !== $module = ModuleQuery::create()->findPk($module_id)) {
+            $title = $module->setLocale($this->getSession()->getLang()->getLocale())->getTitle();
+
+            $finder = null;
+
+            // Check if the module has declared a documentation
+            $moduleDescriptor = $module->getAbsoluteConfigPath().DS.'module.xml';
+
+            if (false !== $xmlData = @simplexml_load_string(file_get_contents($moduleDescriptor))) {
+                $documentationDirectory = (string) $xmlData->documentation;
+
+                if ('' !== $documentationDirectory && '0' !== $documentationDirectory) {
+                    $finder = Finder::create()->files()->in($module->getAbsoluteBaseDir())->name('/.+\.md$/i');
+                }
+            }
+
+            // Fallback to readme.md (if any)
+            if (!$finder instanceof Finder || 0 === $finder->count()) {
+                $finder = Finder::create()->files()->in($module->getAbsoluteBaseDir())->name('/readme\.md/i');
+            }
+
+            // Merge all MD files
+            if ($finder->count() > 0) {
+                $finder->sortByName();
+
+                /** @var \DirectoryIterator $file */
+                foreach ($finder as $file) {
+                    if (false !== $mdDocumentation = @file_get_contents($file->getPathname())) {
+                        if (null === $content) {
+                            $content = '';
+                        }
+
+                        $content .= MarkdownExtra::defaultTransform($mdDocumentation);
+                    }
+                }
+            }
+        } else {
+            $status = 404;
+
+            $title = $this->getTranslator()->trans('Error occured.');
+            $content = $this->getTranslator()->trans('Module ID "%id" was not found.', ['%id' => $module_id]);
+        }
+
+        if (null === $content) {
+            $content = $this->getTranslator()->trans('This module has no Markdown documentation.');
+        }
+
+        return new JsonResponse(['title' => $title, 'body' => $content], $status);
+    }
+}

--- a/Controller/Admin/ModuleHookController.php
+++ b/Controller/Admin/ModuleHookController.php
@@ -1,0 +1,382 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\Hook\ModuleHookCreateEvent;
+use Thelia\Core\Event\Hook\ModuleHookDeleteEvent;
+use Thelia\Core\Event\Hook\ModuleHookToggleActivationEvent;
+use Thelia\Core\Event\Hook\ModuleHookUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\Hook\BaseHook;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Form\ModuleHookModificationForm;
+use Thelia\Model\IgnoredModuleHook;
+use Thelia\Model\IgnoredModuleHookQuery;
+use Thelia\Model\ModuleHook;
+use Thelia\Model\ModuleHookQuery;
+
+/**
+ * Class HookController.
+ *
+ * @author  Julien Chanséaume <jchanseaume@openstudio.fr>
+ */
+class ModuleHookController extends AbstractCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'hook',
+            'manual',
+            'hook_order',
+            AdminResources::MODULE_HOOK,
+            TheliaEvents::MODULE_HOOK_CREATE,
+            TheliaEvents::MODULE_HOOK_UPDATE,
+            TheliaEvents::MODULE_HOOK_DELETE,
+            null,
+            TheliaEvents::MODULE_HOOK_UPDATE_POSITION,
+        );
+    }
+
+    public function indexAction(): Response
+    {
+        if (($response = $this->checkAuth(AdminResources::MODULE_HOOK, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        return $this->renderList();
+    }
+
+    public function toggleActivationAction(EventDispatcherInterface $eventDispatcher, $module_hook_id): Response
+    {
+        if (($response = $this->checkAuth(AdminResources::MODULE_HOOK, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $message = null;
+
+        $event = new ModuleHookToggleActivationEvent($this->getExistingObject());
+
+        try {
+            $eventDispatcher->dispatch($event, TheliaEvents::MODULE_HOOK_TOGGLE_ACTIVATION);
+        } catch (\Exception $exception) {
+            $message = $exception->getMessage();
+        }
+
+        if ($this->getRequest()->isXmlHttpRequest()) {
+            $response = $message ? $this->jsonResponse(json_encode(['error' => $message]), 500) : $this->nullResponse();
+        } else {
+            $response = $this->generateRedirectFromRoute('admin.module-hook');
+        }
+
+        return $response;
+    }
+
+    protected function createUpdatePositionEvent(int $positionChangeMode, ?int $positionValue = null): UpdatePositionEvent
+    {
+        return new UpdatePositionEvent(
+            (int) $this->getRequest()->get('module_hook_id'),
+            $positionChangeMode,
+            $positionValue,
+        );
+    }
+
+    /**
+     * Return the creation form for this object.
+     */
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::MODULE_HOOK_CREATION);
+    }
+
+    /**
+     * Return the update form for this object.
+     */
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::MODULE_HOOK_MODIFICATION);
+    }
+
+    /**
+     * Hydrate the update form for this object, before passing it to the update template.
+     *
+     * @param ModuleHook $object
+     *
+     * @return ModuleHookModificationForm
+     */
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        $data = [
+            'id' => $object->getId(),
+            'hook_id' => $object->getHookId(),
+            'module_id' => $object->getModuleId(),
+            'classname' => $object->getClassname(),
+            'method' => $object->getMethod(),
+            'active' => $object->getActive(),
+            'templates' => $object->getTemplates(),
+        ];
+
+        return $this->createForm(AdminForm::MODULE_HOOK_MODIFICATION, FormType::class, $data);
+    }
+
+    /**
+     * Creates the creation event with the provided form data.
+     *
+     * @return ModuleHookCreateEvent
+     */
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $event = new ModuleHookCreateEvent();
+
+        return $this->hydrateEvent($event, $formData);
+    }
+
+    /**
+     * Creates the update event with the provided form data.
+     *
+     * @return ModuleHookUpdateEvent
+     */
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $event = new ModuleHookUpdateEvent();
+
+        return $this->hydrateEvent($event, $formData, true);
+    }
+
+    protected function hydrateEvent($event, array $formData, $update = false)
+    {
+        if (!$update) {
+            $event
+                ->setModuleId((int) $formData['module_id'])
+                ->setHookId((int) $formData['hook_id']);
+        } else {
+            $event
+                ->setModuleHookId((int) $formData['id'])
+                ->setModuleId((int) $formData['module_id'])
+                ->setHookId((int) $formData['hook_id'])
+                ->setClassname($formData['classname'])
+                ->setMethod($formData['method'])
+                ->setActive($formData['active'])
+                ->setTemplates($formData['templates']);
+        }
+
+        return $event;
+    }
+
+    /**
+     * Creates the delete event with the provided form data.
+     */
+    protected function getDeleteEvent(): ModuleHookDeleteEvent
+    {
+        return new ModuleHookDeleteEvent($this->getRequest()->get('module_hook_id'));
+    }
+
+    /**
+     * Return true if the event contains the object, e.g. the action has updated the object in the event.
+     */
+    protected function eventContainsObject(Event $event): bool
+    {
+        return $event->hasModuleHook();
+    }
+
+    /**
+     * Get the created object from an event.
+     *
+     * @return ModuleHook|null
+     */
+    protected function getObjectFromEvent(Event $event): mixed
+    {
+        return $event->getModuleHook();
+    }
+
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        return ModuleHookQuery::create()
+            ->findPK($this->getRequest()->get('module_hook_id', 0));
+    }
+
+    protected function getObjectLabel(ActiveRecordInterface $object): string
+    {
+        try {
+            return \sprintf(
+                '%s on %s',
+                $object->getModule()->getTitle(),
+                $object->getHook()->getTitle(),
+            );
+        } catch (\Exception) {
+            return 'Undefined module hook';
+        }
+    }
+
+    /**
+     * Returns the object ID from the object.
+     *
+     * @param ModuleHook $object
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    /**
+     * Render the main list template.
+     *
+     * @param string $currentOrder , if any, null otherwise
+     */
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        return $this->render(
+            'module-hooks',
+            ['module_order' => $currentOrder],
+        );
+    }
+
+    /**
+     * Render the edition template.
+     */
+    protected function renderEditionTemplate(): Response
+    {
+        return $this->render('module-hook-edit', $this->getEditionArgument());
+    }
+
+    protected function getEditionArgument(): array
+    {
+        return [
+            'module_hook_id' => $this->getRequest()->get('module_hook_id', 0),
+        ];
+    }
+
+    /**
+     * Redirect to the edition template.
+     */
+    protected function redirectToEditionTemplate($request = null, $country = null): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.module-hook.update',
+            $this->getViewArguments(),
+            $this->getRouteArguments(),
+        );
+    }
+
+    /**
+     * Redirect to the list template.
+     */
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute('admin.module-hook');
+    }
+
+    protected function getViewArguments(): array
+    {
+        return [];
+    }
+
+    protected function getRouteArguments($module_hook_id = null): array
+    {
+        return [
+            'module_hook_id' => $module_hook_id ?? $this->getRequest()->get('module_hook_id'),
+        ];
+    }
+
+    public function getModuleHookClassnames($moduleId): Response|JsonResponse
+    {
+        if (($response = $this->checkAuth(AdminResources::MODULE_HOOK, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        $result = [];
+
+        $moduleHooks = ModuleHookQuery::create()
+            ->filterByModuleId($moduleId)
+            ->groupByClassname()
+            ->find();
+
+        /** @var ModuleHook $moduleHook */
+        foreach ($moduleHooks as $moduleHook) {
+            $result[] = $moduleHook->getClassname();
+        }
+
+        $ignoredModuleHooks = IgnoredModuleHookQuery::create()
+            ->filterByModuleId($moduleId)
+            ->groupByClassname()
+            ->find();
+
+        /** @var IgnoredModuleHook $moduleHook */
+        foreach ($ignoredModuleHooks as $moduleHook) {
+            $className = $moduleHook->getClassname();
+
+            if (null !== $className && !\in_array($className, $result, true)) {
+                $result[] = $className;
+            }
+        }
+
+        sort($result);
+
+        return new JsonResponse($result);
+    }
+
+    public function getModuleHookMethods($moduleId, $className): Response|JsonResponse
+    {
+        if (($response = $this->checkAuth(AdminResources::MODULE_HOOK, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        $result = [BaseHook::INJECT_TEMPLATE_METHOD_NAME];
+
+        $moduleHooks = ModuleHookQuery::create()
+            ->filterByModuleId($moduleId)
+            ->filterByClassname($className)
+            ->find();
+
+        /** @var ModuleHook $moduleHook */
+        foreach ($moduleHooks as $moduleHook) {
+            $method = $moduleHook->getMethod();
+
+            if (!\in_array($method, $result, true)) {
+                $result[] = $method;
+            }
+        }
+
+        $ignoredModuleHooks = IgnoredModuleHookQuery::create()
+            ->filterByModuleId($moduleId)
+            ->filterByClassname($className)
+            ->find();
+
+        /** @var IgnoredModuleHook $moduleHook */
+        foreach ($ignoredModuleHooks as $moduleHook) {
+            $method = $moduleHook->getMethod();
+
+            if (!\in_array($method, $result, true)) {
+                $result[] = $method;
+            }
+        }
+
+        sort($result);
+
+        return new JsonResponse($result);
+    }
+}

--- a/Controller/Admin/OrderController.php
+++ b/Controller/Admin/OrderController.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\Order\OrderAddressEvent;
+use Thelia\Core\Event\Order\OrderEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\OrderUpdateAddress;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\OrderAddressQuery;
+use Thelia\Model\OrderQuery;
+use Thelia\Model\OrderStatusQuery;
+
+/**
+ * Class OrderController.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class OrderController extends BaseAdminController
+{
+    public function indexAction()
+    {
+        if (($response = $this->checkAuth(AdminResources::ORDER, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        return $this->render('orders', [
+            'display_order' => 20,
+            'orders_order' => $this->getListOrderFromSession('orders', 'orders_order', 'create-date-reverse'),
+        ]);
+    }
+
+    public function viewAction($order_id): Response
+    {
+        return $this->render('order-edit', [
+            'order_id' => $order_id,
+        ]);
+    }
+
+    public function updateStatus(EventDispatcherInterface $eventDispatcher, $order_id = null): Response|RedirectResponse
+    {
+        if (($response = $this->checkAuth(AdminResources::ORDER, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $message = null;
+
+        try {
+            if (null === $order_id) {
+                $order_id = $this->getRequest()->get('order_id');
+            }
+
+            $order = OrderQuery::create()->findPk($order_id);
+
+            $statusId = $this->getRequest()->get('status_id');
+            $status = OrderStatusQuery::create()->findPk($statusId);
+
+            if (null === $order) {
+                throw new \InvalidArgumentException('The order you want to update status does not exist');
+            }
+
+            if (null === $status) {
+                throw new \InvalidArgumentException('The status you want to set to the order does not exist');
+            }
+
+            $event = new OrderEvent($order);
+            $event->setStatus((int) $statusId);
+
+            $eventDispatcher->dispatch($event, TheliaEvents::ORDER_UPDATE_STATUS);
+        } catch (\Exception $exception) {
+            $message = $exception->getMessage();
+        }
+
+        $params = [];
+
+        if ($message) {
+            $params['update_status_error_message'] = $message;
+        }
+
+        $browsedPage = $this->getRequest()->get('order_page');
+        $currentStatus = $this->getRequest()->get('status');
+
+        if ($browsedPage) {
+            $params['order_page'] = $browsedPage;
+
+            if (null !== $currentStatus) {
+                $params['status'] = $currentStatus;
+            }
+
+            $response = $this->generateRedirectFromRoute('admin.order.list', $params);
+        } else {
+            $params['tab'] = $this->getRequest()->get('tab', 'cart');
+
+            $response = $this->generateRedirectFromRoute('admin.order.update.view', $params, ['order_id' => $order_id]);
+        }
+
+        return $response;
+    }
+
+    public function updateDeliveryRef(EventDispatcherInterface $eventDispatcher, $order_id): Response|RedirectResponse
+    {
+        if (($response = $this->checkAuth(AdminResources::ORDER, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $message = null;
+
+        try {
+            $order = OrderQuery::create()->findPk($order_id);
+
+            $deliveryRef = $this->getRequest()->get('delivery_ref');
+
+            if (null === $order) {
+                throw new \InvalidArgumentException('The order you want to update status does not exist');
+            }
+
+            $event = new OrderEvent($order);
+            $event->setDeliveryRef($deliveryRef);
+
+            $eventDispatcher->dispatch($event, TheliaEvents::ORDER_UPDATE_DELIVERY_REF);
+        } catch (\Exception $exception) {
+            $message = $exception->getMessage();
+        }
+
+        $params = [];
+
+        if ($message) {
+            $params['update_status_error_message'] = $message;
+        }
+
+        $params['tab'] = $this->getRequest()->get('tab', 'bill');
+
+        return $this->generateRedirectFromRoute(
+            'admin.order.update.view',
+            $params,
+            ['order_id' => $order_id],
+        );
+    }
+
+    public function updateAddress(EventDispatcherInterface $eventDispatcher, $order_id): Response|RedirectResponse
+    {
+        if (($response = $this->checkAuth(AdminResources::ORDER, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $message = null;
+
+        $orderUpdateAddress = $this->createForm(OrderUpdateAddress::getName());
+
+        try {
+            $order = OrderQuery::create()->findPk($order_id);
+
+            if (null === $order) {
+                throw new \InvalidArgumentException('The order you want to update does not exist');
+            }
+
+            $form = $this->validateForm($orderUpdateAddress, 'post');
+
+            $orderAddress = OrderAddressQuery::create()->findPk($form->get('id')->getData());
+
+            if (null === $orderAddress) {
+                throw new \InvalidArgumentException('The order address you want to update does not exist');
+            }
+
+            if ($orderAddress->getId() !== $order->getInvoiceOrderAddressId() && $orderAddress->getId() !== $order->getDeliveryOrderAddressId()) {
+                throw new \InvalidArgumentException('The order address you want to update does not belong to the current order not exist');
+            }
+
+            $event = new OrderAddressEvent(
+                $form->get('title')->getData(),
+                $form->get('firstname')->getData(),
+                $form->get('lastname')->getData(),
+                $form->get('address1')->getData(),
+                $form->get('address2')->getData(),
+                $form->get('address3')->getData(),
+                $form->get('zipcode')->getData(),
+                $form->get('city')->getData(),
+                $form->get('country')->getData(),
+                $form->get('phone')->getData(),
+                $form->get('company')->getData(),
+                $form->get('cellphone')->getData(),
+                $form->get('state')->getData(),
+            );
+            $event->setOrderAddress($orderAddress);
+            $event->setOrder($order);
+
+            $eventDispatcher->dispatch($event, TheliaEvents::ORDER_UPDATE_ADDRESS);
+        } catch (\Exception $exception) {
+            $message = $exception->getMessage();
+        }
+
+        $params = [];
+
+        if ($message) {
+            $params['update_status_error_message'] = $message;
+        }
+
+        $params['tab'] = $this->getRequest()->get('tab', 'bill');
+
+        return $this->generateRedirectFromRoute(
+            'admin.order.update.view',
+            $params,
+            ['order_id' => $order_id],
+        );
+    }
+
+    public function generateInvoicePdf(EventDispatcherInterface $eventDispatcher, int $order_id, $browser): Response|RedirectResponse
+    {
+        if (($response = $this->checkAuth(AdminResources::ORDER, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        return $this->generateBackOfficeOrderPdf($eventDispatcher, $order_id, ConfigQuery::read('pdf_invoice_file', 'invoice'), '1' === $browser);
+    }
+
+    public function generateDeliveryPdf(EventDispatcherInterface $eventDispatcher, int $order_id, $browser): Response|RedirectResponse
+    {
+        if (($response = $this->checkAuth(AdminResources::ORDER, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        return $this->generateBackOfficeOrderPdf($eventDispatcher, $order_id, ConfigQuery::read('pdf_delivery_file', 'delivery'), '1' === $browser);
+    }
+
+    private function generateBackOfficeOrderPdf(EventDispatcherInterface $eventDispatcher, int $orderId, string $fileName, bool $browser): RedirectResponse|Response
+    {
+        return $this->generateOrderPdf($eventDispatcher, $orderId, $fileName, true, true, $browser);
+    }
+}

--- a/Controller/Admin/OrderStatusController.php
+++ b/Controller/Admin/OrderStatusController.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\Event;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\OrderStatus\OrderStatusCreateEvent;
+use Thelia\Core\Event\OrderStatus\OrderStatusDeleteEvent;
+use Thelia\Core\Event\OrderStatus\OrderStatusUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Form\OrderStatus\OrderStatusModificationForm;
+use Thelia\Model\OrderStatus;
+use Thelia\Model\OrderStatusQuery;
+
+/**
+ * Class OrderStatusController.
+ *
+ * @author  Gilles Bourgeat <gbourgeat@openstudio.com>
+ */
+class OrderStatusController extends AbstractCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'orderstatus',
+            'manual',
+            'order',
+            AdminResources::ORDER_STATUS,
+            TheliaEvents::ORDER_STATUS_CREATE,
+            TheliaEvents::ORDER_STATUS_UPDATE,
+            TheliaEvents::ORDER_STATUS_DELETE,
+            null,
+            TheliaEvents::ORDER_STATUS_UPDATE_POSITION,
+        );
+    }
+
+    /**
+     * Return the creation form for this object.
+     */
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::ORDER_STATUS_CREATION);
+    }
+
+    /**
+     * Return the update form for this object.
+     */
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::ORDER_STATUS_MODIFICATION);
+    }
+
+    /**
+     * Hydrate the update form for this object, before passing it to the update template.
+     *
+     * @param OrderStatus $object
+     *
+     * @return OrderStatusModificationForm $object
+     */
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        // Prepare the data that will hydrate the form
+        $data = [
+            'id' => $object->getId(),
+            'locale' => $object->getLocale(),
+            'title' => $object->getTitle(),
+            'chapo' => $object->getChapo(),
+            'description' => $object->getDescription(),
+            'postscriptum' => $object->getPostscriptum(),
+            'color' => $object->getColor(),
+            'code' => $object->getCode(),
+        ];
+
+        // Setup the object form
+        return $this->createForm(AdminForm::ORDER_STATUS_MODIFICATION, FormType::class, $data);
+    }
+
+    /**
+     * Creates the creation event with the provided form data.
+     */
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $orderStatusCreateEvent = new OrderStatusCreateEvent();
+
+        $orderStatusCreateEvent
+            ->setLocale($formData['locale'])
+            ->setTitle($formData['title'])
+            ->setCode($formData['code'])
+            ->setColor($formData['color']);
+
+        return $orderStatusCreateEvent;
+    }
+
+    /**
+     * Creates the update event with the provided form data.
+     */
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $orderStatusUpdateEvent = new OrderStatusUpdateEvent((int) $formData['id']);
+
+        $orderStatusUpdateEvent
+            ->setLocale($formData['locale'])
+            ->setTitle($formData['title'])
+            ->setChapo($formData['chapo'])
+            ->setDescription($formData['description'])
+            ->setPostscriptum($formData['postscriptum'])
+            ->setCode($formData['code'])
+            ->setColor($formData['color']);
+
+        return $orderStatusUpdateEvent;
+    }
+
+    /**
+     * Creates the delete event with the provided form data.
+     *
+     * @throws \Exception
+     */
+    protected function getDeleteEvent(): OrderStatusDeleteEvent
+    {
+        return new OrderStatusDeleteEvent((int) $this->getRequest()->get('order_status_id'));
+    }
+
+    /**
+     * Return true if the event contains the object, e.g. the action has updated the object in the event.
+     */
+    protected function eventContainsObject(Event $event): bool
+    {
+        return $event->hasOrderStatus();
+    }
+
+    /**
+     * Get the created object from an event.
+     *
+     * @param $event \Thelia\Core\Event\OrderStatus\OrderStatusEvent
+     *
+     * @return OrderStatus|null
+     */
+    protected function getObjectFromEvent($event): mixed
+    {
+        return $event->getOrderStatus();
+    }
+
+    /**
+     * Load an existing object from the database.
+     *
+     * @return OrderStatus
+     */
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        $orderStatus = OrderStatusQuery::create()
+            ->findOneById($this->getRequest()->get('order_status_id', 0));
+
+        if (null !== $orderStatus) {
+            $orderStatus->setLocale($this->getCurrentEditionLocale());
+        }
+
+        return $orderStatus;
+    }
+
+    /**
+     * Returns the object label form the object event (name, title, etc.).
+     *
+     * @param OrderStatus $object
+     *
+     * @return string order status title
+     */
+    protected function getObjectLabel(ActiveRecordInterface $object): ?string
+    {
+        return $object->getTitle();
+    }
+
+    /**
+     * Returns the object ID from the object.
+     *
+     * @param OrderStatus $object
+     *
+     * @return int order status id
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    /**
+     * Render the main list template.
+     *
+     * @param string $currentOrder , if any, null otherwise
+     */
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        $this->getListOrderFromSession('orderstatus', 'order', 'manual');
+
+        return $this->render('order-status', [
+            'order' => $currentOrder,
+        ]);
+    }
+
+    protected function getEditionArguments(): array
+    {
+        return [
+            'order_status_id' => $this->getRequest()->get('order_status_id', 0),
+            'current_tab' => $this->getRequest()->get('current_tab', 'general'),
+        ];
+    }
+
+    /**
+     * Render the edition template.
+     */
+    protected function renderEditionTemplate(): Response
+    {
+        return $this->render('order-status-edit', $this->getEditionArguments());
+    }
+
+    /**
+     * Redirect to the edition template.
+     */
+    protected function redirectToEditionTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.order-status.update',
+            [],
+            $this->getEditionArguments(),
+        );
+    }
+
+    /**
+     * Redirect to the list template.
+     */
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute('admin.order-status.default');
+    }
+
+    /**
+     * @return UpdatePositionEvent|void
+     */
+    protected function createUpdatePositionEvent(int $positionChangeMode, ?int $positionValue = null): UpdatePositionEvent
+    {
+        return new UpdatePositionEvent(
+            (int) $this->getRequest()->get('order_status_id'),
+            $positionChangeMode,
+            $positionValue,
+        );
+    }
+
+    /**
+     * @param $positionChangeEvent ActionEvent
+     */
+    protected function performAdditionalUpdatePositionAction(ActionEvent $positionChangeEvent): ?Response
+    {
+        $folder = OrderStatusQuery::create()->findPk($positionChangeEvent->getObjectId());
+
+        if (null !== $folder) {
+            return $this->generateRedirectFromRoute(
+                'admin.order-status.default',
+            );
+        }
+
+        return null;
+    }
+}

--- a/Controller/Admin/ProductController.php
+++ b/Controller/Admin/ProductController.php
@@ -1,0 +1,1955 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\ModelCriteria;
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Propel\Runtime\Event\ActiveRecordEvent;
+use Propel\Runtime\Exception\PropelException;
+use Propel\Runtime\Util\PropelModelPager;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\FeatureProduct\FeatureProductDeleteEvent;
+use Thelia\Core\Event\FeatureProduct\FeatureProductUpdateEvent;
+use Thelia\Core\Event\MetaData\MetaDataCreateOrUpdateEvent;
+use Thelia\Core\Event\MetaData\MetaDataDeleteEvent;
+use Thelia\Core\Event\Product\ProductAddAccessoryEvent;
+use Thelia\Core\Event\Product\ProductAddCategoryEvent;
+use Thelia\Core\Event\Product\ProductAddContentEvent;
+use Thelia\Core\Event\Product\ProductCloneEvent;
+use Thelia\Core\Event\Product\ProductCombinationGenerationEvent;
+use Thelia\Core\Event\Product\ProductCreateEvent;
+use Thelia\Core\Event\Product\ProductDeleteAccessoryEvent;
+use Thelia\Core\Event\Product\ProductDeleteCategoryEvent;
+use Thelia\Core\Event\Product\ProductDeleteContentEvent;
+use Thelia\Core\Event\Product\ProductDeleteEvent;
+use Thelia\Core\Event\Product\ProductSetTemplateEvent;
+use Thelia\Core\Event\Product\ProductToggleVisibilityEvent;
+use Thelia\Core\Event\Product\ProductUpdateEvent;
+use Thelia\Core\Event\ProductSaleElement\ProductSaleElementCreateEvent;
+use Thelia\Core\Event\ProductSaleElement\ProductSaleElementDeleteEvent;
+use Thelia\Core\Event\ProductSaleElement\ProductSaleElementToggleVisibilityEvent;
+use Thelia\Core\Event\ProductSaleElement\ProductSaleElementUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\HttpFoundation\JsonResponse;
+use Thelia\Core\HttpFoundation\Request;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\Loop\Document;
+use Thelia\Core\Template\Loop\Image;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Domain\Taxation\TaxEngine\Calculator;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Form\Exception\FormValidationException;
+use Thelia\Form\ProductModificationForm;
+use Thelia\Model\AccessoryQuery;
+use Thelia\Model\AttributeAv;
+use Thelia\Model\AttributeAvQuery;
+use Thelia\Model\AttributeQuery;
+use Thelia\Model\CategoryI18n;
+use Thelia\Model\CategoryI18nQuery;
+use Thelia\Model\CategoryQuery;
+use Thelia\Model\Content;
+use Thelia\Model\ContentQuery;
+use Thelia\Model\Country;
+use Thelia\Model\Currency;
+use Thelia\Model\CurrencyQuery;
+use Thelia\Model\Feature;
+use Thelia\Model\FeatureProductQuery;
+use Thelia\Model\FeatureQuery;
+use Thelia\Model\FeatureTemplateQuery;
+use Thelia\Model\FolderQuery;
+use Thelia\Model\MetaData;
+use Thelia\Model\MetaDataQuery;
+use Thelia\Model\Product;
+use Thelia\Model\ProductAssociatedContentQuery;
+use Thelia\Model\ProductDocument;
+use Thelia\Model\ProductDocumentQuery;
+use Thelia\Model\ProductI18n;
+use Thelia\Model\ProductI18nQuery;
+use Thelia\Model\ProductImageQuery;
+use Thelia\Model\ProductPrice;
+use Thelia\Model\ProductPriceQuery;
+use Thelia\Model\ProductQuery;
+use Thelia\Model\ProductSaleElements;
+use Thelia\Model\ProductSaleElements as ProductSaleElementsModel;
+use Thelia\Model\ProductSaleElementsProductDocument;
+use Thelia\Model\ProductSaleElementsProductDocumentQuery;
+use Thelia\Model\ProductSaleElementsProductImage;
+use Thelia\Model\ProductSaleElementsProductImageQuery;
+use Thelia\Model\ProductSaleElementsQuery;
+use Thelia\Model\TaxRuleQuery;
+use Thelia\Tools\URL;
+use Thelia\Type\BooleanOrBothType;
+
+/**
+ * Manages products.
+ *
+ * @author Franck Allimant <franck@cqfdev.fr>
+ */
+class ProductController extends AbstractSeoCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'product',
+            'manual',
+            'product_order',
+            AdminResources::PRODUCT,
+            TheliaEvents::PRODUCT_CREATE,
+            TheliaEvents::PRODUCT_UPDATE,
+            TheliaEvents::PRODUCT_DELETE,
+            TheliaEvents::PRODUCT_TOGGLE_VISIBILITY,
+            TheliaEvents::PRODUCT_UPDATE_POSITION,
+            TheliaEvents::PRODUCT_UPDATE_SEO,
+        );
+    }
+
+    /**
+     * Attributes ajax tab loading.
+     */
+    public function loadAttributesAjaxTabAction(): Response
+    {
+        return $this->render(
+            'ajax/product-attributes-tab',
+            [
+                'product_id' => $this->getRequest()->get('product_id', 0),
+            ],
+        );
+    }
+
+    /**
+     * Related information ajax tab loading.
+     */
+    public function loadRelatedAjaxTabAction(): Response
+    {
+        return $this->render(
+            'ajax/product-related-tab',
+            [
+                'product_id' => $this->getRequest()->get('product_id', 0),
+                'folder_id' => $this->getRequest()->get('folder_id', 0),
+                'accessory_category_id' => $this->getRequest()->get('accessory_category_id', 0),
+            ],
+        );
+    }
+
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::PRODUCT_CREATION);
+    }
+
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::PRODUCT_MODIFICATION);
+    }
+
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $createEvent = new ProductCreateEvent();
+
+        $createEvent
+            ->setRef($formData['ref'])
+            ->setTitle($formData['title'])
+            ->setLocale($formData['locale'])
+            ->setDefaultCategory($formData['default_category'])
+            ->setVisible($formData['visible'])
+            ->setVirtual($formData['virtual'])
+            ->setBasePrice($formData['price'])
+            ->setBaseWeight($formData['weight'])
+            ->setCurrencyId((int) $formData['currency'])
+            ->setTaxRuleId((int) $formData['tax_rule'])
+            ->setBaseQuantity((int) $formData['quantity'])
+            ->setTemplateId((int) $formData['template_id']);
+
+        return $createEvent;
+    }
+
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $changeEvent = new ProductUpdateEvent($formData['id']);
+
+        $changeEvent
+            ->setLocale($formData['locale'])
+            ->setRef($formData['ref'])
+            ->setTitle($formData['title'])
+            ->setChapo($formData['chapo'])
+            ->setDescription($formData['description'])
+            ->setPostscriptum($formData['postscriptum'])
+            ->setVisible($formData['visible'] ?? false)
+            ->setVirtual($formData['virtual'] ?? false)
+            ->setDefaultCategory($formData['default_category'])
+            ->setBrandId((int) $formData['brand_id'])
+            ->setVirtualDocumentId((int) $formData['virtual_document_id']);
+
+        // Create and dispatch the change event
+        return $changeEvent;
+    }
+
+    protected function createUpdatePositionEvent(int $positionChangeMode, ?int $positionValue = null): UpdatePositionEvent
+    {
+        return new UpdatePositionEvent(
+            (int) $this->getRequest()->get('product_id'),
+            $positionChangeMode,
+            $positionValue,
+            (int) $this->getRequest()->get('category_id'),
+        );
+    }
+
+    protected function getDeleteEvent(): ProductDeleteEvent
+    {
+        return new ProductDeleteEvent($this->getRequest()->get('product_id', 0));
+    }
+
+    protected function eventContainsObject(Event $event): bool
+    {
+        return $event->hasProduct();
+    }
+
+    protected function updatePriceFromDefaultCurrency(ProductPrice $productPrice, ProductSaleElements $saleElement, Currency $defaultCurrency, Currency $currentCurrency): void
+    {
+        // Get price for default currency
+        $priceForDefaultCurrency = ProductPriceQuery::create()
+            ->filterByCurrency($defaultCurrency)
+            ->filterByProductSaleElements($saleElement)
+            ->findOne();
+
+        if (null !== $priceForDefaultCurrency) {
+            $productPrice
+                ->setPrice((string) ((float) $priceForDefaultCurrency->getPrice() * $currentCurrency->getRate()))
+                ->setPromoPrice((string) ((float) $priceForDefaultCurrency->getPromoPrice() * $currentCurrency->getRate()));
+        }
+    }
+
+    protected function appendValue(&$array, $key, $value): void
+    {
+        if (!isset($array[$key])) {
+            $array[$key] = [];
+        }
+
+        $array[$key][] = $value;
+    }
+
+    /**
+     * @param Product $object
+     *
+     * @return ProductModificationForm
+     */
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        // Find product's sale elements
+        $saleElements = ProductSaleElementsQuery::create()
+            ->filterByProduct($object)
+            ->find();
+
+        $defaultCurrency = Currency::getDefaultCurrency();
+        $currentCurrency = $this->getCurrentEditionCurrency();
+        // Common parts
+        $defaultPseData = [
+            'product_id' => $object->getId(),
+            'tax_rule' => $object->getTaxRuleId(),
+        ];
+        $combinationPseData = [
+            'product_id' => $object->getId(),
+            'tax_rule' => $object->getTaxRuleId(),
+        ];
+
+        /** @var ProductSaleElements $saleElement */
+        foreach ($saleElements as $saleElement) {
+            // Get the product price for the current currency
+            $productPrice = ProductPriceQuery::create()
+                ->filterByCurrency($currentCurrency)
+                ->filterByProductSaleElements($saleElement)
+                ->findOne();
+
+            // No one exists ?
+            if (null === $productPrice) {
+                $productPrice = new ProductPrice();
+
+                // If the current currency is not the default one, calculate the price
+                // using default currency price and current currency rate
+                if ($currentCurrency->getId() !== $defaultCurrency->getId()) {
+                    $productPrice->setFromDefaultCurrency(true);
+                }
+            }
+
+            // Caclulate prices if we have to use the rate * default currency price
+            if ($productPrice->getFromDefaultCurrency()) {
+                $this->updatePriceFromDefaultCurrency($productPrice, $saleElement, $defaultCurrency, $currentCurrency);
+            }
+
+            $isDefaultPse = 0 === \count($saleElement->getAttributeCombinations());
+
+            // If this PSE has no combination -> this is the default one
+            // affect it to the thelia.admin.product_sale_element.update form
+            if ($isDefaultPse) {
+                $defaultPseData = [
+                    'product_sale_element_id' => $saleElement->getId(),
+                    'reference' => $saleElement->getRef(),
+                    'price' => $this->formatPrice($productPrice->getPrice()),
+                    'price_with_tax' => $this->formatPrice($this->computePrice($productPrice->getPrice(), 'without_tax', $object)),
+                    'use_exchange_rate' => $productPrice->getFromDefaultCurrency() ? 1 : 0,
+                    'currency' => $productPrice->getCurrencyId(),
+                    'weight' => $saleElement->getWeight(),
+                    'quantity' => $saleElement->getQuantity(),
+                    'sale_price' => $this->formatPrice($productPrice->getPromoPrice()),
+                    'sale_price_with_tax' => $this->formatPrice($this->computePrice($productPrice->getPromoPrice(), 'without_tax', $object)),
+                    'onsale' => $saleElement->getPromo() > 0 ? 1 : 0,
+                    'isnew' => $saleElement->getNewness() > 0 ? 1 : 0,
+                    'isdefault' => $saleElement->getIsDefault() > 0 ? 1 : 0,
+                    'ean_code' => $saleElement->getEanCode(),
+                ];
+            } else {
+                if ($saleElement->getIsDefault()) {
+                    $combinationPseData['default_pse'] = $saleElement->getId();
+                    $combinationPseData['currency'] = $currentCurrency->getId();
+                    $combinationPseData['use_exchange_rate'] = $productPrice->getFromDefaultCurrency() ? 1 : 0;
+                }
+
+                $this->appendValue($combinationPseData, 'product_sale_element_id', $saleElement->getId());
+                $this->appendValue($combinationPseData, 'reference', $saleElement->getRef());
+                $this->appendValue($combinationPseData, 'price', $this->formatPrice($productPrice->getPrice()));
+                $this->appendValue($combinationPseData, 'price_with_tax', $this->formatPrice($this->computePrice($productPrice->getPrice(), 'without_tax', $object)));
+                $this->appendValue($combinationPseData, 'weight', $saleElement->getWeight());
+                $this->appendValue($combinationPseData, 'quantity', $saleElement->getQuantity());
+                $this->appendValue($combinationPseData, 'sale_price', $this->formatPrice($productPrice->getPromoPrice()));
+                $this->appendValue($combinationPseData, 'sale_price_with_tax', $this->formatPrice($this->computePrice($productPrice->getPromoPrice(), 'without_tax', $object)));
+                $this->appendValue($combinationPseData, 'onsale', $saleElement->getPromo() > 0 ? 1 : 0);
+                $this->appendValue($combinationPseData, 'isnew', $saleElement->getNewness() > 0 ? 1 : 0);
+                $this->appendValue($combinationPseData, 'isdefault', $saleElement->getIsDefault() > 0 ? 1 : 0);
+                $this->appendValue($combinationPseData, 'ean_code', $saleElement->getEanCode());
+            }
+        }
+
+        $defaultPseForm = $this->createForm(AdminForm::PRODUCT_DEFAULT_SALE_ELEMENT_UPDATE, FormType::class, $defaultPseData);
+        $parserContext->addForm($defaultPseForm);
+
+        $combinationPseForm = $this->createForm(AdminForm::PRODUCT_SALE_ELEMENT_UPDATE, FormType::class, $combinationPseData);
+        $parserContext->addForm($combinationPseForm);
+
+        // Hydrate the "SEO" tab form
+        $this->hydrateSeoForm($parserContext, $object);
+
+        // The "General" tab form
+        $data = [
+            'id' => $object->getId(),
+            'ref' => $object->getRef(),
+            'locale' => $object->getLocale(),
+            'title' => $object->getTitle(),
+            'chapo' => $object->getChapo(),
+            'description' => $object->getDescription(),
+            'postscriptum' => $object->getPostscriptum(),
+            'visible' => $object->getVisible(),
+            'virtual' => $object->getVirtual(),
+            'default_category' => $object->getDefaultCategoryId(),
+            'brand_id' => $object->getBrandId(),
+        ];
+
+        // Virtual document
+        if (\array_key_exists('product_sale_element_id', $defaultPseData)) {
+            $virtualDocumentId = (int) MetaDataQuery::getVal('virtual', MetaData::PSE_KEY, $defaultPseData['product_sale_element_id']);
+
+            if (0 !== $virtualDocumentId) {
+                $data['virtual_document_id'] = $virtualDocumentId;
+            }
+        }
+
+        // Setup the object form
+        return $this->createForm(AdminForm::PRODUCT_MODIFICATION, FormType::class, $data);
+    }
+
+    protected function getObjectFromEvent(Event $event): mixed
+    {
+        return $event->hasProduct() ? $event->getProduct() : null;
+    }
+
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        $product = ProductQuery::create()
+            ->findOneById($this->getRequest()->get('product_id', 0));
+
+        if (null !== $product) {
+            $product->setLocale($this->getCurrentEditionLocale());
+        }
+
+        return $product;
+    }
+
+    /**
+     * @param Product $object
+     */
+    protected function getObjectLabel(ActiveRecordInterface $object): ?string
+    {
+        return $object->getTitle();
+    }
+
+    /**
+     * @param Product $object
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    protected function getEditionArguments(): array
+    {
+        return [
+            'category_id' => $this->getCategoryId(),
+            'product_id' => $this->getRequest()->get('product_id', 0),
+            'folder_id' => $this->getRequest()->get('folder_id', 0),
+            'accessory_category_id' => $this->getRequest()->get('accessory_category_id', 0),
+            'current_tab' => $this->getRequest()->get('current_tab', 'general'),
+            'page' => $this->getRequest()->get('page', 1),
+        ];
+    }
+
+    protected function getCategoryId()
+    {
+        // Trouver le category_id, soit depuis la reques, souit depuis le produit courant
+        $category_id = $this->getRequest()->get('category_id');
+
+        if (null === $category_id) {
+            $product = $this->getExistingObject();
+
+            if ($product instanceof ActiveRecordInterface) {
+                $category_id = $product->getDefaultCategoryId();
+            }
+        }
+
+        return $category_id ?? 0;
+    }
+
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        $this->getListOrderFromSession('product', 'product_order', 'manual');
+
+        return $this->render(
+            'categories',
+            [
+                'product_order' => $currentOrder,
+                'category_id' => $this->getCategoryId(),
+                'page' => $this->getRequest()->get('page', 1),
+            ],
+        );
+    }
+
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.products.default',
+            [
+                'category_id' => $this->getCategoryId(),
+                'page' => $this->getRequest()->get('page', 1),
+            ],
+        );
+    }
+
+    protected function renderEditionTemplate(): Response
+    {
+        return $this->render('product-edit', $this->getEditionArguments());
+    }
+
+    protected function redirectToEditionTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute('admin.products.update', $this->getEditionArguments());
+    }
+
+    /**
+     * Online status toggle product.
+     */
+    public function setToggleVisibilityAction(
+        EventDispatcherInterface $eventDispatcher,
+    ): Response {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $event = new ProductToggleVisibilityEvent($this->getExistingObject());
+
+        try {
+            $eventDispatcher->dispatch($event, TheliaEvents::PRODUCT_TOGGLE_VISIBILITY);
+        } catch (\Exception $exception) {
+            // Any error
+            return $this->errorPage($exception);
+        }
+
+        // Ajax response -> no action
+        return $this->nullResponse();
+    }
+
+    protected function performAdditionalDeleteAction(ActionEvent|ActiveRecordEvent|null $deleteEvent): ?Response
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.products.default',
+            ['category_id' => $this->getCategoryId()],
+        );
+    }
+
+    protected function performAdditionalUpdatePositionAction(ActionEvent $positionChangeEvent): ?Response
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.categories.default',
+            ['category_id' => $this->getCategoryId()],
+        );
+    }
+
+    protected function performAdditionalUpdateAction(EventDispatcherInterface $eventDispatcher, ActionEvent|ActiveRecordEvent|null $updateEvent): ?Response
+    {
+        if (null === $updateEvent) {
+            return null;
+        }
+
+        // Associate the file if it's a virtual product
+        // and with only 1 PSE
+        $virtualDocumentId = (int) $updateEvent->getVirtualDocumentId();
+
+        if ($virtualDocumentId >= 0) {
+            $defaultPSE = ProductSaleElementsQuery::create()
+                ->filterByProductId($updateEvent->getProductId())
+                ->filterByIsDefault(true)
+                ->findOne();
+
+            if (null !== $defaultPSE) {
+                if (0 !== $virtualDocumentId) {
+                    $assocEvent = new MetaDataCreateOrUpdateEvent('virtual', MetaData::PSE_KEY, $defaultPSE->getId(), $virtualDocumentId);
+                    $eventDispatcher->dispatch($assocEvent, TheliaEvents::META_DATA_UPDATE);
+                } else {
+                    $assocEvent = new MetaDataDeleteEvent('virtual', MetaData::PSE_KEY, $defaultPSE->getId());
+                    $eventDispatcher->dispatch($assocEvent, TheliaEvents::META_DATA_DELETE);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * return a list of document which will be displayed in AJAX.
+     */
+    public function getVirtualDocumentListAjaxAction($productId, $pseId): Response
+    {
+        $this->checkAuth(AdminResources::PRODUCT, [], AccessManager::VIEW);
+        $this->checkXmlHttpRequest();
+
+        $selectedId = (int) MetaDataQuery::getVal('virtual', MetaData::PSE_KEY, $pseId);
+
+        $documents = ProductDocumentQuery::create()
+            ->filterByProductId($productId)
+            ->filterByVisible(0)
+            ->orderByPosition()
+            ->find();
+
+        $results = [];
+
+        if (null !== $documents) {
+            /** @var ProductDocument $document */
+            foreach ($documents as $document) {
+                $results[] = [
+                    'id' => $document->getId(),
+                    'title' => $document->getTitle(),
+                    'file' => $document->getFile(),
+                    'selected' => ($document->getId() === $selectedId),
+                ];
+            }
+        }
+
+        return $this->jsonResponse(json_encode($results));
+    }
+
+    // -- Related content management -------------------------------------------
+
+    public function getAvailableRelatedContentAction($productId, $folderId): Response
+    {
+        $result = [];
+
+        $folders = FolderQuery::create()->filterById($folderId)->find();
+
+        if (null !== $folders) {
+            $list = ContentQuery::create()
+                ->joinWithI18n($this->getCurrentEditionLocale())
+                ->filterByFolder($folders, Criteria::IN)
+                ->filterById(ProductAssociatedContentQuery::create()->filterByProductId($productId)->select('content_id')->find(), Criteria::NOT_IN)
+                ->find();
+
+            if (null !== $list) {
+                /** @var Content $item */
+                foreach ($list as $item) {
+                    $result[] = ['id' => $item->getId(), 'title' => $item->getTitle()];
+                }
+            }
+        }
+
+        return $this->jsonResponse(json_encode($result));
+    }
+
+    public function addRelatedContentAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $content_id = (int) $this->getRequest()->get('content_id');
+
+        if ($content_id > 0) {
+            $event = new ProductAddContentEvent(
+                $this->getExistingObject(),
+                $content_id,
+            );
+
+            try {
+                $eventDispatcher->dispatch($event, TheliaEvents::PRODUCT_ADD_CONTENT);
+            } catch (\Exception $ex) {
+                // Any error
+                return $this->errorPage($ex);
+            }
+        }
+
+        return $this->redirectToEditionTemplate();
+    }
+
+    public function deleteRelatedContentAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $content_id = (int) $this->getRequest()->get('content_id');
+
+        if ($content_id > 0) {
+            $event = new ProductDeleteContentEvent(
+                $this->getExistingObject(),
+                $content_id,
+            );
+
+            try {
+                $eventDispatcher->dispatch($event, TheliaEvents::PRODUCT_REMOVE_CONTENT);
+            } catch (\Exception $ex) {
+                // Any error
+                return $this->errorPage($ex);
+            }
+        }
+
+        return $this->redirectToEditionTemplate();
+    }
+
+    // -- Accessories management ----------------------------------------------
+
+    public function getAvailableAccessoriesAction($productId, $categoryId): Response
+    {
+        $result = [];
+
+        $categories = CategoryQuery::create()->filterById($categoryId)->find();
+
+        if (null !== $categories) {
+            $list = ProductQuery::create()
+                ->joinWithI18n($this->getCurrentEditionLocale())
+                ->filterByCategory($categories, Criteria::IN)
+                ->filterById(AccessoryQuery::create()->filterByProductId($productId)->select('accessory')->find(), Criteria::NOT_IN)
+                ->find();
+
+            if (null !== $list) {
+                /** @var Product $item */
+                foreach ($list as $item) {
+                    $result[] = ['id' => $item->getId(), 'title' => $item->getTitle()];
+                }
+            }
+        }
+
+        return $this->jsonResponse(json_encode($result));
+    }
+
+    public function addAccessoryAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $accessory_id = (int) $this->getRequest()->get('accessory_id');
+
+        if ($accessory_id > 0) {
+            $event = new ProductAddAccessoryEvent(
+                $this->getExistingObject(),
+                $accessory_id,
+            );
+
+            try {
+                $eventDispatcher->dispatch($event, TheliaEvents::PRODUCT_ADD_ACCESSORY);
+            } catch (\Exception $ex) {
+                // Any error
+                return $this->errorPage($ex);
+            }
+        }
+
+        return $this->redirectToEditionTemplate();
+    }
+
+    public function deleteAccessoryAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $accessory_id = (int) $this->getRequest()->get('accessory_id');
+
+        if ($accessory_id > 0) {
+            $event = new ProductDeleteAccessoryEvent(
+                $this->getExistingObject(),
+                $accessory_id,
+            );
+
+            try {
+                $eventDispatcher->dispatch($event, TheliaEvents::PRODUCT_REMOVE_ACCESSORY);
+            } catch (\Exception $ex) {
+                // Any error
+                return $this->errorPage($ex);
+            }
+        }
+
+        return $this->redirectToEditionTemplate();
+    }
+
+    /**
+     * Update accessory position.
+     */
+    public function updateAccessoryPositionAction(
+        Request $request,
+        EventDispatcherInterface $eventDispatcher,
+    ): ?Response {
+        $accessory = AccessoryQuery::create()->findPk($request->get('accessory_id'));
+
+        return $this->genericUpdatePositionAction(
+            $request,
+            $eventDispatcher,
+            $accessory,
+            TheliaEvents::PRODUCT_UPDATE_ACCESSORY_POSITION,
+        );
+    }
+
+    /**
+     * Update related content position.
+     */
+    public function updateContentPositionAction(
+        Request $request,
+        EventDispatcherInterface $eventDispatcher,
+    ): ?Response {
+        $content = ProductAssociatedContentQuery::create()->findPk($request->get('content_id'));
+
+        return $this->genericUpdatePositionAction(
+            $request,
+            $eventDispatcher,
+            $content,
+            TheliaEvents::PRODUCT_UPDATE_CONTENT_POSITION,
+        );
+    }
+
+    /**
+     * Change product template for a given product.
+     */
+    public function setProductTemplateAction(EventDispatcherInterface $eventDispatcher, int $productId): Response|RedirectResponse
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $product = ProductQuery::create()->findPk($productId);
+
+        if (null !== $product) {
+            $template_id = (int) $this->getRequest()->get('template_id', 0);
+
+            $eventDispatcher->dispatch(
+                new ProductSetTemplateEvent($product, $template_id, $this->getCurrentEditionCurrency()->getId()),
+                TheliaEvents::PRODUCT_SET_TEMPLATE,
+            );
+        }
+
+        return $this->redirectToEditionTemplate();
+    }
+
+    /**
+     * Update product attributes and features.
+     *
+     * @return RedirectResponse
+     *
+     * @throws PropelException
+     */
+    public function updateAttributesAndFeaturesAction(EventDispatcherInterface $eventDispatcher, int $productId): Response|RedirectResponse
+    {
+        $product = ProductQuery::create()->findPk($productId);
+
+        if (null !== $product) {
+            $featureTemplate = FeatureTemplateQuery::create()->filterByTemplateId($product->getTemplateId())->find();
+
+            if (null !== $featureTemplate) {
+                // Get all features for the template attached to this product
+                $allFeatures = FeatureQuery::create()
+                    ->filterByFeatureTemplate($featureTemplate)
+                    ->find();
+
+                $updatedFeatures = [];
+
+                // Update all features values, starting with feature av. values
+                $featureValues = $this->getRequest()->get('feature_value', []);
+
+                foreach ($featureValues as $featureId => $featureValueList) {
+                    // Delete all features av. for this feature.
+                    $event = new FeatureProductDeleteEvent($productId, $featureId);
+
+                    $eventDispatcher->dispatch($event, TheliaEvents::PRODUCT_FEATURE_DELETE_VALUE);
+
+                    // Add then all selected values
+                    foreach ($featureValueList as $featureValue) {
+                        $event = new FeatureProductUpdateEvent($productId, $featureId, $featureValue);
+
+                        $eventDispatcher->dispatch($event, TheliaEvents::PRODUCT_FEATURE_UPDATE_VALUE);
+                    }
+
+                    $updatedFeatures[] = $featureId;
+                }
+
+                // Update then features text values
+                $featureTextValues = $this->getRequest()->get('feature_text_value', []);
+
+                foreach ($featureTextValues as $featureId => $featureValue) {
+                    // Check if a FeatureProduct exists for this product and this feature (for another lang)
+                    $freeTextFeatureProduct = FeatureProductQuery::create()
+                        ->filterByProductId($productId)
+                        ->filterByIsFreeText(true)
+                        ->findOneByFeatureId($featureId);
+
+                    // If no corresponding FeatureProduct exists AND if the feature_text_value is null or 'empty', do nothing
+                    if (null === $freeTextFeatureProduct && (null === $featureValue || '' === $featureValue)) {
+                        continue;
+                    }
+
+                    $event = new FeatureProductUpdateEvent($productId, $featureId, $featureValue, true);
+                    $event->setLocale($this->getCurrentEditionLocale());
+
+                    $eventDispatcher->dispatch($event, TheliaEvents::PRODUCT_FEATURE_UPDATE_VALUE);
+
+                    $updatedFeatures[] = $featureId;
+                }
+
+                // Delete features which don't have any values
+                /** @var Feature $feature */
+                foreach ($allFeatures as $feature) {
+                    if (!\in_array($feature->getId(), $updatedFeatures, true)) {
+                        $event = new FeatureProductDeleteEvent($productId, $feature->getId());
+
+                        $eventDispatcher->dispatch($event, TheliaEvents::PRODUCT_FEATURE_DELETE_VALUE);
+                    }
+                }
+            }
+        }
+
+        // If we have to stay on the same page, do not redirect to the successUrl,
+        // just redirect to the edit page again.
+        if ('stay' === $this->getRequest()->get('save_mode')) {
+            return $this->redirectToEditionTemplate();
+        }
+
+        // Redirect to the category/product list
+        return $this->redirectToListTemplate();
+    }
+
+    public function addAdditionalCategoryAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $category_id = (int) $this->getRequest()->request->get('additional_category_id');
+
+        if ($category_id > 0) {
+            $event = new ProductAddCategoryEvent(
+                $this->getExistingObject(),
+                $category_id,
+            );
+
+            try {
+                $eventDispatcher->dispatch($event, TheliaEvents::PRODUCT_ADD_CATEGORY);
+            } catch (\Exception $ex) {
+                // Any error
+                return $this->errorPage($ex);
+            }
+        }
+
+        return $this->redirectToEditionTemplate();
+    }
+
+    public function deleteAdditionalCategoryAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $category_id = (int) $this->getRequest()->get('additional_category_id');
+
+        if ($category_id > 0) {
+            $event = new ProductDeleteCategoryEvent(
+                $this->getExistingObject(),
+                $category_id,
+            );
+
+            try {
+                $eventDispatcher->dispatch($event, TheliaEvents::PRODUCT_REMOVE_CATEGORY);
+            } catch (\Exception $ex) {
+                // Any error
+                return $this->errorPage($ex);
+            }
+        }
+
+        return $this->redirectToEditionTemplate();
+    }
+
+    // -- Product combination management ---------------------------------------
+
+    public function getAttributeValuesAction(/* @noinspection PhpUnusedParameterInspection */ $productId, $attributeId): Response
+    {
+        $result = [];
+
+        // Get attribute for this product
+        $attribute = AttributeQuery::create()->findPk($attributeId);
+
+        if (null !== $attribute) {
+            $values = AttributeAvQuery::create()
+                ->joinWithI18n($this->getCurrentEditionLocale())
+                ->filterByAttribute($attribute)
+                ->find();
+
+            if (null !== $values) {
+                /** @var AttributeAv $value */
+                foreach ($values as $value) {
+                    $result[] = ['id' => $value->getId(), 'title' => $value->getTitle()];
+                }
+            }
+        }
+
+        return $this->jsonResponse(json_encode($result));
+    }
+
+    public function addAttributeValueToCombinationAction(/* @noinspection PhpUnusedParameterInspection */ $productId, $attributeAvId, $combination): Response
+    {
+        $result = [];
+
+        // Get attribute for this product
+        $attributeAv = AttributeAvQuery::create()->joinWithI18n($this->getCurrentEditionLocale())->findPk($attributeAvId);
+
+        if (null !== $attributeAv) {
+            $addIt = true;
+
+            $attribute = AttributeQuery::create()
+                ->joinWithI18n($this->getCurrentEditionLocale())
+                ->findPk($attributeAv->getAttributeId());
+
+            // Check if this attribute is not already present
+            $combinationArray = explode(',', (string) $combination);
+
+            foreach ($combinationArray as $id) {
+                $attrAv = AttributeAvQuery::create()->joinWithI18n($this->getCurrentEditionLocale())->findPk($id);
+
+                if (null !== $attrAv) {
+                    if ($attrAv->getId() === $attributeAv->getId()) {
+                        $result['error'] = $this->getTranslator()->trans(
+                            'A value for attribute "%name" is already present in the combination',
+                            ['%name' => $attribute->getTitle().' : '.$attributeAv->getTitle()],
+                        );
+
+                        $addIt = false;
+                    }
+
+                    $subAttribute = AttributeQuery::create()
+                        ->joinWithI18n($this->getCurrentEditionLocale())
+                        ->findPk($attributeAv->getAttributeId());
+
+                    $result[] = ['id' => $attrAv->getId(), 'title' => $subAttribute->getTitle().' : '.$attrAv->getTitle()];
+                }
+            }
+
+            if ($addIt) {
+                $result[] = ['id' => $attributeAv->getId(), 'title' => $attribute->getTitle().' : '.$attributeAv->getTitle()];
+            }
+        }
+
+        return $this->jsonResponse(json_encode($result));
+    }
+
+    /**
+     * A a new combination to a product.
+     */
+    public function addProductSaleElementAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $event = new ProductSaleElementCreateEvent(
+            $this->getExistingObject(),
+            $this->getRequest()->get('combination_attributes', []),
+            $this->getCurrentEditionCurrency()->getId(),
+        );
+
+        try {
+            $eventDispatcher->dispatch($event, TheliaEvents::PRODUCT_ADD_PRODUCT_SALE_ELEMENT);
+        } catch (\Exception $exception) {
+            // Any error
+            return $this->errorPage($exception);
+        }
+
+        return $this->redirectToEditionTemplate();
+    }
+
+    /**
+     * A a new combination to a product.
+     */
+    public function deleteProductSaleElementAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $event = new ProductSaleElementDeleteEvent(
+            (int) $this->getRequest()->get('product_sale_element_id', 0),
+            $this->getCurrentEditionCurrency()->getId(),
+        );
+
+        try {
+            $eventDispatcher->dispatch($event, TheliaEvents::PRODUCT_DELETE_PRODUCT_SALE_ELEMENT);
+        } catch (\Exception $exception) {
+            // Any error
+            return $this->errorPage($exception);
+        }
+
+        return $this->redirectToEditionTemplate();
+    }
+
+    /**
+     * Process a single PSE update, using form data array.
+     *
+     * @param array $data the form data
+     */
+    protected function processSingleProductSaleElementUpdate(EventDispatcherInterface $eventDispatcher, array $data): void
+    {
+        $event = new ProductSaleElementUpdateEvent(
+            $this->getExistingObject(),
+            $data['product_sale_element_id'],
+        );
+
+        $event
+            ->setReference($data['reference'])
+            ->setPrice((float) $data['price'])
+            ->setCurrencyId((int) $data['currency'])
+            ->setWeight((float) ($data['weight'] ?? 0))
+            ->setQuantity((float) $data['quantity'])
+            ->setSalePrice((float) $data['sale_price'])
+            ->setOnsale((int) ($data['onsale'] ?? 0))
+            ->setIsnew((int) ($data['isnew'] ?? 0))
+            ->setIsdefault($data['isdefault'] ? (bool) $data['isdefault'] : false)
+            ->setEanCode($data['ean_code'])
+            ->setTaxRuleId((int) $data['tax_rule'])
+            ->setFromDefaultCurrency((int) $data['use_exchange_rate']);
+
+        $eventDispatcher->dispatch($event, TheliaEvents::PRODUCT_UPDATE_PRODUCT_SALE_ELEMENT);
+
+        // Log object modification
+        if (($changedObject = $event->getProductSaleElement()) instanceof ProductSaleElementsModel) {
+            $this->adminLogAppend(
+                $this->resourceCode,
+                AccessManager::UPDATE,
+                \sprintf(
+                    'Product Sale Element (ID %s) for product reference %s modified',
+                    $changedObject->getId(),
+                    $event->getProduct()->getRef(),
+                ),
+                $changedObject->getId(),
+            );
+        }
+    }
+
+    /**
+     * Change a product sale element.
+     *
+     * @return mixed|RedirectResponse|Response|null
+     */
+    protected function processProductSaleElementUpdate(EventDispatcherInterface $eventDispatcher, ?BaseForm $changeForm): Response|RedirectResponse|null
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        try {
+            // Check the form against constraints violations
+            $form = $this->validateForm($changeForm, 'POST');
+
+            // Get the form field values
+            $data = $form->getData();
+
+            if (\is_array($data['product_sale_element_id'])) {
+                // Common fields
+                $tmp_data = [
+                    'tax_rule' => $data['tax_rule'],
+                    'currency' => $data['currency'],
+                    'use_exchange_rate' => $data['use_exchange_rate'],
+                ];
+
+                $count = \count($data['product_sale_element_id']);
+
+                for ($idx = 0; $idx < $count; ++$idx) {
+                    $tmp_data['product_sale_element_id'] = $pse_id = $data['product_sale_element_id'][$idx];
+                    $tmp_data['reference'] = $data['reference'][$idx];
+                    $tmp_data['price'] = $data['price'][$idx];
+                    $tmp_data['weight'] = $data['weight'][$idx];
+                    $tmp_data['quantity'] = $data['quantity'][$idx];
+                    $tmp_data['sale_price'] = $data['sale_price'][$idx];
+                    $tmp_data['onsale'] = isset($data['onsale'][$idx]) ? 1 : 0;
+                    $tmp_data['isnew'] = isset($data['isnew'][$idx]) ? 1 : 0;
+                    $tmp_data['isdefault'] = $data['default_pse'] === $pse_id;
+                    $tmp_data['ean_code'] = $data['ean_code'][$idx];
+
+                    $this->processSingleProductSaleElementUpdate($eventDispatcher, $tmp_data);
+                }
+            } else {
+                // No need to preprocess data
+                $this->processSingleProductSaleElementUpdate($eventDispatcher, $data);
+            }
+
+            // If we have to stay on the same page, do not redirect to the successUrl, just redirect to the edit page again.
+            if ('stay' === $this->getRequest()->get('save_mode')) {
+                return $this->redirectToEditionTemplate();
+            }
+
+            // Redirect to the success URL
+            return $this->generateSuccessRedirect($changeForm);
+        } catch (FormValidationException $ex) {
+            // Form cannot be validated
+            $error_msg = $this->createStandardFormValidationErrorMessage($ex);
+        } catch (\Exception $ex) {
+            // Any other error
+            $error_msg = $ex->getMessage();
+        }
+
+        $this->setupFormErrorContext(
+            $this->getTranslator()->trans('ProductSaleElement modification'),
+            $error_msg,
+            $changeForm,
+            $ex,
+        );
+
+        // At this point, the form has errors, and should be redisplayed.
+        return $this->renderEditionTemplate();
+    }
+
+    /**
+     * Process the change of product's PSE list.
+     */
+    public function updateProductSaleElementsAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse|null
+    {
+        return $this->processProductSaleElementUpdate(
+            $eventDispatcher,
+            $this->createForm(AdminForm::PRODUCT_SALE_ELEMENT_UPDATE),
+        );
+    }
+
+    /**
+     * Update default product sale element (not attached to any combination).
+     */
+    public function updateProductDefaultSaleElementAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse|null
+    {
+        return $this->processProductSaleElementUpdate(
+            $eventDispatcher,
+            $this->createForm(AdminForm::PRODUCT_DEFAULT_SALE_ELEMENT_UPDATE),
+        );
+    }
+
+    // Create combinations
+    protected function combine($input, &$output, &$tmp): void
+    {
+        $current = array_shift($input);
+
+        if ([] !== $input) {
+            foreach ($current as $element) {
+                $tmp[] = $element;
+                $this->combine($input, $output, $tmp);
+                array_pop($tmp);
+            }
+        } else {
+            foreach ($current as $element) {
+                $tmp[] = $element;
+                $output[] = $tmp;
+                array_pop($tmp);
+            }
+        }
+    }
+
+    /**
+     * Build combinations from the combination output builder.
+     */
+    public function buildCombinationsAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse|null
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $changeForm = $this->createForm(AdminForm::PRODUCT_COMBINATION_GENERATION);
+
+        try {
+            // Check the form against constraints violations
+            $form = $this->validateForm($changeForm, 'POST');
+
+            // Get the form field values
+            $data = $form->getData();
+            // Rework attributes_av array, to build an array which contains all combinations,
+            // in the form combination[] = array of combination attributes av IDs
+            //
+            // First, create an array of attributes_av ID in the form $attributes_av_list[$attribute_id] = array of attributes_av ID
+            // from the list of attribute_id:attributes_av ID from the form.
+            $combinations = [];
+            $attributes_av_list = [];
+            $tmp = [];
+
+            foreach ($data['attribute_av'] as $item) {
+                [$attribute_id, $attribute_av_id] = explode(':', (string) $item);
+
+                if (!isset($attributes_av_list[$attribute_id])) {
+                    $attributes_av_list[$attribute_id] = [];
+                }
+
+                $attributes_av_list[$attribute_id][] = $attribute_av_id;
+            }
+
+            // Next, recursively combine array
+            $this->combine($attributes_av_list, $combinations, $tmp);
+
+            // Create event
+            $event = new ProductCombinationGenerationEvent(
+                $this->getExistingObject(),
+                $data['currency'],
+                $combinations,
+            );
+
+            $event
+                ->setReference($data['reference'] ?? '')
+                ->setPrice((float) ($data['price'] ?? 0))
+                ->setWeight((float) ($data['weight'] ?? 0))
+                ->setQuantity((float) ($data['quantity'] ?? 0))
+                ->setSalePrice((float) ($data['sale_price'] ?? 0))
+                ->setOnsale($data['onsale'] ?? false)
+                ->setIsnew($data['isnew'] ?? false)
+                ->setEanCode($data['ean_code'] ?? '');
+
+            $eventDispatcher->dispatch($event, TheliaEvents::PRODUCT_COMBINATION_GENERATION);
+
+            // Log object modification
+            $this->adminLogAppend(
+                $this->resourceCode,
+                AccessManager::CREATE,
+                \sprintf(
+                    'Combination generation for product reference %s',
+                    $event->getProduct()->getRef(),
+                ),
+                $event->getProduct()->getId(),
+            );
+
+            // Redirect to the success URL
+            return $this->generateSuccessRedirect($changeForm);
+        } catch (FormValidationException $ex) {
+            // Form cannot be validated
+            $error_msg = $this->createStandardFormValidationErrorMessage($ex);
+        } catch (\Exception $ex) {
+            // Any other error
+            $error_msg = $ex->getMessage();
+        }
+
+        $this->setupFormErrorContext(
+            $this->getTranslator()->trans('Combination builder'),
+            $error_msg,
+            $changeForm,
+            $ex,
+        );
+
+        // At this point, the form has errors, and should be redisplayed.
+        return $this->renderEditionTemplate();
+    }
+
+    /**
+     * Invoked through Ajax; this method calculates the taxed price from the untaxed price, and vice versa.
+     */
+    public function priceCalculator(): JsonResponse
+    {
+        $return_price = 0;
+
+        $price = (float) $this->getRequest()->query->get('price', 0);
+        $product_id = (int) $this->getRequest()->query->get('product_id', 0);
+        $action = $this->getRequest()->query->get('action', ''); // With ot without tax
+        $convert = (int) $this->getRequest()->query->get('convert_from_default_currency', 0);
+
+        if (null !== $product = ProductQuery::create()->findPk($product_id)) {
+            if ('to_tax' === $action) {
+                $return_price = $this->computePrice($price, 'without_tax', $product);
+            } elseif ('from_tax' === $action) {
+                $return_price = $this->computePrice($price, 'with_tax', $product);
+            } else {
+                $return_price = $price;
+            }
+
+            if (0 !== $convert) {
+                $return_price = $price * Currency::getDefaultCurrency()->getRate();
+            }
+        }
+
+        return new JsonResponse(['result' => $this->formatPrice($return_price)]);
+    }
+
+    /**
+     * Calculate tax or untax price for a non existing product.
+     *
+     * For an existing product, use self::priceCaclulator
+     */
+    public function calculatePrice(): JsonResponse
+    {
+        $return_price = 0;
+
+        $price = (float) $this->getRequest()->query->get('price');
+        $tax_rule_id = (int) $this->getRequest()->query->get('tax_rule');
+        $action = $this->getRequest()->query->get('action'); // With ot without tax
+
+        $taxRule = TaxRuleQuery::create()->findPk($tax_rule_id);
+
+        if (null !== $taxRule) {
+            $calculator = new Calculator();
+
+            $calculator->loadTaxRuleWithoutProduct(
+                $taxRule,
+                Country::getShopLocation(),
+            );
+
+            if ('to_tax' === $action) {
+                $return_price = $calculator->getTaxedPrice($price);
+            } elseif ('from_tax' === $action) {
+                $return_price = $calculator->getUntaxedPrice($price);
+            } else {
+                $return_price = $price;
+            }
+        }
+
+        return new JsonResponse(['result' => $this->formatPrice($return_price)]);
+    }
+
+    /**
+     * Calculate all prices.
+     *
+     * @return \Symfony\Component\HttpFoundation\JsonResponse
+     */
+    public function loadConvertedPrices(): JsonResponse
+    {
+        $product_sale_element_id = (int) $this->getRequest()->get('product_sale_element_id', 0);
+        $currency_id = (int) $this->getRequest()->get('currency_id', 0);
+        $price_with_tax = 0;
+        $price_without_tax = 0;
+        $sale_price_with_tax = 0;
+        $sale_price_without_tax = 0;
+
+        if (null !== $pse = ProductSaleElementsQuery::create()->findPk($product_sale_element_id)) {
+            if ($currency_id > 0
+                && $currency_id !== Currency::getDefaultCurrency()->getId()
+                && null !== $currency = CurrencyQuery::create()->findPk($currency_id)) {
+                // Get the default currency price
+                $productPrice = ProductPriceQuery::create()
+                    ->filterByCurrency(Currency::getDefaultCurrency())
+                    ->filterByProductSaleElementsId($product_sale_element_id)
+                    ->findOne();
+
+                // Calculate the converted price
+                if (null !== $productPrice) {
+                    $price_without_tax = $productPrice->getPrice() * $currency->getRate();
+                    $sale_price_without_tax = $productPrice->getPromoPrice() * $currency->getRate();
+                }
+            }
+
+            if (null !== $product = $pse->getProduct()) {
+                $price_with_tax = $this->computePrice($price_without_tax, 'with_tax', $product);
+                $sale_price_with_tax = $this->computePrice($sale_price_without_tax, 'with_tax', $product);
+            }
+        }
+
+        return new JsonResponse([
+            'price_with_tax' => $this->formatPrice($price_with_tax),
+            'price_without_tax' => $this->formatPrice($price_without_tax),
+            'sale_price_with_tax' => $this->formatPrice($sale_price_with_tax),
+            'sale_price_without_tax' => $this->formatPrice($sale_price_without_tax),
+        ]);
+    }
+
+    /**
+     * Calculate taxed/untexted price for a product.
+     */
+    protected function computePrice($price, $price_type, Product $product, bool $convert = false): float
+    {
+        $calc = new Calculator();
+        $calc->load($product, Country::getShopLocation());
+
+        // Calculer le prix selon le type demandé
+        $return_price = match ($price_type) {
+            'with_tax' => $calc->getUntaxedPrice((float) $price),
+            'without_tax' => $calc->getTaxedPrice((float) $price),
+            default => (float) $price,
+        };
+
+        if ($convert) {
+            $defaultCurrency = Currency::getDefaultCurrency();
+
+            if ($defaultCurrency) {
+                $return_price *= $defaultCurrency->getRate();
+            }
+        }
+
+        return $return_price;
+    }
+
+    /**
+     * @return mixed|Response
+     */
+    public function productSaleElementsProductImageDocumentAssociation(EventDispatcherInterface $eventDispatcher, int $pseId, string $type, int $typeId): Response|JsonResponse
+    {
+        /*
+         * Check user's auth
+         */
+        if (($response = $this->checkAuth(AdminResources::PRODUCT, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $this->checkXmlHttpRequest();
+
+        /**
+         * Check given type.
+         */
+        $responseData = [];
+
+        try {
+            $responseData = $this->getAssociationResponseData($eventDispatcher, $pseId, $type, $typeId);
+        } catch (\Exception $exception) {
+            $responseData['error'] = $exception->getMessage();
+        }
+
+        return new JsonResponse($responseData, isset($responseData['error']) ? 500 : 200);
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getAssociationResponseData(EventDispatcherInterface $eventDispatcher, $pseId, $type, $typeId): array
+    {
+        $responseData = [];
+
+        if (null !== $msg = $this->checkFileType($type)) {
+            throw new \Exception($msg);
+        }
+
+        $responseData['product_sale_elements_id'] = $pseId;
+
+        $pse = ProductSaleElementsQuery::create()->findPk($pseId);
+
+        if (null === $pse) {
+            throw new \Exception($this->getTranslator()->trans("The product sale elements id %id doesn't exists", ['%id' => $pseId]));
+        }
+
+        $assoc = null;
+
+        if ('image' === $type) {
+            $image = ProductImageQuery::create()->findPk($typeId);
+
+            if (null === $image) {
+                throw new \Exception($this->getTranslator()->trans("The product image id %id doesn't exists", ['%id' => $typeId]));
+            }
+
+            $assoc = ProductSaleElementsProductImageQuery::create()
+                ->filterByProductSaleElementsId($pseId)
+                ->findOneByProductImageId($typeId);
+
+            if (null === $assoc) {
+                $assoc = new ProductSaleElementsProductImage();
+
+                $assoc
+                    ->setProductSaleElementsId($pseId)
+                    ->setProductImageId($typeId)
+                    ->save();
+            } else {
+                $assoc->delete();
+            }
+
+            $responseData['product_image_id'] = $typeId;
+            $responseData['is-associated'] = (int) (!$assoc->isDeleted());
+        } elseif ('document' === $type) {
+            $image = ProductDocumentQuery::create()->findPk($typeId);
+
+            if (null === $image) {
+                throw new \Exception($this->getTranslator()->trans("The product document id %id doesn't exists", ['%id' => $pseId]));
+            }
+
+            $assoc = ProductSaleElementsProductDocumentQuery::create()
+                ->filterByProductSaleElementsId($pseId)
+                ->findOneByProductDocumentId($typeId);
+
+            if (null === $assoc) {
+                $assoc = new ProductSaleElementsProductDocument();
+
+                $assoc
+                    ->setProductSaleElementsId($pseId)
+                    ->setProductDocumentId($typeId)
+                    ->save();
+            } else {
+                $assoc->delete();
+            }
+
+            $responseData['product_document_id'] = $typeId;
+            $responseData['is-associated'] = (int) (!$assoc->isDeleted());
+        } elseif ('virtual' === $type) {
+            $image = ProductDocumentQuery::create()->findPk($typeId);
+
+            if (null === $image) {
+                throw new \Exception($this->getTranslator()->trans("The product document id %id doesn't exists", ['%id' => $pseId]));
+            }
+
+            $documentId = (int) MetaDataQuery::getVal('virtual', MetaData::PSE_KEY, $pseId);
+
+            if ($documentId === (int) $typeId) {
+                $assocEvent = new MetaDataDeleteEvent('virtual', MetaData::PSE_KEY, $pseId);
+                $eventDispatcher->dispatch($assocEvent, TheliaEvents::META_DATA_DELETE);
+                $responseData['is-associated'] = 0;
+            } else {
+                $assocEvent = new MetaDataCreateOrUpdateEvent('virtual', MetaData::PSE_KEY, $pseId, $typeId);
+                $eventDispatcher->dispatch($assocEvent, TheliaEvents::META_DATA_UPDATE);
+                $responseData['is-associated'] = 1;
+            }
+
+            $responseData['product_document_id'] = $typeId;
+        }
+
+        return $responseData;
+    }
+
+    public function checkFileType($type): ?string
+    {
+        $types = ['image', 'document', 'virtual'];
+
+        if (!\in_array($type, $types, true)) {
+            return $this->getTranslator()->trans(
+                'The type %type is not valid',
+                [
+                    '%type' => $type,
+                ],
+            );
+        }
+
+        return null;
+    }
+
+    public function getAjaxProductSaleElementsImagesDocuments(EventDispatcherInterface $eventDispatcher, $id, $type): JsonResponse|Response
+    {
+        if ($this->checkAuth(AdminResources::PRODUCT, [], AccessManager::VIEW) instanceof Response) {
+            return JsonResponse::createAuthError(AccessManager::VIEW);
+        }
+
+        $this->checkXmlHttpRequest();
+
+        $pse = ProductSaleElementsQuery::create()
+            ->findPk($id);
+
+        $errorMessage = $this->checkFileType($type);
+
+        if (null === $pse && null === $errorMessage) {
+            $type = null;
+
+            $errorMessage = $this->getTranslator()->trans(
+                "The product sale elements id %id doesn't exist",
+                [
+                    '%id' => $pse->getId(),
+                ],
+            );
+        }
+
+        switch ($type) {
+            case 'image':
+                $modalTitle = $this->getTranslator()->trans('Associate images');
+                $data = $this->getPSEImages($eventDispatcher, $pse);
+                break;
+            case 'document':
+                $modalTitle = $this->getTranslator()->trans('Associate documents');
+                $data = $this->getPSEDocuments($eventDispatcher, $pse);
+                break;
+            case 'virtual':
+                $modalTitle = $this->getTranslator()->trans('Select the virtual document');
+                $data = $this->getPSEVirtualDocument($eventDispatcher, $pse);
+                break;
+            case null:
+            default:
+                $modalTitle = $this->getTranslator()->trans('Unsupported type');
+                $data = [];
+        }
+
+        if ([] === $data && null === $errorMessage) {
+            $errorMessage = $this->getTranslator()->trans('There are no files to associate.');
+
+            if ('virtual' === $type) {
+                $errorMessage .= $this->getTranslator()->trans(' note: only non-visible documents can be associated.');
+            }
+        }
+
+        $this->getParserContext()
+            ->set('items', $data)
+            ->set('type', $type)
+            ->set('error_message', $errorMessage)
+            ->set('modal_title', $modalTitle);
+
+        return $this->render('ajax/pse-image-document-assoc-modal');
+    }
+
+    /**
+     * @return list<array{id: mixed, url: mixed, title: mixed, is_associated: mixed, filename: mixed}>
+     */
+    protected function getPSEImages(EventDispatcherInterface $eventDispatcher, ProductSaleElementsModel $pse): array
+    {
+        /** @var Image $imageLoop */
+        $imageLoop = $this->createLoopInstance($eventDispatcher, Image::class);
+
+        $imageLoop->initializeArgs([
+            'product' => $pse->getProductId(),
+            'width' => 100,
+            'height' => 75,
+            'resize_mode' => 'borders',
+        ]);
+
+        $propelModelPager = new PropelModelPager(new ModelCriteria(), 50);
+
+        $images = $imageLoop->exec($propelModelPager);
+
+        $imageAssoc = ProductSaleElementsProductImageQuery::create()
+            ->filterByProductSaleElementsId($pse->getId())
+            ->find()
+            ->toArray();
+
+        $data = [];
+
+        /* @var \Thelia\Core\Template\Element\LoopResultRow $image */
+        for ($images->rewind(); $images->valid(); $images->next()) {
+            $image = $images->current();
+
+            $isAssociated = $this->arrayHasEntries($imageAssoc, [
+                'ProductImageId' => $image->get('ID'),
+                'ProductSaleElementsId' => $pse->getId(),
+            ]);
+
+            $data[] = [
+                'id' => $image->get('ID'),
+                'url' => $image->get('IMAGE_URL'),
+                'title' => $image->get('TITLE'),
+                'is_associated' => $isAssociated,
+                'filename' => $image->model->getFile(),
+            ];
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return list<array{id: mixed, url: mixed, title: mixed, is_associated: mixed, filename: mixed}>
+     */
+    protected function getPSEDocuments(EventDispatcherInterface $eventDispatcher, ProductSaleElementsModel $pse): array
+    {
+        /** @var Document $documentLoop */
+        $documentLoop = $this->createLoopInstance($eventDispatcher, Document::class);
+
+        $documentLoop->initializeArgs([
+            'product' => $pse->getProductId(),
+            'visible' => BooleanOrBothType::ANY, // Do not restrict on visibility for single association
+        ]);
+
+        $documents = $documentLoop
+            ->exec($documentPagination);
+
+        $documentAssoc = ProductSaleElementsProductDocumentQuery::create()
+            ->useProductSaleElementsQuery()
+            ->filterById($pse->getId())
+            ->endUse()
+            ->find()
+            ->toArray();
+
+        $data = [];
+
+        /* @var \Thelia\Core\Template\Element\LoopResultRow $document */
+        for ($documents->rewind(); $documents->valid(); $documents->next()) {
+            $document = $documents->current();
+
+            $isAssociated = $this->arrayHasEntries($documentAssoc, [
+                'ProductDocumentId' => $document->get('ID'),
+                'ProductSaleElementsId' => $pse->getId(),
+            ]);
+
+            $data[] = [
+                'id' => $document->get('ID'),
+                'url' => $document->get('DOCUMENT_URL'),
+                'title' => $document->get('TITLE'),
+                'is_associated' => $isAssociated,
+                'filename' => $document->model->getFile(),
+            ];
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return list<array{id: mixed, url: mixed, title: mixed, is_associated: bool, filename: mixed}>
+     */
+    protected function getPSEVirtualDocument(EventDispatcherInterface $eventDispatcher, ProductSaleElementsModel $pse): array
+    {
+        /** @var Document $documentLoop */
+        $documentLoop = $this->createLoopInstance($eventDispatcher, Document::class);
+
+        // select only not visible documents
+        $documentLoop->initializeArgs([
+            'product' => $pse->getProductId(),
+            'visible' => 0,
+        ]);
+
+        $documents = $documentLoop
+            ->exec($documentPagination);
+
+        $documentId = (int) MetaDataQuery::getVal('virtual', 'pse', $pse->getId());
+
+        $data = [];
+
+        /* @var \Thelia\Core\Template\Element\LoopResultRow $document */
+        for ($documents->rewind(); $documents->valid(); $documents->next()) {
+            $document = $documents->current();
+
+            $data[] = [
+                'id' => $document->get('ID'),
+                'url' => $document->get('DOCUMENT_URL'),
+                'title' => $document->get('TITLE'),
+                'is_associated' => ($documentId === $document->get('ID')),
+                'filename' => $document->model->getFile(),
+            ];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Todo refactor this to not use container or not use loop at all
+     * Compute images with the associated loop.
+     */
+    protected function createLoopInstance(EventDispatcherInterface $eventDispatcher, $loopClass)
+    {
+        /** @var Image|Document $instance */
+        $instance = new $loopClass();
+
+        $instance->init(
+            $this->container,
+            $this->container->get('request_stack'),
+            $eventDispatcher,
+            $this->getSecurityContext(),
+            $this->getTranslator(),
+            $this->container->getParameter('Thelia.parser.loops'),
+            $this->container->getParameter('kernel.environment'),
+        );
+
+        return $instance;
+    }
+
+    protected function arrayHasEntries(array $data, array $entries)
+    {
+        $status = false;
+        $countEntries = \count($entries);
+
+        foreach ($data as $line) {
+            $localMatch = 0;
+
+            foreach ($entries as $key => $entry) {
+                if (isset($line[$key]) && $line[$key] === $entry) {
+                    ++$localMatch;
+                }
+            }
+
+            if ($localMatch === $countEntries) {
+                $status = true;
+                unset($line);
+                break;
+            }
+        }
+
+        return $status;
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function cloneAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        if (($response = $this->checkAuth($this->resourceCode, $this->getModuleCode(), [AccessManager::CREATE, AccessManager::UPDATE])) instanceof Response) {
+            return $response;
+        }
+
+        // Initialize vars
+        $cloneProductForm = $this->createForm(AdminForm::PRODUCT_CLONE);
+        $lang = $this->getSession()->getLang()->getLocale();
+
+        try {
+            // Check the form against constraints violations
+            $form = $this->validateForm($cloneProductForm, 'POST');
+
+            $originalProduct = ProductQuery::create()
+                ->findPk($form->getData()['productId']);
+
+            // Build and dispatch product clone event
+            $productCloneEvent = new ProductCloneEvent(
+                $form->getData()['newRef'],
+                $lang,
+                $originalProduct,
+            );
+            $eventDispatcher->dispatch($productCloneEvent, TheliaEvents::PRODUCT_CLONE);
+
+            return $this->generateRedirectFromRoute(
+                'admin.products.update',
+                ['product_id' => $productCloneEvent->getClonedProduct()->getId()],
+            );
+        } catch (FormValidationException $formValidationException) {
+            $this->setupFormErrorContext(
+                $this->getTranslator()->trans('Product clone'),
+                $formValidationException->getMessage(),
+                $cloneProductForm,
+                $formValidationException,
+            );
+
+            return $this->redirectToEditionTemplate();
+        }
+    }
+
+    protected function formatPrice(string|float $price): float
+    {
+        return (float) number_format((float) $price, 6, '.', '');
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function searchCategoryAction(): Response
+    {
+        $search = '%'.$this->getRequest()->query->get('q').'%';
+
+        $resultArray = [];
+
+        $categoriesI18n = CategoryI18nQuery::create()->filterByTitle($search, Criteria::LIKE)->limit(100);
+
+        /** @var CategoryI18n $categoryI18n */
+        foreach ($categoriesI18n as $categoryI18n) {
+            $category = $categoryI18n->getCategory();
+            $resultArray[$category->getId()] = $categoryI18n->getTitle();
+        }
+
+        return $this->jsonResponse(json_encode($resultArray));
+    }
+
+    /**
+     * @return mixed|Response
+     *
+     * @throws PropelException
+     */
+    public function searchProductAction(): Response
+    {
+        $search = '%'.$this->getRequest()->query->get('q').'%';
+
+        $resultArray = [];
+
+        $productsI18nQuery = ProductI18nQuery::create()->filterByTitle($search, Criteria::LIKE);
+
+        $category_id = $this->getRequest()->query->get('category_id');
+
+        if (null !== $category_id) {
+            $productsI18nQuery
+                ->useProductQuery()
+                ->useProductCategoryQuery()
+                ->filterByCategoryId($category_id)
+                ->endUse()
+                ->endUse();
+        }
+
+        $products = $productsI18nQuery->limit(100);
+
+        /** @var ProductI18n $product */
+        foreach ($products as $product) {
+            $resultArray[$product->getId()] = $product->getTitle();
+        }
+
+        return $this->jsonResponse(json_encode($resultArray));
+    }
+
+    public function toggleProductSaleElementVisibility(EventDispatcherInterface $eventDispatcher): Response
+    {
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $event = new ProductSaleElementToggleVisibilityEvent(
+            (int) $this->getRequest()->get('product_sale_element_id', 0)
+        );
+
+        try {
+            $eventDispatcher->dispatch($event, TheliaEvents::PRODUCT_PRODUCT_SALE_ELEMENT_TOGGLE_VISIBILITY);
+        } catch (\Exception $exception) {
+            return $this->errorPage($exception);
+        }
+
+        return $this->nullResponse();
+    }
+
+    public function updateProductSalementPosition(
+        Request $request,
+        EventDispatcherInterface $eventDispatcher,
+    ): Response {
+        $pse = ProductSaleElementsQuery::create()->findPk((int) $request->get('product_sale_element_id'));
+
+        $this->genericUpdatePositionAction(
+            $request,
+            $eventDispatcher,
+            $pse,
+            TheliaEvents::PRODUCT_PRODUCT_SALE_ELEMENT_UPDATE_POSITION
+        );
+
+        return new RedirectResponse(
+            URL::getInstance()->absoluteUrl('/admin/products/update',
+                [
+                    'product_id' => $pse->getProductId(),
+                    'current_tab' => 'prices',
+                ])
+        );
+    }
+}

--- a/Controller/Admin/ProfileController.php
+++ b/Controller/Admin/ProfileController.php
@@ -1,0 +1,437 @@
+<?php
+
+/** @noinspection PhpRedundantOptionalArgumentInspection */
+/* @noinspection PhpRedundantOptionalArgumentInspection */
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Propel\Runtime\Event\ActiveRecordEvent;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\Profile\ProfileEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Form\Exception\FormValidationException;
+use Thelia\Form\ProfileUpdateModuleAccessForm;
+use Thelia\Form\ProfileUpdateResourceAccessForm;
+use Thelia\Model\Profile;
+use Thelia\Model\ProfileQuery;
+
+class ProfileController extends AbstractCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'profile',
+            'manual',
+            'order',
+            AdminResources::PROFILE,
+            TheliaEvents::PROFILE_CREATE,
+            TheliaEvents::PROFILE_UPDATE,
+            TheliaEvents::PROFILE_DELETE,
+        );
+    }
+
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::PROFILE_CREATION);
+    }
+
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::PROFILE_MODIFICATION);
+    }
+
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $event = new ProfileEvent();
+
+        $event->setLocale($formData['locale']);
+        $event->setCode($formData['code']);
+        $event->setTitle($formData['title']);
+        $event->setChapo($formData['chapo']);
+        $event->setDescription($formData['description']);
+        $event->setPostscriptum($formData['postscriptum']);
+
+        return $event;
+    }
+
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $event = new ProfileEvent();
+
+        $event->setLocale($formData['locale']);
+        $event->setId($formData['id']);
+        $event->setTitle($formData['title']);
+        $event->setChapo($formData['chapo']);
+        $event->setDescription($formData['description']);
+        $event->setPostscriptum($formData['postscriptum']);
+
+        return $event;
+    }
+
+    protected function getDeleteEvent(): ProfileEvent
+    {
+        $event = new ProfileEvent();
+
+        $event->setId(
+            $this->getRequest()->get('profile_id', 0),
+        );
+
+        return $event;
+    }
+
+    protected function eventContainsObject(Event $event): bool
+    {
+        return $event->hasProfile();
+    }
+
+    /**
+     * @param Profile $object
+     */
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        $data = [
+            'id' => $object->getId(),
+            'locale' => $object->getLocale(),
+            'title' => $object->getTitle(),
+            'description' => $object->getDescription(),
+            'code' => $object->getCode(),
+        ];
+
+        // Setup the object form
+        return $this->createForm(AdminForm::PROFILE_MODIFICATION, FormType::class, $data);
+    }
+
+    protected function hydrateResourceUpdateForm(Profile $object): BaseForm
+    {
+        $data = [
+            'id' => $object->getId(),
+        ];
+
+        // Setup the object form
+        return $this->createForm(AdminForm::PROFILE_UPDATE_RESOURCE_ACCESS, FormType::class, $data);
+    }
+
+    protected function hydrateModuleUpdateForm(Profile $object): BaseForm
+    {
+        $data = [
+            'id' => $object->getId(),
+        ];
+
+        // Setup the object form
+        return $this->createForm(AdminForm::PROFILE_UPDATE_MODULE_ACCESS, FormType::class, $data);
+    }
+
+    protected function getObjectFromEvent($event): mixed
+    {
+        return $event->hasProfile() ? $event->getProfile() : null;
+    }
+
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        $profile = ProfileQuery::create()
+            ->findOneById($this->getRequest()->get('profile_id', 0));
+
+        if (null !== $profile) {
+            $profile->setLocale($this->getCurrentEditionLocale());
+        }
+
+        return $profile;
+    }
+
+    protected function getObjectLabel(?ActiveRecordInterface $object): ?string
+    {
+        if ($object instanceof Profile) {
+            return $object->getTitle();
+        }
+
+        return (string) $object;
+    }
+
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        if ($object instanceof Profile) {
+            return (int) $object->getId();
+        }
+
+        return (int) $object;
+    }
+
+    protected function getViewArguments(): array
+    {
+        return (null !== $tab = $this->getRequest()->get('tab')) ? ['tab' => $tab] : [];
+    }
+
+    protected function getRouteArguments($profile_id = null): array
+    {
+        return [
+            'profile_id' => $profile_id ?? $this->getRequest()->get('profile_id'),
+        ];
+    }
+
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        // We always return to the feature edition form
+        return $this->render(
+            'profiles',
+        );
+    }
+
+    protected function renderEditionTemplate(): Response
+    {
+        // We always return to the feature edition form
+        return $this->render('profile-edit', array_merge($this->getViewArguments(), $this->getRouteArguments()));
+    }
+
+    protected function redirectToEditionTemplate(): Response|RedirectResponse
+    {
+        // We always return to the feature edition form
+        return $this->generateRedirectFromRoute(
+            'admin.configuration.profiles.update',
+            $this->getViewArguments(),
+            $this->getRouteArguments(),
+        );
+    }
+
+    /**
+     * Put in this method post object creation processing if required.
+     */
+    protected function performAdditionalCreateAction(ActionEvent|ActiveRecordEvent|null $createEvent): ?Response
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.configuration.profiles.update',
+            $this->getViewArguments(),
+            $this->getRouteArguments($createEvent->getProfile()->getId()),
+        );
+    }
+
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute('admin.configuration.profiles.list');
+    }
+
+    public function updateAction(ParserContext $parserContext): Response
+    {
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $object = $this->getExistingObject();
+
+        if ($object instanceof ActiveRecordInterface) {
+            // Hydrate the form and pass it to the parser
+            $resourceAccessForm = $this->hydrateResourceUpdateForm($object);
+            $moduleAccessForm = $this->hydrateModuleUpdateForm($object);
+
+            // Pass it to the parser
+            $parserContext->addForm($resourceAccessForm);
+            $parserContext->addForm($moduleAccessForm);
+        }
+
+        return parent::updateAction($parserContext);
+    }
+
+    protected function getUpdateResourceAccessEvent(array $formData): ProfileEvent
+    {
+        $event = new ProfileEvent();
+
+        $event->setId($formData['id']);
+        $event->setResourceAccess($this->getResourceAccess($formData));
+
+        return $event;
+    }
+
+    protected function getUpdateModuleAccessEvent(array $formData): ProfileEvent
+    {
+        $event = new ProfileEvent();
+
+        $event->setId($formData['id']);
+        $event->setModuleAccess($this->getModuleAccess($formData));
+
+        return $event;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    protected function getResourceAccess($formData): array
+    {
+        $requirements = [];
+
+        foreach ($formData as $data => $value) {
+            if (!strstr((string) $data, ':')) {
+                continue;
+            }
+
+            $explosion = explode(':', (string) $data);
+
+            $prefix = array_shift($explosion);
+
+            if (ProfileUpdateResourceAccessForm::RESOURCE_ACCESS_FIELD_PREFIX !== $prefix) {
+                continue;
+            }
+
+            $requirements[implode('.', $explosion)] = $value;
+        }
+
+        return $requirements;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    protected function getModuleAccess($formData): array
+    {
+        $requirements = [];
+
+        foreach ($formData as $data => $value) {
+            if (!strstr((string) $data, ':')) {
+                continue;
+            }
+
+            $explosion = explode(':', (string) $data);
+
+            $prefix = array_shift($explosion);
+
+            if (ProfileUpdateModuleAccessForm::MODULE_ACCESS_FIELD_PREFIX !== $prefix) {
+                continue;
+            }
+
+            $requirements[implode('.', $explosion)] = $value;
+        }
+
+        return $requirements;
+    }
+
+    public function processUpdateResourceAccess(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        // Create the form from the request
+        $changeForm = $this->createForm(AdminForm::PROFILE_UPDATE_RESOURCE_ACCESS);
+
+        try {
+            // Check the form against constraints violations
+            $form = $this->validateForm($changeForm, 'POST');
+
+            // Get the form field values
+            $data = $form->getData();
+
+            $changeEvent = $this->getUpdateResourceAccessEvent($data);
+
+            $eventDispatcher->dispatch($changeEvent, TheliaEvents::PROFILE_RESOURCE_ACCESS_UPDATE);
+
+            if (!$this->eventContainsObject($changeEvent)) {
+                throw new \LogicException($this->getTranslator()->trans('No %obj was updated.', ['%obj', $this->objectName]));
+            }
+
+            // Log object modification
+            if (null !== $changedObject = $this->getObjectFromEvent($changeEvent)) {
+                $this->adminLogAppend(
+                    $this->resourceCode,
+                    AccessManager::UPDATE,
+                    \sprintf(
+                        '%s %s (ID %s) modified',
+                        ucfirst($this->objectName),
+                        $this->getObjectLabel($changedObject),
+                        $this->getObjectId($changedObject),
+                    ),
+                    $this->getObjectId($changedObject),
+                );
+            }
+
+            return $this->redirectToEditionTemplate();
+        } catch (FormValidationException $ex) {
+            // Form cannot be validated
+            $error_msg = $this->createStandardFormValidationErrorMessage($ex);
+        } catch (\Exception $ex) {
+            // Any other error
+            $error_msg = $ex->getMessage();
+        }
+
+        $this->setupFormErrorContext($this->getTranslator()->trans('%obj modification', ['%obj' => 'taxrule']), $error_msg, $changeForm, $ex);
+
+        // At this point, the form has errors, and should be redisplayed.
+        return $this->renderEditionTemplate();
+    }
+
+    public function processUpdateModuleAccess(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        // Create the form from the request
+        $changeForm = $this->createForm(AdminForm::PROFILE_UPDATE_MODULE_ACCESS);
+
+        try {
+            // Check the form against constraints violations
+            $form = $this->validateForm($changeForm, 'POST');
+
+            // Get the form field values
+            $data = $form->getData();
+
+            $changeEvent = $this->getUpdateModuleAccessEvent($data);
+
+            $eventDispatcher->dispatch($changeEvent, TheliaEvents::PROFILE_MODULE_ACCESS_UPDATE);
+
+            if (!$this->eventContainsObject($changeEvent)) {
+                throw new \LogicException($this->getTranslator()->trans('No %obj was updated.', ['%obj', $this->objectName]));
+            }
+
+            // Log object modification
+            if (null !== $changedObject = $this->getObjectFromEvent($changeEvent)) {
+                $this->adminLogAppend(
+                    $this->resourceCode,
+                    AccessManager::UPDATE,
+                    \sprintf(
+                        '%s %s (ID %s) modified',
+                        ucfirst($this->objectName),
+                        $this->getObjectLabel($changedObject),
+                        $this->getObjectId($changedObject),
+                    ),
+                    $this->getObjectId($changedObject),
+                );
+            }
+
+            return $this->redirectToEditionTemplate();
+        } catch (FormValidationException $ex) {
+            // Form cannot be validated
+            $error_msg = $this->createStandardFormValidationErrorMessage($ex);
+        } catch (\Exception $ex) {
+            // Any other error
+            $error_msg = $ex->getMessage();
+        }
+
+        $this->setupFormErrorContext($this->getTranslator()->trans('%obj modification', ['%obj' => 'taxrule']), $error_msg, $changeForm, $ex);
+
+        // At this point, the form has errors, and should be redisplayed.
+        return $this->renderEditionTemplate();
+    }
+}

--- a/Controller/Admin/SaleController.php
+++ b/Controller/Admin/SaleController.php
@@ -1,0 +1,397 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\Sale\SaleActiveStatusCheckEvent;
+use Thelia\Core\Event\Sale\SaleClearStatusEvent;
+use Thelia\Core\Event\Sale\SaleCreateEvent;
+use Thelia\Core\Event\Sale\SaleDeleteEvent;
+use Thelia\Core\Event\Sale\SaleToggleActivityEvent;
+use Thelia\Core\Event\Sale\SaleUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Form\Sale\SaleModificationForm;
+use Thelia\Model\Sale;
+use Thelia\Model\SaleProduct;
+use Thelia\Model\SaleQuery;
+
+/**
+ * Class SaleController.
+ *
+ * @author  Franck Allimant <franck@cqfdev.fr>
+ */
+class SaleController extends AbstractCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'sale',
+            'start-date',
+            'order',
+            AdminResources::SALES,
+            TheliaEvents::SALE_CREATE,
+            TheliaEvents::SALE_UPDATE,
+            TheliaEvents::SALE_DELETE,
+        );
+    }
+
+    /**
+     * Return the creation form for this object.
+     */
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::SALE_CREATION);
+    }
+
+    /**
+     * Return the update form for this object.
+     */
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::SALE_MODIFICATION);
+    }
+
+    /**
+     * Hydrate the update form for this object, before passing it to the update template.
+     *
+     * @return SaleModificationForm
+     */
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        if (!$object instanceof Sale) {
+            throw new \InvalidArgumentException(\sprintf('The object must be an instance of %s', Sale::class));
+        }
+        // Find all categories of the selected products
+        $saleProducts = $object->getSaleProductList();
+        $categories = [];
+        $products = [];
+
+        /** @var SaleProduct $saleProduct */
+        foreach ($saleProducts as $saleProduct) {
+            $categories[] = $saleProduct->getProduct()->getDefaultCategoryId();
+            $products[$saleProduct->getProduct()->getId()] = $saleProduct->getProduct()->getId();
+        }
+
+        $dateFormat = SaleModificationForm::PHP_DATE_FORMAT;
+
+        // Transform the selected attributes list (product_id => array of attributes av id) into
+        // product_id => comma separated list of attributes av id, to math the collection type (text)
+        $saleProductsAttributesAvs = $object->getSaleProductsAttributeList();
+
+        $product_attributes = [];
+
+        foreach ($saleProductsAttributesAvs as $productId => $saleProductsAttributesAv) {
+            $product_attributes[$productId] = implode(',', $saleProductsAttributesAv);
+        }
+
+        // Prepare the data that will hydrate the form
+        $data = [
+            'id' => $object->getId(),
+            'locale' => $object->getLocale(),
+            'title' => $object->getTitle(),
+            'label' => $object->getSaleLabel(),
+            'chapo' => $object->getChapo(),
+            'description' => $object->getDescription(),
+            'postscriptum' => $object->getPostscriptum(),
+            'active' => $object->getActive(),
+            'display_initial_price' => $object->getDisplayInitialPrice(),
+            'start_date' => $object->getStartDate($dateFormat),
+            'end_date' => $object->getEndDate($dateFormat),
+            'price_offset_type' => $object->getPriceOffsetType(),
+            'price_offset' => $object->getPriceOffsets(),
+            'categories' => $categories,
+            'products' => $products,
+            'product_attributes' => $product_attributes,
+        ];
+
+        // Setup the object form
+        return $this->createForm(AdminForm::SALE_MODIFICATION, FormType::class, $data);
+    }
+
+    /**
+     * Creates the creation event with the provided form data.
+     */
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $saleCreateEvent = new SaleCreateEvent();
+
+        $saleCreateEvent
+            ->setLocale($formData['locale'])
+            ->setTitle($formData['title'])
+            ->setSaleLabel($formData['label']);
+
+        return $saleCreateEvent;
+    }
+
+    /**
+     * Creates the update event with the provided form data.
+     */
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        // Build the product attributes array
+        $productAttributes = [];
+
+        foreach ($formData['product_attributes'] as $productId => $attributeAvIdList) {
+            if (!empty($attributeAvIdList)) {
+                $productAttributes[$productId] = explode(',', (string) $attributeAvIdList);
+            }
+        }
+
+        $saleUpdateEvent = new SaleUpdateEvent($formData['id']);
+
+        $saleUpdateEvent
+            ->setStartDate($formData['start_date'])
+            ->setEndDate($formData['end_date'])
+            ->setActive($formData['active'])
+            ->setDisplayInitialPrice($formData['display_initial_price'])
+            ->setPriceOffsetType($formData['price_offset_type'])
+            ->setPriceOffsets($formData['price_offset'])
+            ->setProducts($formData['products'])
+            ->setProductAttributes($productAttributes)
+            ->setLocale($formData['locale'])
+            ->setTitle($formData['title'])
+            ->setSaleLabel($formData['label'])
+            ->setChapo($formData['chapo'] ?? '')
+            ->setDescription($formData['description'] ?? '')
+            ->setPostscriptum($formData['postscriptum'] ?? '');
+
+        return $saleUpdateEvent;
+    }
+
+    /**
+     * Creates the delete event with the provided form data.
+     */
+    protected function getDeleteEvent(): SaleDeleteEvent
+    {
+        return new SaleDeleteEvent($this->getRequest()->get('sale_id'));
+    }
+
+    /**
+     * Return true if the event contains the object, e.g. the action has updated the object in the event.
+     */
+    protected function eventContainsObject(Event $event): bool
+    {
+        return $event->hasSale();
+    }
+
+    /**
+     * Get the created object from an event.
+     *
+     * @param $event \Thelia\Core\Event\Sale\SaleEvent
+     *
+     * @return Sale|null
+     */
+    protected function getObjectFromEvent($event): mixed
+    {
+        return $event->getSale();
+    }
+
+    /**
+     * Load an existing object from the database.
+     *
+     * @return Sale
+     */
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        $sale = SaleQuery::create()
+            ->findOneById($this->getRequest()->get('sale_id', 0));
+
+        if (null !== $sale) {
+            $sale->setLocale($this->getCurrentEditionLocale());
+        }
+
+        return $sale;
+    }
+
+    /**
+     * Returns the object label form the object event (name, title, etc.).
+     *
+     * @param Sale $object
+     *
+     * @return string sale title
+     */
+    protected function getObjectLabel(ActiveRecordInterface $object): ?string
+    {
+        return $object->getTitle();
+    }
+
+    /**
+     * Returns the object ID from the object.
+     *
+     * @param Sale $object
+     *
+     * @return int sale id
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    /**
+     * Render the main list template.
+     */
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        $this->getListOrderFromSession('sale', 'order', 'start-date');
+
+        return $this->render('sales', [
+            'order' => $currentOrder,
+        ]);
+    }
+
+    protected function getEditionArguments(): array
+    {
+        return [
+            'sale_id' => $this->getRequest()->get('sale_id', 0),
+        ];
+    }
+
+    /**
+     * Render the edition template.
+     */
+    protected function renderEditionTemplate(): Response
+    {
+        return $this->render('sale-edit', $this->getEditionArguments());
+    }
+
+    /**
+     * Redirect to the edition template.
+     */
+    protected function redirectToEditionTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute('admin.sale.update', [], $this->getEditionArguments());
+    }
+
+    /**
+     * Redirect to the list template.
+     */
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute('admin.sale.default');
+    }
+
+    /**
+     * Toggle activity status of the sale.
+     */
+    public function toggleActivity(EventDispatcherInterface $eventDispatcher): Response
+    {
+        if (($response = $this->checkAuth(AdminResources::SALES, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        try {
+            $eventDispatcher->dispatch(
+                new SaleToggleActivityEvent(
+                    $this->getExistingObject(),
+                ),
+                TheliaEvents::SALE_TOGGLE_ACTIVITY,
+            );
+        } catch (\Exception $exception) {
+            // Any error
+            return $this->errorPage($exception);
+        }
+
+        return $this->nullResponse();
+    }
+
+    public function updateProductList()
+    {
+        if (($response = $this->checkAuth(AdminResources::SALES, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        // Build the list of categories
+        $categories = '';
+
+        foreach ($this->getRequest()->get('categories', []) as $category_id) {
+            $categories .= $category_id.',';
+        }
+
+        return $this->render(
+            'ajax/sale-edit-products',
+            [
+                'sale_id' => $this->getRequest()->get('sale_id'),
+                'category_list' => rtrim($categories, ','),
+                'product_list' => $this->getRequest()->get('products', []),
+            ],
+        );
+    }
+
+    public function updateProductAttributes()
+    {
+        if (($response = $this->checkAuth(AdminResources::SALES, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $selectedAttributesAvId = explode(',', (string) $this->getRequest()->get('selected_attributes_av_id', []));
+
+        $productId = $this->getRequest()->get('product_id');
+
+        return $this->render(
+            'ajax/sale-edit-product-attributes',
+            [
+                'product_id' => $productId,
+                'selected_attributes_av_id' => $selectedAttributesAvId,
+            ],
+        );
+    }
+
+    public function resetSaleStatus(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth(AdminResources::SALES, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        try {
+            $eventDispatcher->dispatch(
+                new SaleClearStatusEvent(),
+                TheliaEvents::SALE_CLEAR_SALE_STATUS,
+            );
+        } catch (\Exception $exception) {
+            // Any error
+            return $this->errorPage($exception);
+        }
+
+        return $this->redirectToListTemplate();
+    }
+
+    public function checkSalesActivationStatus(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        // We do not check auth, as the related route may be invoked from a cron
+        try {
+            $eventDispatcher->dispatch(
+                new SaleActiveStatusCheckEvent(),
+                TheliaEvents::CHECK_SALE_ACTIVATION_EVENT,
+            );
+        } catch (\Exception $exception) {
+            // Any error
+            return $this->errorPage($exception);
+        }
+
+        return $this->redirectToListTemplate();
+    }
+}

--- a/Controller/Admin/SessionController.php
+++ b/Controller/Admin/SessionController.php
@@ -1,0 +1,331 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\Administrator\AdministratorEvent;
+use Thelia\Core\Event\Administrator\AdministratorUpdatePasswordEvent;
+use Thelia\Core\Event\DefaultActionEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\Authentication\AdminUsernamePasswordFormAuthenticator;
+use Thelia\Core\Security\Exception\AuthenticationException;
+use Thelia\Core\Security\User\UserInterface;
+use Thelia\Domain\Localization\Service\LangService;
+use Thelia\Form\AdminLogin;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Form\Exception\FormValidationException;
+use Thelia\Model\Admin;
+use Thelia\Model\AdminLog;
+use Thelia\Model\AdminQuery;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\Lang;
+use Thelia\Model\LangQuery;
+use Thelia\Tools\RememberMeTrait;
+use Thelia\Tools\URL;
+
+class SessionController extends BaseAdminController
+{
+    use RememberMeTrait;
+
+    public const ADMIN_TOKEN_SESSION_VAR_NAME = 'thelia_admin_password_renew_token';
+
+    public function __construct(
+        private readonly LangService $langService,
+    ) {
+    }
+
+    protected function checkAdminLoggedIn(): ?RedirectResponse
+    {
+        // Check if user is already authenticate
+        if ($this->getSecurityContext()->hasAdminUser()) {
+            // Redirect to the homepage
+            return new RedirectResponse(URL::getInstance()->absoluteUrl('/admin'));
+        }
+
+        return null;
+    }
+
+    protected function checkPasswordRecoveryEnabled(): ?Response
+    {
+        // Check if user is already authenticate
+        if (!ConfigQuery::read('enable_lost_admin_password_recovery', false)) {
+            AdminLog::append(
+                'admin',
+                'ADMIN_CREATE_PASSWORD',
+                'Lost password recovery function invoked',
+                $this->getRequest(),
+            );
+
+            // Redirect to the error page
+            return $this->errorPage($this->getTranslator()->trans('The lost admin password recovery feature is disabled.'), 403);
+        }
+
+        return null;
+    }
+
+    public function showLoginAction(): RedirectResponse|Response
+    {
+        if (($response = $this->checkAdminLoggedIn()) instanceof RedirectResponse) {
+            return $response;
+        }
+
+        return $this->render('login');
+    }
+
+    public function showLostPasswordAction(): Response|RedirectResponse
+    {
+        if ((($response = $this->checkPasswordRecoveryEnabled()) instanceof Response) || (($response = $this->checkAdminLoggedIn()) instanceof RedirectResponse)) {
+            return $response;
+        }
+
+        return $this->render('lost-password');
+    }
+
+    public function passwordCreateRequestAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse|null
+    {
+        if ((($response = $this->checkPasswordRecoveryEnabled()) instanceof Response) || (($response = $this->checkAdminLoggedIn()) instanceof RedirectResponse)) {
+            return $response;
+        }
+
+        $adminLostPasswordForm = $this->createForm(AdminForm::ADMIN_LOST_PASSWORD);
+
+        try {
+            $form = $this->validateForm($adminLostPasswordForm, 'post');
+
+            $data = $form->getData();
+
+            // Check if user exists
+            if (null === $admin = AdminQuery::create()->findOneByEmail($data['username_or_email'])) {
+                $admin = AdminQuery::create()->findOneByLogin($data['username_or_email']);
+            }
+
+            if (null === $admin) {
+                throw new \Exception($this->getTranslator()->trans('Invalid username or email.'));
+            }
+
+            $email = $admin->getEmail();
+
+            if (empty($email)) {
+                throw new \Exception($this->getTranslator()->trans('Sorry, no email defined for this administrator.'));
+            }
+
+            $eventDispatcher->dispatch(new AdministratorEvent($admin), TheliaEvents::ADMINISTRATOR_CREATEPASSWORD);
+
+            // Redirect to the success URL
+            return $this->generateSuccessRedirect($adminLostPasswordForm);
+        } catch (FormValidationException $ex) {
+            // Validation problem
+            $message = $this->createStandardFormValidationErrorMessage($ex);
+        } catch (\Exception $ex) {
+            // Log failure
+            AdminLog::append('admin', 'ADMIN_LOST_PASSWORD', $ex->getMessage(), $this->getRequest());
+
+            $message = $ex->getMessage();
+        }
+
+        $this->setupFormErrorContext('Admin password create request', $message, $adminLostPasswordForm, $ex);
+
+        return $this->render('lost-password');
+    }
+
+    public function passwordCreateRequestSuccessAction(): Response|RedirectResponse
+    {
+        if ((($response = $this->checkPasswordRecoveryEnabled()) instanceof Response) || (($response = $this->checkAdminLoggedIn()) instanceof RedirectResponse)) {
+            return $response;
+        }
+
+        return $this->render('lost-password', ['create_request_success' => true]);
+    }
+
+    public function displayCreateFormAction($token): Response|RedirectResponse
+    {
+        if ((($response = $this->checkPasswordRecoveryEnabled()) instanceof Response) || (($response = $this->checkAdminLoggedIn()) instanceof RedirectResponse)) {
+            return $response;
+        }
+
+        // Check the token
+        if (null === $admin = AdminQuery::create()->findOneByPasswordRenewToken($token)) {
+            return $this->render(
+                'lost-password',
+                ['token_error' => true],
+            );
+        }
+
+        $this->getSession()->set(self::ADMIN_TOKEN_SESSION_VAR_NAME, $token);
+
+        return $this->render('create-password');
+    }
+
+    public function passwordCreatedAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse|null
+    {
+        if ((($response = $this->checkPasswordRecoveryEnabled()) instanceof Response) || (($response = $this->checkAdminLoggedIn()) instanceof RedirectResponse)) {
+            return $response;
+        }
+
+        $adminCreatePasswordForm = $this->createForm(AdminForm::ADMIN_CREATE_PASSWORD);
+
+        try {
+            $form = $this->validateForm($adminCreatePasswordForm, 'post');
+
+            $data = $form->getData();
+
+            $token = $this->getSession()->get(self::ADMIN_TOKEN_SESSION_VAR_NAME);
+
+            if (empty($token) || null === $admin = AdminQuery::create()->findOneByPasswordRenewToken($token)) {
+                throw new \Exception($this->getTranslator()->trans('An invalid token was provided, your password cannot be changed'));
+            }
+
+            $event = new AdministratorUpdatePasswordEvent($admin);
+            $event->setPassword($data['password']);
+
+            $eventDispatcher->dispatch($event, TheliaEvents::ADMINISTRATOR_UPDATEPASSWORD);
+
+            $this->getSession()->set(self::ADMIN_TOKEN_SESSION_VAR_NAME, null);
+
+            return $this->generateSuccessRedirect($adminCreatePasswordForm);
+        } catch (FormValidationException $ex) {
+            // Validation problem
+            $message = $this->createStandardFormValidationErrorMessage($ex);
+        } catch (\Exception $ex) {
+            // Log authentication failure
+            AdminLog::append('admin', 'ADMIN_CREATE_PASSWORD', $ex->getMessage(), $this->getRequest());
+
+            $message = $ex->getMessage();
+        }
+
+        $this->setupFormErrorContext('Login process', $message, $adminCreatePasswordForm, $ex);
+
+        return $this->render('create-password');
+    }
+
+    public function passwordCreatedSuccessAction(): Response|RedirectResponse
+    {
+        if ((($response = $this->checkPasswordRecoveryEnabled()) instanceof Response) || (($response = $this->checkAdminLoggedIn()) instanceof RedirectResponse)) {
+            return $response;
+        }
+
+        return $this->render('create-password-success');
+    }
+
+    public function checkLogoutAction(EventDispatcherInterface $eventDispatcher): RedirectResponse
+    {
+        $eventDispatcher->dispatch(new DefaultActionEvent(), TheliaEvents::ADMIN_LOGOUT);
+
+        $this->getSecurityContext()->clearAdminUser();
+
+        // Clear the remember me cookie, if any
+        $this->clearRememberMeCookie($this->getRememberMeCookieName());
+
+        // Go back to login page.
+        return $this->generateRedirectFromRoute('admin.login');
+    }
+
+    public function checkLoginAction(EventDispatcherInterface $eventDispatcher): RedirectResponse|Response|null
+    {
+        $request = $this->getRequest();
+
+        /** @var AdminLogin $adminLoginForm */
+        $adminLoginForm = $this->createForm('thelia.admin.login');
+
+        $authenticator = null;
+
+        try {
+            $form = $this->validateForm($adminLoginForm, 'post');
+
+            $authenticator = new AdminUsernamePasswordFormAuthenticator($request, $adminLoginForm);
+
+            /** @var Admin $user */
+            $user = $authenticator->getAuthentifiedUser();
+
+            // Success -> store user in security context
+            $this->getSecurityContext()->setAdminUser($user);
+
+            // Log authentication success
+            AdminLog::append('admin', 'LOGIN', 'Authentication successful', $request, $user, false);
+
+            $this->applyUserLocale($user);
+
+            if ((int) $form->get('remember_me')->getData() > 0) {
+                // If a remember me field if present and set in the form, create
+                // the cookie thant store "remember me" information
+                $this->createRememberMeCookie(
+                    $user,
+                    $this->getRememberMeCookieName(),
+                    $this->getRememberMeCookieExpiration(),
+                );
+            }
+
+            $eventDispatcher->dispatch(new DefaultActionEvent(), TheliaEvents::ADMIN_LOGIN);
+
+            // Check if we have to ask the user to set its address email.
+            // This is the case if Thelia has been updated from a pre 2.3.0 version
+            if (!str_contains((string) $user->getEmail(), '@')) {
+                return $this->generateRedirectFromRoute('admin.set-email-address');
+            }
+
+            // Redirect to the success URL, passing the cookie if one exists.
+            return $this->generateSuccessRedirect($adminLoginForm);
+        } catch (FormValidationException $ex) {
+            // Validation problem
+            $message = $this->createStandardFormValidationErrorMessage($ex);
+        } catch (AuthenticationException $ex) {
+            $username = $authenticator instanceof AdminUsernamePasswordFormAuthenticator ? $authenticator->getUsername() : 'unknown';
+            // Log authentication failure
+            AdminLog::append('admin', 'LOGIN', \sprintf("Authentication failure for username '%s'", $username), $request);
+
+            $message = $this->getTranslator()->trans('Login failed. Please check your username and password.');
+        } catch (\Exception $ex) {
+            // Log authentication failure
+            AdminLog::append('admin', 'LOGIN', \sprintf('Undefined error: %s', $ex->getMessage()), $request);
+
+            $message = $this->getTranslator()->trans(
+                'Unable to process your request. Please try again (%err).',
+                ['%err' => $ex->getMessage()],
+            );
+        }
+
+        $this->setupFormErrorContext('Login process', $message, $adminLoginForm, $ex);
+
+        // Display the login form again
+        return $this->render('login');
+    }
+
+    /**
+     * Save user locale preference in session.
+     */
+    protected function applyUserLocale(UserInterface $user): void
+    {
+        // Set the current language according to locale preference
+        $locale = $user->getLocale();
+
+        if (null === $lang = LangQuery::create()->filterByActive(true)->findOneByLocale($locale)) {
+            $lang = Lang::getDefaultLanguage();
+        }
+
+        $this->langService->setLang($lang);
+    }
+
+    protected function getRememberMeCookieName()
+    {
+        return ConfigQuery::read('admin_remember_me_cookie_name', 'armcn');
+    }
+
+    protected function getRememberMeCookieExpiration()
+    {
+        return ConfigQuery::read('admin_remember_me_cookie_expiration', 2592000 /* 1 month */);
+    }
+}

--- a/Controller/Admin/ShippingZoneController.php
+++ b/Controller/Admin/ShippingZoneController.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\ShippingZone\ShippingZoneAddAreaEvent;
+use Thelia\Core\Event\ShippingZone\ShippingZoneRemoveAreaEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Exception\FormValidationException;
+use Thelia\Form\ShippingZone\ShippingZoneRemoveArea;
+
+/**
+ * Class ShippingZoneController.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class ShippingZoneController extends BaseAdminController
+{
+    public $objectName = 'areaDeliveryModule';
+
+    public function indexAction()
+    {
+        if (($response = $this->checkAuth(AdminResources::SHIPPING_ZONE, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        return $this->render('shipping-zones', ['display_shipping_zone' => 20]);
+    }
+
+    public function updateAction($delivery_module_id)
+    {
+        if (($response = $this->checkAuth(AdminResources::SHIPPING_ZONE, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        return $this->render(
+            'shipping-zones-edit',
+            ['delivery_module_id' => $delivery_module_id],
+        );
+    }
+
+    /**
+     * @return mixed|Response
+     */
+    public function addArea(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse|null
+    {
+        if (($response = $this->checkAuth(AdminResources::SHIPPING_ZONE, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $shippingAreaForm = $this->createForm('thelia.shipping_zone_area');
+        $error_msg = null;
+
+        try {
+            $form = $this->validateForm($shippingAreaForm);
+
+            $event = new ShippingZoneAddAreaEvent(
+                $form->get('area_id')->getData(),
+                $form->get('shipping_zone_id')->getData(),
+            );
+
+            $eventDispatcher->dispatch($event, TheliaEvents::SHIPPING_ZONE_ADD_AREA);
+
+            // Redirect to the success URL
+            return $this->generateSuccessRedirect($shippingAreaForm);
+        } catch (FormValidationException $ex) {
+            // Form cannot be validated
+            $error_msg = $this->createStandardFormValidationErrorMessage($ex);
+        } catch (\Exception $ex) {
+            // Any other error
+            $error_msg = $ex->getMessage();
+        }
+
+        $this->setupFormErrorContext(
+            $this->getTranslator()->trans('%obj modification', ['%obj' => $this->objectName]),
+            $error_msg,
+            $shippingAreaForm,
+        );
+
+        // At this point, the form has errors, and should be redisplayed.
+        return $this->renderEditionTemplate();
+    }
+
+    public function removeArea(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse|null
+    {
+        if (($response = $this->checkAuth(AdminResources::SHIPPING_ZONE, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $shippingAreaForm = $this->createForm(ShippingZoneRemoveArea::class);
+        $error_msg = null;
+
+        try {
+            $form = $this->validateForm($shippingAreaForm);
+
+            $event = new ShippingZoneRemoveAreaEvent(
+                $form->get('area_id')->getData(),
+                $form->get('shipping_zone_id')->getData(),
+            );
+
+            $eventDispatcher->dispatch($event, TheliaEvents::SHIPPING_ZONE_REMOVE_AREA);
+
+            // Redirect to the success URL
+            return $this->generateSuccessRedirect($shippingAreaForm);
+        } catch (FormValidationException $ex) {
+            // Form cannot be validated
+            $error_msg = $this->createStandardFormValidationErrorMessage($ex);
+        } catch (\Exception $ex) {
+            // Any other error
+            $error_msg = $ex->getMessage();
+        }
+
+        $this->setupFormErrorContext(
+            $this->getTranslator()->trans('%obj modification', ['%obj' => $this->objectName]),
+            $error_msg,
+            $shippingAreaForm,
+        );
+
+        // At this point, the form has errors, and should be redisplayed.
+        return $this->renderEditionTemplate();
+    }
+
+    /**
+     * Render the edition template.
+     */
+    protected function renderEditionTemplate(): Response
+    {
+        return $this->render(
+            'shipping-zones-edit',
+            ['delivery_module_id' => $this->getDeliveryModuleId()],
+        );
+    }
+
+    protected function getDeliveryModuleId(): mixed
+    {
+        return $this->getRequest()->get('delivery_module_id', 0);
+    }
+}

--- a/Controller/Admin/StateController.php
+++ b/Controller/Admin/StateController.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\Event;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\State\StateCreateEvent;
+use Thelia\Core\Event\State\StateDeleteEvent;
+use Thelia\Core\Event\State\StateToggleVisibilityEvent;
+use Thelia\Core\Event\State\StateUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Model\State;
+use Thelia\Model\StateQuery;
+
+/**
+ * Class StateController.
+ *
+ * @author Julien Chanséaume <manu@raynaud.io>
+ */
+class StateController extends AbstractCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'state',
+            'manual',
+            'state_order',
+            AdminResources::STATE,
+            TheliaEvents::STATE_CREATE,
+            TheliaEvents::STATE_UPDATE,
+            TheliaEvents::STATE_DELETE,
+            TheliaEvents::STATE_TOGGLE_VISIBILITY,
+        );
+    }
+
+    /**
+     * Return the creation form for this object.
+     */
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::STATE_CREATION);
+    }
+
+    /**
+     * Return the update form for this object.
+     */
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::STATE_MODIFICATION);
+    }
+
+    /**
+     * Hydrate the update form for this object, before passing it to the update template.
+     *
+     * @param State $object
+     */
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        $data = [
+            'id' => (int) $object->getId(),
+            'locale' => $object->getLocale(),
+            'visible' => (bool) $object->getVisible(),
+            'country_id' => $object->getCountryId(),
+            'title' => $object->getTitle(),
+            'isocode' => $object->getIsocode(),
+        ];
+
+        return $this->createForm(AdminForm::STATE_MODIFICATION, FormType::class, $data);
+    }
+
+    /**
+     * Creates the creation event with the provided form data.
+     */
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $event = new StateCreateEvent();
+
+        return $this->hydrateEvent($event, $formData);
+    }
+
+    /**
+     * Creates the update event with the provided form data.
+     */
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $event = new StateUpdateEvent((int) $formData['id']);
+
+        return $this->hydrateEvent($event, $formData);
+    }
+
+    protected function hydrateEvent($event, array $formData)
+    {
+        $event
+            ->setLocale($formData['locale'])
+            ->setVisible($formData['visible'])
+            ->setCountry($formData['country_id'])
+            ->setTitle($formData['title'])
+            ->setIsocode($formData['isocode']);
+
+        return $event;
+    }
+
+    /**
+     * Creates the delete event with the provided form data.
+     */
+    protected function getDeleteEvent(): StateDeleteEvent
+    {
+        return new StateDeleteEvent((int) $this->getRequest()->get('state_id'));
+    }
+
+    /**
+     * Return true if the event contains the object, e.g. the action has updated the object in the event.
+     */
+    protected function eventContainsObject(Event $event): bool
+    {
+        return $event->hasState();
+    }
+
+    /**
+     * Get the created object from an event.
+     */
+    protected function getObjectFromEvent($event): mixed
+    {
+        return $event->getState();
+    }
+
+    /**
+     * Load an existing object from the database.
+     */
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        $state = StateQuery::create()
+            ->findPk($this->getRequest()->get('state_id', 0));
+
+        if (null !== $state) {
+            $state->setLocale($this->getCurrentEditionLocale());
+        }
+
+        return $state;
+    }
+
+    /**
+     * Returns the object label form the object event (name, title, etc.).
+     *
+     * @param State $object
+     */
+    protected function getObjectLabel(ActiveRecordInterface $object): ?string
+    {
+        return $object->getTitle();
+    }
+
+    /**
+     * Returns the object ID from the object.
+     *
+     * @param State $object
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    /**
+     * Render the main list template.
+     */
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        return $this->render(
+            'states',
+            [
+                'page' => $this->getRequest()->get('page', 1),
+                'page_limit' => $this->getRequest()->get('page_limit', 50),
+                'page_order' => $this->getRequest()->get('page_order', 1),
+            ],
+        );
+    }
+
+    /**
+     * Render the edition template.
+     */
+    protected function renderEditionTemplate(): Response
+    {
+        return $this->render('state-edit', $this->getEditionArgument());
+    }
+
+    protected function getEditionArgument(): array
+    {
+        return [
+            'state_id' => (int) $this->getRequest()->get('state_id', 0),
+            'page' => $this->getRequest()->get('page', 1),
+            'page_order' => $this->getRequest()->get('page_order', 1),
+        ];
+    }
+
+    /**
+     * Redirect to the edition template.
+     */
+    protected function redirectToEditionTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.configuration.states.update',
+            [],
+            [
+                'state_id' => (int) $this->getRequest()->get('state_id', 0),
+            ],
+        );
+    }
+
+    /**
+     * Redirect to the list template.
+     */
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute('admin.configuration.states.default');
+    }
+
+    /**
+     * @return StateToggleVisibilityEvent|void
+     */
+    protected function createToggleVisibilityEvent(): StateToggleVisibilityEvent
+    {
+        return new StateToggleVisibilityEvent($this->getExistingObject());
+    }
+}

--- a/Controller/Admin/SystemLogController.php
+++ b/Controller/Admin/SystemLogController.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Log\Tlog;
+use Thelia\Model\ConfigQuery;
+
+/**
+ * Class LangController.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class SystemLogController extends BaseAdminController
+{
+    protected function renderTemplate(): Response
+    {
+        $destinations = [];
+
+        $destination_directories = Tlog::getInstance()->getDestinationsDirectories();
+
+        foreach ($destination_directories as $dir) {
+            $this->loadDefinedDestinations($dir, $destinations);
+        }
+
+        $active_destinations = explode(';', (string) ConfigQuery::read(Tlog::VAR_DESTINATIONS, Tlog::DEFAUT_DESTINATIONS));
+
+        return $this->render(
+            'system-logs',
+            [
+                'ip_address' => $this->getRequest()->getClientIp(),
+                'destinations' => $destinations,
+                'active_destinations' => $active_destinations,
+            ],
+        );
+    }
+
+    protected function loadDefinedDestinations($directory, &$destinations): void
+    {
+        try {
+            foreach (new \DirectoryIterator($directory) as $fileInfo) {
+                if ($fileInfo->isDot()) {
+                    continue;
+                }
+
+                $matches = [];
+
+                if (preg_match('/([^\\.]+)\\.php/', $fileInfo->getFilename(), $matches)) {
+                    $classname = $matches[1];
+
+                    if (!isset($destinations[$classname])) {
+                        $full_class_name = 'Thelia\\Log\\Destination\\'.$classname;
+
+                        $destinations[$classname] = new $full_class_name();
+                    }
+                }
+            }
+        } catch (\UnexpectedValueException) {
+            // Directory does no exists -> Nothing to do
+        }
+    }
+
+    public function defaultAction(): mixed
+    {
+        if (($response = $this->checkAuth(AdminResources::SYSTEM_LOG, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        // Hydrate the general configuration form
+        $systemLogForm = $this->createForm(AdminForm::SYSTEM_LOG_CONFIGURATION, FormType::class, [
+            'level' => ConfigQuery::read(Tlog::VAR_LEVEL, Tlog::DEFAULT_LEVEL),
+            'format' => ConfigQuery::read(Tlog::VAR_PREFIXE, Tlog::DEFAUT_PREFIXE),
+            'show_redirections' => ConfigQuery::read(Tlog::VAR_SHOW_REDIRECT, Tlog::DEFAUT_SHOW_REDIRECT),
+            'files' => ConfigQuery::read(Tlog::VAR_FILES, Tlog::DEFAUT_FILES),
+            'ip_addresses' => ConfigQuery::read(Tlog::VAR_IP, Tlog::DEFAUT_IP),
+        ]);
+
+        $this->getParserContext()->addForm($systemLogForm);
+
+        return $this->renderTemplate();
+    }
+
+    public function saveAction(): Response|RedirectResponse
+    {
+        if (($response = $this->checkAuth(AdminResources::SYSTEM_LOG, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $systemLogForm = $this->createForm(AdminForm::SYSTEM_LOG_CONFIGURATION);
+
+        try {
+            $form = $this->validateForm($systemLogForm);
+
+            $data = $form->getData();
+
+            ConfigQuery::write(Tlog::VAR_LEVEL, $data['level']);
+            ConfigQuery::write(Tlog::VAR_PREFIXE, $data['format']);
+            ConfigQuery::write(Tlog::VAR_SHOW_REDIRECT, $data['show_redirections']);
+            ConfigQuery::write(Tlog::VAR_FILES, $data['files']);
+            ConfigQuery::write(Tlog::VAR_IP, $data['ip_addresses'] ?? '');
+
+            // Save destination configuration
+            $destinations = $this->getRequest()->get('destinations');
+            $configs = $this->getRequest()->get('config');
+
+            $active_destinations = [];
+
+            foreach ($destinations as $classname => $destination) {
+                if (isset($destination['active'])) {
+                    $active_destinations[] = $destination['classname'];
+                }
+
+                if (isset($configs[$classname])) {
+                    // Update destinations configuration
+                    foreach ($configs[$classname] as $var => $value) {
+                        ConfigQuery::write($var, $value, true, true);
+                    }
+                }
+            }
+
+            // Update active destinations list
+            ConfigQuery::write(Tlog::VAR_DESTINATIONS, implode(';', $active_destinations));
+
+            $this->adminLogAppend(
+                AdminResources::SYSTEM_LOG,
+                AccessManager::UPDATE,
+                'System log configuration changed',
+            );
+
+            $response = $this->generateRedirectFromRoute('admin.configuration.system-logs.default');
+        } catch (\Exception $exception) {
+            $error_msg = $exception->getMessage();
+
+            $this->setupFormErrorContext(
+                $this->getTranslator()->trans('System log configuration failed.'),
+                $error_msg,
+                $systemLogForm,
+                $exception,
+            );
+
+            $response = $this->renderTemplate();
+        }
+
+        return $response;
+    }
+}

--- a/Controller/Admin/TaxController.php
+++ b/Controller/Admin/TaxController.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Propel\Runtime\Event\ActiveRecordEvent;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\Tax\TaxEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Model\Tax;
+use Thelia\Model\TaxQuery;
+
+class TaxController extends AbstractCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'tax',
+            'manual',
+            'order',
+            AdminResources::TAX,
+            TheliaEvents::TAX_CREATE,
+            TheliaEvents::TAX_UPDATE,
+            TheliaEvents::TAX_DELETE,
+        );
+    }
+
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::TAX_CREATION);
+    }
+
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::TAX_MODIFICATION);
+    }
+
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $event = new TaxEvent();
+
+        $event->setLocale($formData['locale']);
+        $event->setTitle($formData['title']);
+        $event->setDescription($formData['description']);
+        $event->setType($formData['type']);
+        $event->setRequirements($this->getRequirements($formData['type'], $formData));
+
+        return $event;
+    }
+
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $event = new TaxEvent();
+
+        $event->setLocale($formData['locale']);
+        $event->setId($formData['id']);
+        $event->setTitle($formData['title']);
+        $event->setDescription($formData['description']);
+        $event->setType($formData['type']);
+        $event->setRequirements($this->getRequirements($formData['type'], $formData));
+
+        return $event;
+    }
+
+    protected function getDeleteEvent(): TaxEvent
+    {
+        $event = new TaxEvent();
+
+        $event->setId(
+            $this->getRequest()->get('tax_id', 0),
+        );
+
+        return $event;
+    }
+
+    protected function eventContainsObject($event): bool
+    {
+        return $event->hasTax();
+    }
+
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        $data = [
+            'id' => $object->getId(),
+            'locale' => $object->getLocale(),
+            'title' => $object->getTitle(),
+            'description' => $object->getDescription(),
+            'type' => Tax::escapeTypeName($object->getType()),
+        ];
+
+        // Setup the object form
+        return $this->createForm(
+            AdminForm::TAX_MODIFICATION,
+            FormType::class,
+            $data,
+        );
+    }
+
+    protected function getObjectFromEvent($event): mixed
+    {
+        return $event->hasTax() ? $event->getTax() : null;
+    }
+
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        $tax = TaxQuery::create()
+            ->findOneById($this->getRequest()->get('tax_id', 0));
+
+        if (null !== $tax) {
+            $tax->setLocale($this->getCurrentEditionLocale());
+        }
+
+        return $tax;
+    }
+
+    /**
+     * @param Tax $object
+     */
+    protected function getObjectLabel(ActiveRecordInterface $object): ?string
+    {
+        return $object->getTitle();
+    }
+
+    /**
+     * @param Tax $object
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    protected function getViewArguments(): array
+    {
+        return [];
+    }
+
+    protected function getRouteArguments($tax_id = null): array
+    {
+        return [
+            'tax_id' => $tax_id ?? $this->getRequest()->get('tax_id'),
+        ];
+    }
+
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        return $this->render(
+            'taxes-rules',
+        );
+    }
+
+    protected function renderEditionTemplate(): Response
+    {
+        // We always return to the feature edition form
+        return $this->render('tax-edit', array_merge($this->getViewArguments(), $this->getRouteArguments()));
+    }
+
+    protected function redirectToEditionTemplate($request = null, $country = null): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.configuration.taxes.update',
+            $this->getViewArguments(),
+            $this->getRouteArguments(),
+        );
+    }
+
+    /**
+     * Put in this method post object creation processing if required.
+     */
+    protected function performAdditionalCreateAction(ActionEvent|ActiveRecordEvent|null $createEvent): ?Response
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.configuration.taxes.update',
+            $this->getViewArguments(),
+            $this->getRouteArguments($createEvent?->getTax()?->getId()),
+        );
+    }
+
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute('admin.configuration.taxes-rules.list');
+    }
+
+    /**
+     * @return mixed[]
+     */
+    protected function getRequirements($type, $formData): array
+    {
+        $requirements = [];
+
+        foreach ($formData as $data => $value) {
+            if (!strstr((string) $data, ':')) {
+                continue;
+            }
+
+            $couple = explode(':', (string) $data);
+
+            if (2 === \count($couple) && $couple[0] === $type) {
+                $requirements[$couple[1]] = $value;
+            }
+        }
+
+        return $requirements;
+    }
+}

--- a/Controller/Admin/TaxRuleController.php
+++ b/Controller/Admin/TaxRuleController.php
@@ -1,0 +1,437 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Propel\Runtime\Event\ActiveRecordEvent;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\Tax\TaxRuleEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Form\Exception\FormValidationException;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\CountryQuery;
+use Thelia\Model\TaxRule;
+use Thelia\Model\TaxRuleCountryQuery;
+use Thelia\Model\TaxRuleQuery;
+use Thelia\Tools\URL;
+
+class TaxRuleController extends AbstractCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'taxrule',
+            'manual',
+            'order',
+            AdminResources::TAX,
+            TheliaEvents::TAX_RULE_CREATE,
+            TheliaEvents::TAX_RULE_UPDATE,
+            TheliaEvents::TAX_RULE_DELETE,
+        );
+    }
+
+    public function defaultAction(): Response
+    {
+        // In the tax rule template we use the TaxCreationForm.
+        //
+        // The TaxCreationForm require the TaxEngine, but we cannot pass it from the Parser Form plugin,
+        // as the container is not passed to forms by this plugin.
+        //
+        // So we create an instance of TaxCreationForm here (we have the container), and put it in the ParserContext.
+        // This way, the Form plugin will use this instance, instead on creating it.
+        $taxCreationForm = $this->createForm(AdminForm::TAX_CREATION);
+
+        $this->getParserContext()->addForm($taxCreationForm);
+
+        return parent::defaultAction();
+    }
+
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::TAX_RULE_CREATION);
+    }
+
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::TAX_RULE_MODIFICATION);
+    }
+
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $event = new TaxRuleEvent();
+
+        $event->setLocale($formData['locale']);
+        $event->setTitle($formData['title']);
+        $event->setDescription($formData['description']);
+
+        return $event;
+    }
+
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $event = new TaxRuleEvent();
+
+        $event->setLocale($formData['locale']);
+        $event->setId($formData['id']);
+        $event->setTitle($formData['title']);
+        $event->setDescription($formData['description']);
+
+        return $event;
+    }
+
+    protected function getUpdateTaxListEvent(array $formData): TaxRuleEvent
+    {
+        $event = new TaxRuleEvent();
+
+        $event->setId($formData['id']);
+        $event->setTaxList($formData['tax_list']);
+        $event->setCountryList($formData['country_list']);
+        $event->setCountryDeletedList($formData['country_deleted_list']);
+
+        return $event;
+    }
+
+    protected function getDeleteEvent(): TaxRuleEvent
+    {
+        $event = new TaxRuleEvent();
+
+        $event->setId(
+            $this->getRequest()->get('tax_rule_id', 0),
+        );
+
+        return $event;
+    }
+
+    protected function eventContainsObject($event): bool
+    {
+        return $event->hasTaxRule();
+    }
+
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        $data = [
+            'id' => $object->getId(),
+            'locale' => $object->getLocale(),
+            'title' => $object->getTitle(),
+            'description' => $object->getDescription(),
+        ];
+
+        // Setup the object form
+        return $this->createForm(AdminForm::TAX_RULE_MODIFICATION, FormType::class, $data);
+    }
+
+    protected function hydrateTaxUpdateForm(TaxRule $object): BaseForm
+    {
+        $data = [
+            'id' => $object->getId(),
+        ];
+
+        // Setup the object form
+        return $this->createForm(AdminForm::TAX_RULE_TAX_LIST_UPDATE, FormType::class, $data);
+    }
+
+    protected function getObjectFromEvent($event): mixed
+    {
+        return $event->hasTaxRule() ? $event->getTaxRule() : null;
+    }
+
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        $taxRule = TaxRuleQuery::create()
+            ->findOneById($this->getRequest()->get('tax_rule_id'));
+
+        if (null !== $taxRule) {
+            $taxRule->setLocale($this->getCurrentEditionLocale());
+        }
+
+        return $taxRule;
+    }
+
+    /**
+     * @param TaxRule $object
+     */
+    protected function getObjectLabel(ActiveRecordInterface $object): ?string
+    {
+        return $object->getTitle();
+    }
+
+    /**
+     * @param TaxRule $object
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    protected function getViewArguments($country = null, $tab = null, $state = null): array
+    {
+        return [
+            'tab' => $tab ?? $this->getRequest()->get('tab', 'data'),
+            'country' => $country ?? $this->getRequest()->get('country', CountryQuery::create()->findOneByByDefault(1)?->getId()),
+            'state' => $state,
+        ];
+    }
+
+    protected function getRouteArguments($tax_rule_id = null): array
+    {
+        return [
+            'tax_rule_id' => $tax_rule_id ?? $this->getRequest()->get('tax_rule_id'),
+        ];
+    }
+
+    protected function renderListTemplate(string $currentOrder): Response
+    {
+        // We always return to the feature edition form
+        return $this->render(
+            'taxes-rules',
+            [
+                'taxruleIdDeliveryModule' => ConfigQuery::read('taxrule_id_delivery_module'),
+            ],
+        );
+    }
+
+    protected function renderEditionTemplate(): Response
+    {
+        // We always return to the feature edition form
+        return $this->render('tax-rule-edit', array_merge($this->getViewArguments(), $this->getRouteArguments()));
+    }
+
+    protected function redirectToEditionTemplate($request = null, $country = null, $state = null): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.configuration.taxes-rules.update',
+            $this->getViewArguments($country, null, $state),
+            $this->getRouteArguments(),
+        );
+    }
+
+    /**
+     * Put in this method post object creation processing if required.
+     */
+    protected function performAdditionalCreateAction(ActionEvent|ActiveRecordEvent|null $createEvent): ?Response
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.configuration.taxes-rules.update',
+            $this->getViewArguments(),
+            $this->getRouteArguments($createEvent?->getTaxRule()?->getId()),
+        );
+    }
+
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute('admin.configuration.taxes-rules.list');
+    }
+
+    public function updateAction(ParserContext $parserContext): Response
+    {
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $object = $this->getExistingObject();
+
+        if ($object instanceof ActiveRecordInterface) {
+            // Hydrate the form abd pass it to the parser
+            $changeTaxesForm = $this->hydrateTaxUpdateForm($object);
+
+            // Pass it to the parser
+            $parserContext->addForm($changeTaxesForm);
+        }
+
+        return parent::updateAction($parserContext);
+    }
+
+    public function setDefaultAction(EventDispatcherInterface $eventDispatcher): Response|RedirectResponse
+    {
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $setDefaultEvent = new TaxRuleEvent();
+
+        $taxRuleId = $this->getRequest()->attributes->get('tax_rule_id');
+
+        $setDefaultEvent->setId(
+            $taxRuleId,
+        );
+
+        $eventDispatcher->dispatch($setDefaultEvent, TheliaEvents::TAX_RULE_SET_DEFAULT);
+
+        return $this->redirectToListTemplate();
+    }
+
+    public function processUpdateTaxesAction(EventDispatcherInterface $eventDispatcher): Response
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $responseData = [
+            'success' => false,
+            'message' => '',
+        ];
+
+        $error_msg = false;
+
+        // Create the form from the request
+        $changeForm = $this->createForm(AdminForm::TAX_RULE_TAX_LIST_UPDATE);
+
+        try {
+            // Check the form against constraints violations
+            $form = $this->validateForm($changeForm, 'POST');
+
+            // Get the form field values
+            $data = $form->getData();
+
+            $changeEvent = $this->getUpdateTaxListEvent($data);
+
+            $eventDispatcher->dispatch($changeEvent, TheliaEvents::TAX_RULE_TAXES_UPDATE);
+
+            if (!$this->eventContainsObject($changeEvent)) {
+                throw new \LogicException($this->getTranslator()->trans('No %obj was updated.', ['%obj', $this->objectName]));
+            }
+
+            // Log object modification
+            if (null !== $changedObject = $this->getObjectFromEvent($changeEvent)) {
+                $this->adminLogAppend(
+                    $this->resourceCode,
+                    AccessManager::UPDATE,
+                    \sprintf(
+                        '%s %s (ID %s) modified',
+                        ucfirst($this->objectName),
+                        $this->getObjectLabel($changedObject),
+                        $this->getObjectId($changedObject),
+                    ),
+                    $this->getObjectId($changedObject),
+                );
+            }
+
+            $responseData['success'] = true;
+            $responseData['data'] = $this->getSpecification(
+                $changeEvent->getTaxRule()->getId(),
+            );
+
+            return $this->jsonResponse(json_encode($responseData));
+        } catch (FormValidationException $ex) {
+            // Form cannot be validated
+            $error_msg = $this->createStandardFormValidationErrorMessage($ex);
+        } catch (\Exception $ex) {
+            // Any other error
+            $error_msg = $ex->getMessage();
+        }
+
+        $this->setupFormErrorContext($this->getTranslator()->trans('%obj modification', ['%obj' => 'taxrule']), $error_msg, $changeForm, $ex);
+
+        // At this point, the form has errors, and should be redisplayed.
+        $responseData['message'] = $error_msg;
+
+        return $this->jsonResponse(json_encode($responseData));
+    }
+
+    public function specsAction($taxRuleId): Response
+    {
+        $data = $this->getSpecification($taxRuleId);
+
+        return $this->jsonResponse(json_encode($data));
+    }
+
+    protected function getSpecification($taxRuleId): array
+    {
+        $taxRuleCountries = TaxRuleCountryQuery::create()
+            ->filterByTaxRuleId($taxRuleId)
+            ->orderByCountryId()
+            ->orderByStateId()
+            ->orderByPosition()
+            ->orderByTaxId()
+            ->find();
+
+        $specKey = [];
+        $specifications = [];
+        $taxRules = [];
+
+        if (!$taxRuleCountries->isEmpty()) {
+            $taxRuleCountry = $taxRuleCountries->getFirst();
+            $currentCountryId = $taxRuleCountry->getCountryId();
+            $currentStateId = (int) $taxRuleCountry->getStateId();
+
+            while (true) {
+                $hasChanged = null === $taxRuleCountry
+                    || $taxRuleCountry->getCountryId() !== $currentCountryId
+                    || (int) $taxRuleCountry->getStateId() !== $currentStateId;
+
+                if ($hasChanged) {
+                    $specification = implode(',', $specKey);
+
+                    $specifications[] = [
+                        'country' => $currentCountryId,
+                        'state' => $currentStateId,
+                        'specification' => $specification,
+                    ];
+
+                    if (!\in_array($specification, $taxRules, true)) {
+                        $taxRules[] = $specification;
+                    }
+
+                    if (null === $taxRuleCountry) {
+                        break;
+                    }
+
+                    $currentCountryId = $taxRuleCountry->getCountryId();
+                    $currentStateId = (int) $taxRuleCountry->getStateId();
+                    $specKey = [];
+                }
+
+                $specKey[] = $taxRuleCountry->getTaxId().'-'.$taxRuleCountry->getPosition();
+
+                $taxRuleCountry = $taxRuleCountries->getNext();
+            }
+        }
+
+        return [
+            'taxRules' => $taxRules,
+            'specifications' => $specifications,
+        ];
+    }
+
+    #[Route(
+        '/admin/configuration/taxes_rules/delivery_module/update',
+        name: 'admin.configuration.tax-rule.delivery.modules.update',
+        methods: ['POST'],
+    )]
+    public function updateDeliveryModulesTaxRule(): Response|RedirectResponse
+    {
+        if (($response = $this->checkAuth($this->resourceCode, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $data = $this->getRequest()->request;
+        $taxruleId = $data->get('delivery-module-tax-rule');
+
+        ConfigQuery::write('taxrule_id_delivery_module', $taxruleId);
+
+        return $this->generateRedirect(URL::getInstance()->absoluteUrl('admin/configuration/taxes_rules'));
+    }
+}

--- a/Controller/Admin/TemplateController.php
+++ b/Controller/Admin/TemplateController.php
@@ -1,0 +1,376 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Propel\Runtime\Event\ActiveRecordEvent;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\Template\TemplateAddAttributeEvent;
+use Thelia\Core\Event\Template\TemplateAddFeatureEvent;
+use Thelia\Core\Event\Template\TemplateCreateEvent;
+use Thelia\Core\Event\Template\TemplateDeleteAttributeEvent;
+use Thelia\Core\Event\Template\TemplateDeleteEvent;
+use Thelia\Core\Event\Template\TemplateDeleteFeatureEvent;
+use Thelia\Core\Event\Template\TemplateDuplicateEvent;
+use Thelia\Core\Event\Template\TemplateUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\HttpFoundation\Request;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Model\AttributeTemplateQuery;
+use Thelia\Model\FeatureTemplateQuery;
+use Thelia\Model\Template;
+use Thelia\Model\TemplateQuery;
+
+/**
+ * Manages product templates.
+ *
+ * @author Franck Allimant <franck@cqfdev.fr>
+ */
+class TemplateController extends AbstractCrudController
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'template',
+            null,
+            null,
+            AdminResources::TEMPLATE,
+            TheliaEvents::TEMPLATE_CREATE,
+            TheliaEvents::TEMPLATE_UPDATE,
+            TheliaEvents::TEMPLATE_DELETE, // No position update
+        );
+    }
+
+    protected function getCreationForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::TEMPLATE_CREATION);
+    }
+
+    protected function getUpdateForm(): BaseForm
+    {
+        return $this->createForm(AdminForm::TEMPLATE_MODIFICATION);
+    }
+
+    protected function getCreationEvent(array $formData): ActionEvent
+    {
+        $createEvent = new TemplateCreateEvent();
+
+        $createEvent
+            ->setTemplateName($formData['name'])
+            ->setLocale($formData['locale']);
+
+        return $createEvent;
+    }
+
+    protected function getUpdateEvent(array $formData): ActionEvent
+    {
+        $changeEvent = new TemplateUpdateEvent($formData['id']);
+
+        // Create and dispatch the change event
+        $changeEvent
+            ->setLocale($formData['locale'])
+            ->setTemplateName($formData['name']);
+
+        // Add feature and attributes list
+        return $changeEvent;
+    }
+
+    protected function getDeleteEvent(): TemplateDeleteEvent
+    {
+        return new TemplateDeleteEvent((int) $this->getRequest()->get('template_id'));
+    }
+
+    protected function eventContainsObject($event): bool
+    {
+        return $event->hasTemplate();
+    }
+
+    protected function hydrateObjectForm(ParserContext $parserContext, ActiveRecordInterface $object): BaseForm
+    {
+        $data = [
+            'id' => $object->getId(),
+            'locale' => $object->getLocale(),
+            'name' => $object->getName(),
+        ];
+
+        // Setup the object form
+        return $this->createForm(AdminForm::TEMPLATE_MODIFICATION, FormType::class, $data);
+    }
+
+    protected function getObjectFromEvent($event): mixed
+    {
+        return $event->hasTemplate() ? $event->getTemplate() : null;
+    }
+
+    protected function getExistingObject(): ?ActiveRecordInterface
+    {
+        $template = TemplateQuery::create()
+            ->findOneById($this->getRequest()->get('template_id', 0));
+
+        if (null !== $template) {
+            $template->setLocale($this->getCurrentEditionLocale());
+        }
+
+        return $template;
+    }
+
+    /**
+     * @param Template $object
+     */
+    protected function getObjectLabel(ActiveRecordInterface $object): ?string
+    {
+        return $object->getName();
+    }
+
+    /**
+     * @param Template $object
+     */
+    protected function getObjectId(ActiveRecordInterface $object): int
+    {
+        return $object->getId();
+    }
+
+    protected function renderListTemplate(?string $currentOrder): Response
+    {
+        return $this->render('templates', ['order' => $currentOrder]);
+    }
+
+    protected function renderEditionTemplate(): Response
+    {
+        return $this->render(
+            'template-edit',
+            [
+                'template_id' => $this->getRequest()->get('template_id'),
+            ],
+        );
+    }
+
+    protected function redirectToEditionTemplate(?Request $request = null, ?int $id = null): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute(
+            'admin.configuration.templates.update',
+            [
+                'template_id' => $id ?: $this->getRequest()->get('template_id'),
+            ],
+        );
+    }
+
+    protected function redirectToListTemplate(): Response|RedirectResponse
+    {
+        return $this->generateRedirectFromRoute('admin.configuration.templates.default');
+    }
+
+    /**
+     * Process delete failure, which may occurs if template is in use.
+     */
+    protected function performAdditionalDeleteAction(ActionEvent|ActiveRecordEvent|null $deleteEvent): ?Response
+    {
+        if ($deleteEvent->getProductCount() > 0) {
+            $this->getParserContext()->setGeneralError(
+                $this->getTranslator()->trans(
+                    'This template is in use in some of your products, and cannot be deleted. Delete it from all your products and try again.',
+                ),
+            );
+
+            return $this->renderList();
+        }
+
+        // Normal delete processing
+        return null;
+    }
+
+    public function duplicateAction(EventDispatcherInterface $eventDispatcher): Response
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth(AdminResources::TEMPLATE, [], AccessManager::CREATE)) instanceof Response) {
+            return $response;
+        }
+
+        $template_id = (int) $this->getRequest()->get('template_id');
+
+        if ($template_id > 0) {
+            try {
+                $event = new TemplateDuplicateEvent($template_id, $this->getCurrentEditionLocale());
+
+                $eventDispatcher->dispatch($event, TheliaEvents::TEMPLATE_DUPLICATE);
+
+                if ($event->hasTemplate()) {
+                    $template_id = $event->getTemplate()->getId();
+                }
+            } catch (\Exception $ex) {
+                // Any error
+                return $this->errorPage($ex);
+            }
+        }
+
+        return $this->redirectToEditionTemplate(null, $template_id);
+    }
+
+    public function getAjaxFeaturesAction(): Response
+    {
+        return $this->render(
+            'ajax/template-feature-list',
+            ['template_id' => $this->getRequest()->get('template_id')],
+        );
+    }
+
+    public function getAjaxAttributesAction(): Response
+    {
+        return $this->render(
+            'ajax/template-attribute-list',
+            ['template_id' => $this->getRequest()->get('template_id')],
+        );
+    }
+
+    public function addAttributeAction(EventDispatcherInterface $eventDispatcher): Response
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth(AdminResources::TEMPLATE, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $attribute_id = (int) $this->getRequest()->get('attribute_id');
+
+        if ($attribute_id > 0) {
+            $event = new TemplateAddAttributeEvent(
+                $this->getExistingObject(),
+                $attribute_id,
+            );
+
+            try {
+                $eventDispatcher->dispatch($event, TheliaEvents::TEMPLATE_ADD_ATTRIBUTE);
+            } catch (\Exception $ex) {
+                // Any error
+                return $this->errorPage($ex);
+            }
+        }
+
+        return $this->redirectToEditionTemplate();
+    }
+
+    public function deleteAttributeAction(EventDispatcherInterface $eventDispatcher): Response
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth(AdminResources::TEMPLATE, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $event = new TemplateDeleteAttributeEvent(
+            $this->getExistingObject(),
+            (int) $this->getRequest()->get('attribute_id'),
+        );
+
+        try {
+            $eventDispatcher->dispatch($event, TheliaEvents::TEMPLATE_DELETE_ATTRIBUTE);
+        } catch (\Exception $exception) {
+            // Any error
+            return $this->errorPage($exception);
+        }
+
+        return $this->redirectToEditionTemplate();
+    }
+
+    public function updateAttributePositionAction(
+        Request $request,
+        EventDispatcherInterface $eventDispatcher,
+    ): ?Response {
+        // Find attribute_template
+        $attributeTemplate = AttributeTemplateQuery::create()
+            ->filterByTemplateId($request->get('template_id'))
+            ->filterByAttributeId($request->get('attribute_id'))
+            ->findOne();
+
+        return $this->genericUpdatePositionAction(
+            $request,
+            $eventDispatcher,
+            $attributeTemplate,
+            TheliaEvents::TEMPLATE_CHANGE_ATTRIBUTE_POSITION,
+        );
+    }
+
+    public function addFeatureAction(EventDispatcherInterface $eventDispatcher): Response
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth(AdminResources::TEMPLATE, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $feature_id = (int) $this->getRequest()->get('feature_id');
+
+        if ($feature_id > 0) {
+            $event = new TemplateAddFeatureEvent(
+                $this->getExistingObject(),
+                $feature_id,
+            );
+
+            try {
+                $eventDispatcher->dispatch($event, TheliaEvents::TEMPLATE_ADD_FEATURE);
+            } catch (\Exception $ex) {
+                // Any error
+                return $this->errorPage($ex);
+            }
+        }
+
+        return $this->redirectToEditionTemplate();
+    }
+
+    public function deleteFeatureAction(EventDispatcherInterface $eventDispatcher): Response
+    {
+        // Check current user authorization
+        if (($response = $this->checkAuth(AdminResources::TEMPLATE, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        $event = new TemplateDeleteFeatureEvent(
+            $this->getExistingObject(),
+            (int) $this->getRequest()->get('feature_id'),
+        );
+
+        try {
+            $eventDispatcher->dispatch($event, TheliaEvents::TEMPLATE_DELETE_FEATURE);
+        } catch (\Exception $exception) {
+            // Any error
+            return $this->errorPage($exception);
+        }
+
+        return $this->redirectToEditionTemplate();
+    }
+
+    public function updateFeaturePositionAction(
+        Request $request,
+        EventDispatcherInterface $eventDispatcher,
+    ): ?Response {
+        // Find feature_template
+        $featureTemplate = FeatureTemplateQuery::create()
+            ->filterByTemplateId($request->get('template_id'))
+            ->filterByFeatureId($request->get('feature_id'))
+            ->findOne();
+
+        return $this->genericUpdatePositionAction(
+            $request,
+            $eventDispatcher,
+            $featureTemplate,
+            TheliaEvents::TEMPLATE_CHANGE_FEATURE_POSITION,
+        );
+    }
+}

--- a/Controller/Admin/ToolsController.php
+++ b/Controller/Admin/ToolsController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Symfony\Component\HttpFoundation\Response;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+
+/**
+ * Class ToolsController.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class ToolsController extends BaseAdminController
+{
+    public function indexAction()
+    {
+        if (($response = $this->checkAuth([AdminResources::TOOLS], [], [AccessManager::VIEW])) instanceof Response) {
+            return $response;
+        }
+
+        return $this->render('tools');
+    }
+}

--- a/Controller/Admin/TranslationsController.php
+++ b/Controller/Admin/TranslationsController.php
@@ -1,0 +1,373 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Event\Translation\TranslationEvent;
+use Thelia\Core\HttpFoundation\Request;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\TemplateDefinition;
+use Thelia\Core\Template\TemplateHelperInterface;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\Module;
+use Thelia\Model\ModuleQuery;
+use Thelia\Tools\URL;
+
+/**
+ * Class TranslationsController.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class TranslationsController extends BaseAdminController
+{
+    /**
+     * @param string
+     */
+    protected function getModule(TranslatorInterface $translator, string $moduleCode): Module
+    {
+        if (null !== $module = ModuleQuery::create()->findPk($moduleCode)) {
+            return $module;
+        }
+
+        throw new \InvalidArgumentException($translator->trans("No module found for code '%item'", ['%item' => $moduleCode]));
+    }
+
+    protected function getModuleTemplateNames(TemplateHelperInterface $templateHelper, Module $module, int $templateType): array
+    {
+        $templates =
+            $templateHelper->getList(
+                $templateType,
+                $module->getAbsoluteTemplateBasePath(),
+            );
+
+        $names = [];
+
+        foreach ($templates as $template) {
+            $names[] = $template->getName();
+        }
+
+        return $names;
+    }
+
+    protected function renderTemplate(
+        Request $request,
+        TemplateHelperInterface $templateHelper,
+        EventDispatcherInterface $eventDispatcher,
+        TranslatorInterface $translator,
+    ): RedirectResponse|Response {
+        // Get related strings, if all input data are here
+        $itemToTranslate = $request->get('item_to_translate');
+
+        $itemName = $request->get('item_name', '');
+
+        $modulePart = false;
+
+        if ('mo' === $itemToTranslate && !empty($itemName)) {
+            $modulePart = $request->get('module_part', '');
+        }
+
+        $template = false;
+        $directory = false;
+        $i18nDirectory = false;
+
+        $walkMode = TranslationEvent::WALK_MODE_TEMPLATE;
+
+        $templateArguments = [
+            'item_to_translate' => $itemToTranslate,
+            'item_name' => $itemName,
+            'module_part' => $modulePart,
+            'view_missing_traductions_only' => $request->get('view_missing_traductions_only'),
+            'max_input_vars_warning' => false,
+        ];
+
+        // Find the i18n directory, and the directory to examine.
+
+        $domain = '';
+
+        if (!empty($itemName) || 'co' === $itemToTranslate || 'in' === $itemToTranslate || 'wi' === $itemToTranslate) {
+            switch ($itemToTranslate) {
+                // Module core
+                case 'mo':
+                    $module = $this->getModule($translator, $itemName);
+
+                    if ('core' === $modulePart) {
+                        $directory = $module->getAbsoluteBaseDir();
+                        $domain = $module->getTranslationDomain();
+                        $i18nDirectory = $module->getAbsoluteI18nPath();
+                        $walkMode = TranslationEvent::WALK_MODE_PHP;
+                    } elseif ('admin-includes' === $modulePart) {
+                        $directory = $module->getAbsoluteAdminIncludesPath();
+                        $domain = $module->getAdminIncludesTranslationDomain();
+                        $i18nDirectory = $module->getAbsoluteAdminIncludesI18nPath();
+                        $walkMode = TranslationEvent::WALK_MODE_TEMPLATE;
+                    } elseif (!empty($modulePart)) {
+                        // Front, back, pdf or email office template,
+                        // form of $module_part is [bo|fo|pdf|email].subdir-name
+                        [$type, $subdir] = explode('.', (string) $modulePart);
+
+                        switch ($type) {
+                            case 'bo':
+                                $directory = $module->getAbsoluteBackOfficeTemplatePath($subdir);
+                                $domain = $module->getBackOfficeTemplateTranslationDomain($subdir);
+                                $i18nDirectory = $module->getAbsoluteBackOfficeI18nTemplatePath($subdir);
+                                break;
+                            case 'fo':
+                                $directory = $module->getAbsoluteFrontOfficeTemplatePath($subdir);
+                                $domain = $module->getFrontOfficeTemplateTranslationDomain($subdir);
+                                $i18nDirectory = $module->getAbsoluteFrontOfficeI18nTemplatePath($subdir);
+                                break;
+                            case 'email':
+                                $directory = $module->getAbsoluteEmailTemplatePath($subdir);
+                                $domain = $module->getEmailTemplateTranslationDomain($subdir);
+                                $i18nDirectory = $module->getAbsoluteEmailI18nTemplatePath($subdir);
+                                break;
+                            case 'pdf':
+                                $directory = $module->getAbsolutePdfTemplatePath($subdir);
+                                $domain = $module->getPdfTemplateTranslationDomain($subdir);
+                                $i18nDirectory = $module->getAbsolutePdfI18nTemplatePath($subdir);
+                                break;
+                            default:
+                                throw new \InvalidArgumentException(\sprintf("Undefined module template type: '%s'.", $type));
+                        }
+
+                        $walkMode = TranslationEvent::WALK_MODE_TEMPLATE;
+                    }
+
+                    // Modules translations files are in the cache, and are not always
+                    // updated. Force a reload of the files to get last changes.
+                    if ('' !== $domain && '0' !== $domain) {
+                        $this->loadTranslation($i18nDirectory, $domain);
+                    }
+
+                    // List front and back office templates defined by this module
+                    $templateArguments['back_office_templates'] =
+                        implode(',', $this->getModuleTemplateNames($templateHelper, $module, TemplateDefinition::BACK_OFFICE));
+
+                    $templateArguments['front_office_templates'] =
+                        implode(',', $this->getModuleTemplateNames($templateHelper, $module, TemplateDefinition::FRONT_OFFICE));
+
+                    $templateArguments['email_templates'] =
+                        implode(',', $this->getModuleTemplateNames($templateHelper, $module, TemplateDefinition::EMAIL));
+
+                    $templateArguments['pdf_templates'] =
+                        implode(',', $this->getModuleTemplateNames($templateHelper, $module, TemplateDefinition::PDF));
+
+                    // Check if we have admin-include files
+                    try {
+                        $finder = Finder::create()
+                            ->files()
+                            ->depth(0)
+                            ->in($module->getAbsoluteAdminIncludesPath())
+                            ->name('/\.html$/i');
+
+                        $hasAdminIncludes = $finder->count() > 0;
+                    } catch (\InvalidArgumentException) {
+                        $hasAdminIncludes = false;
+                    }
+
+                    $templateArguments['has_admin_includes'] = $hasAdminIncludes;
+
+                    break;
+                    // Thelia Core
+                case 'co':
+                    $directory = THELIA_LIB;
+                    $domain = 'core';
+                    $i18nDirectory = THELIA_LIB.'Config'.DS.'I18n';
+                    $walkMode = TranslationEvent::WALK_MODE_PHP;
+                    break;
+                    // Thelia Install
+                case 'in':
+                    $directory = THELIA_SETUP_DIRECTORY;
+                    $domain = 'install';
+                    $i18nDirectory = THELIA_SETUP_DIRECTORY.'I18n';
+                    $walkMode = TranslationEvent::WALK_MODE_TEMPLATE;
+                    // resources not loaded by default
+                    $this->loadTranslation($i18nDirectory, $domain);
+                    break;
+                    // Thelia Install wizard
+                case 'wi':
+                    $directory = THELIA_SETUP_WIZARD_DIRECTORY;
+                    $domain = 'wizard';
+                    $i18nDirectory = THELIA_SETUP_WIZARD_DIRECTORY.'I18n';
+                    $walkMode = TranslationEvent::WALK_MODE_PHP;
+                    // resources not loaded by default
+                    $this->loadTranslation($i18nDirectory, $domain);
+                    break;
+                    // Front-office template
+                case 'fo':
+                    $template = new TemplateDefinition($itemName, TemplateDefinition::FRONT_OFFICE);
+                    break;
+                    // Back-office template
+                case 'bo':
+                    $template = new TemplateDefinition($itemName, TemplateDefinition::BACK_OFFICE);
+                    break;
+                    // PDF templates
+                case 'pf':
+                    $template = new TemplateDefinition($itemName, TemplateDefinition::PDF);
+                    break;
+                    // Email templates
+                case 'ma':
+                    $template = new TemplateDefinition($itemName, TemplateDefinition::EMAIL);
+                    break;
+            }
+
+            if ($template) {
+                $directory = $template->getAbsolutePath();
+
+                $i18nDirectory = $template->getAbsoluteI18nPath();
+
+                $domain = $template->getTranslationDomain();
+
+                // Load translations files if this template is not the current template
+                // as it is not loaded in Thelia.php
+                if (!$templateHelper->isActive($template)) {
+                    $this->loadTranslation($i18nDirectory, $domain);
+                }
+            }
+
+            // Load strings to translate
+            if ($directory && ('' !== $domain && '0' !== $domain)) {
+                // Save the string set, if the form was submitted
+                if ($i18nDirectory) {
+                    $save_mode = $request->get('save_mode', false);
+
+                    if (false !== $save_mode) {
+                        $texts = $request->get('text', []);
+
+                        if (!empty($texts)) {
+                            $event = TranslationEvent::createWriteFileEvent(
+                                \sprintf('%s'.DS.'%s.php', $i18nDirectory, $this->getCurrentEditionLocale()),
+                                $texts,
+                                $request->get('translation', []),
+                                true,
+                            );
+
+                            $event
+                                ->setDomain($domain)
+                                ->setLocale($this->getCurrentEditionLocale())
+                                ->setCustomFallbackStrings($request->get('translation_custom', []))
+                                ->setGlobalFallbackStrings($request->get('translation_global', []));
+
+                            $eventDispatcher->dispatch($event, TheliaEvents::TRANSLATION_WRITE_FILE);
+
+                            if ('stay' === $save_mode) {
+                                return $this->generateRedirectFromRoute(
+                                    'admin.configuration.translations',
+                                    $templateArguments,
+                                );
+                            }
+
+                            return $this->generateRedirect(URL::getInstance()->adminViewUrl('configuration'));
+                        }
+                    }
+                }
+
+                // Load strings
+                $event = TranslationEvent::createGetStringsEvent(
+                    $directory,
+                    $walkMode,
+                    $this->getCurrentEditionLocale(),
+                    $domain,
+                );
+
+                $eventDispatcher->dispatch($event, TheliaEvents::TRANSLATION_GET_STRINGS);
+
+                // Estimate number of fields, and compare to php ini max_input_vars
+                $stringsCount = $event->getTranslatableStringCount() * 4 + 6;
+
+                if ($stringsCount > \ini_get('max_input_vars')) {
+                    $templateArguments['max_input_vars_warning'] = true;
+                    $templateArguments['required_max_input_vars'] = $stringsCount;
+                    $templateArguments['current_max_input_vars'] = \ini_get('max_input_vars');
+                } else {
+                    $templateArguments['all_strings'] = $event->getTranslatableStrings();
+                }
+
+                $templateArguments['is_writable'] = $this->checkWritableI18nDirectory(THELIA_LOCAL_DIR.'I18n');
+            }
+        }
+
+        return $this->render('translations', $templateArguments);
+    }
+
+    /**
+     * Check if a directory is writable or if the parent directory is writable.
+     *
+     * @param string $dir the directory to test
+     *
+     * @return bool return true if the directory is writable otr if the parent dir is writable
+     */
+    public function checkWritableI18nDirectory(string $dir): bool
+    {
+        if (file_exists($dir)) {
+            return is_writable($dir);
+        }
+
+        $parentDir = \dirname($dir);
+
+        return file_exists($parentDir) && is_writable($parentDir);
+    }
+
+    public function defaultAction(
+        Request $request,
+        TemplateHelperInterface $templateHelper,
+        EventDispatcherInterface $eventDispatcher,
+        TranslatorInterface $translator,
+    ): Response|RedirectResponse {
+        if (($response = $this->checkAuth(AdminResources::TRANSLATIONS, [], AccessManager::VIEW)) instanceof Response) {
+            return $response;
+        }
+
+        return $this->renderTemplate($request, $templateHelper, $eventDispatcher, $translator);
+    }
+
+    public function updateAction(
+        Request $request,
+        TemplateHelperInterface $templateHelper,
+        EventDispatcherInterface $eventDispatcher,
+        TranslatorInterface $translator,
+    ): Response|RedirectResponse {
+        if (($response = $this->checkAuth(AdminResources::LANGUAGE, [], AccessManager::UPDATE)) instanceof Response) {
+            return $response;
+        }
+
+        return $this->renderTemplate($request, $templateHelper, $eventDispatcher, $translator);
+    }
+
+    private function loadTranslation(string|bool $directory, string $domain): void
+    {
+        try {
+            $finder = Finder::create()
+                ->files()
+                ->depth(0)
+                ->in($directory);
+
+            /** @var \DirectoryIterator $file */
+            foreach ($finder as $file) {
+                [$locale, $format] = explode('.', $file->getBaseName(), 2);
+
+                Translator::getInstance()->addResource($format, $file->getPathname(), $locale, $domain);
+            }
+        } catch (\InvalidArgumentException) {
+            // Ignore missing I18n directories
+        }
+    }
+}

--- a/Controller/Admin/TranslationsCustomerTitleController.php
+++ b/Controller/Admin/TranslationsCustomerTitleController.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Admin;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Thelia\Form\Exception\FormValidationException;
+use Thelia\Model\CustomerTitleQuery;
+
+class TranslationsCustomerTitleController extends BaseAdminController
+{
+    public function defaultAction(): Response
+    {
+        return $this->render('translations-customer-title');
+    }
+
+    public function updateAction(): RedirectResponse
+    {
+        $request = $this->getRequest();
+
+        $translationForm = $this->createForm('thelia.admin.translations.customer_title');
+
+        try {
+            $form = $this->validateForm($translationForm);
+
+            $data = $form->getData();
+
+            $local = $data['locale'];
+
+            $myCustomersTitle = CustomerTitleQuery::create()->find();
+
+            foreach ($myCustomersTitle as $aCustomerTitle) {
+                $aCustomerTitle->setLocale($local)
+                    ->setShort($data['short_title_'.$aCustomerTitle->getId()])
+                    ->setLong($data['long_title_'.$aCustomerTitle->getId()])
+                    ->save();
+            }
+
+            if ('close' === $request->get('save_mode')) {
+                return $this->generateRedirectFromRoute('admin.configuration.index');
+            }
+
+            return $this->generateRedirectFromRoute('admin.configuration.translations-customers-title');
+        } catch (FormValidationException $ex) {
+            // Form cannot be validated
+            $errorMessage = $this->createStandardFormValidationErrorMessage($ex);
+        } catch (\Exception $ex) {
+            // Any other error
+            $errorMessage = $ex->getMessage();
+        }
+
+        $this->setupFormErrorContext(
+            'customer title i18n',
+            $errorMessage,
+            $translationForm,
+            $ex,
+        );
+
+        return $this->generateRedirectFromRoute('admin.configuration.translations-customers-title');
+    }
+}

--- a/DependencyInjection/Compiler/RegisterAdminFormsPass.php
+++ b/DependencyInjection/Compiler/RegisterAdminFormsPass.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackOfficeDefaultBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class RegisterAdminFormsPass implements CompilerPassInterface
+{
+    private const FORMS_PARAMETER = 'Thelia.parser.forms';
+
+    public function process(ContainerBuilder $container): void
+    {
+        $existingForms = $container->hasParameter(self::FORMS_PARAMETER)
+            ? (array) $container->getParameter(self::FORMS_PARAMETER)
+            : [];
+
+        $adminForms = require \dirname(__DIR__, 2).'/Config/Resources/parameters/forms_admin.php';
+
+        $container->setParameter(self::FORMS_PARAMETER, array_merge($existingForms, $adminForms));
+    }
+}

--- a/Form/AdminCreatePassword.php
+++ b/Form/AdminCreatePassword.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\ConfigQuery;
+
+class AdminCreatePassword extends BruteforceForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('password', PasswordType::class, [
+                'constraints' => [],
+                'label' => $this->translator->trans('Password'),
+                'label_attr' => [
+                    'for' => 'password',
+                ],
+                'attr' => [
+                    'placeholder' => Translator::getInstance()->trans('Enter the new password'),
+                ],
+            ])
+            ->add('password_confirm', PasswordType::class, [
+                'constraints' => [
+                    new Callback(
+                        $this->verifyPasswordField(...),
+                    ),
+                ],
+                'label' => $this->translator->trans('Password confirmation'),
+                'label_attr' => [
+                    'for' => 'password_confirmation',
+                ],
+                'attr' => [
+                    'placeholder' => Translator::getInstance()->trans('Enter the new password again'),
+                ],
+            ]);
+    }
+
+    public function verifyPasswordField($value, ExecutionContextInterface $context): void
+    {
+        $data = $context->getRoot()->getData();
+
+        if ('' === $data['password'] && '' === $data['password_confirm']) {
+            $context->addViolation("password can't be empty");
+        }
+
+        if ($data['password'] !== $data['password_confirm']) {
+            $context->addViolation('password confirmation is not the same as password field');
+        }
+
+        $minLength = ConfigQuery::getMinimuAdminPasswordLength();
+
+        if (\strlen((string) $data['password']) < $minLength) {
+            $context->addViolation(\sprintf('password must be composed of at least %s characters', $minLength));
+        }
+    }
+}

--- a/Form/AdminLogin.php
+++ b/Form/AdminLogin.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+
+class AdminLogin extends BruteforceForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('username', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new Length(['min' => 3]),
+                ],
+                'label' => Translator::getInstance()->trans('Username or e-mail address *'),
+                'label_attr' => [
+                    'for' => 'username',
+                ],
+            ])
+            ->add('password', PasswordType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('Password *'),
+                'label_attr' => [
+                    'for' => 'password',
+                ],
+            ])
+            ->add('remember_me', CheckboxType::class, [
+                'value' => 'yes',
+                'label' => Translator::getInstance()->trans('Remember me ?'),
+                'label_attr' => [
+                    'for' => 'remember_me',
+                ],
+            ]);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_admin_login';
+    }
+}

--- a/Form/AdminLostPassword.php
+++ b/Form/AdminLostPassword.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+
+class AdminLostPassword extends BruteforceForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('username_or_email', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new Length(['min' => 3]),
+                ],
+                'label' => Translator::getInstance()->trans('Username or e-mail address *'),
+                'label_attr' => [
+                    'for' => 'username',
+                ],
+            ]);
+    }
+}

--- a/Form/AdministratorCreationForm.php
+++ b/Form/AdministratorCreationForm.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Model\AdminQuery;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\LangQuery;
+use Thelia\Model\ProfileQuery;
+
+class AdministratorCreationForm extends BaseForm
+{
+    public const PROFILE_FIELD_PREFIX = 'profile';
+
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('login', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new Callback(
+                        $this->verifyExistingLogin(...),
+                    ),
+                ],
+                'label' => $this->translator->trans('Login name'),
+                'label_attr' => [
+                    'for' => 'login',
+                    'help' => $this->translator->trans('This is the name used on the login screen'),
+                ],
+            ])
+            ->add('email', EmailType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new Email(),
+                    new Callback(
+                        $this->verifyExistingEmail(...),
+                    ),
+                ],
+                'label' => $this->translator->trans('Email address'),
+                'label_attr' => [
+                    'for' => 'email',
+                    'help' => $this->translator->trans('Please enter a valid email address'),
+                ],
+                'attr' => [
+                    'placeholder' => $this->translator->trans('Administrator email address'),
+                ],
+            ])
+            ->add('firstname', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => $this->translator->trans('First Name'),
+                'label_attr' => [
+                    'for' => 'firstname',
+                ],
+            ])
+            ->add('lastname', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => $this->translator->trans('Last Name'),
+                'label_attr' => [
+                    'for' => 'lastname',
+                ],
+            ])
+            ->add('password', PasswordType::class, [
+                'constraints' => [],
+                'label' => $this->translator->trans('Password'),
+                'label_attr' => [
+                    'for' => 'password',
+                ],
+            ])
+            ->add('password_confirm', PasswordType::class, [
+                'constraints' => [
+                    new Callback($this->verifyPasswordField(...)),
+                ],
+                'label' => $this->translator->trans('Password confirmation'),
+                'label_attr' => [
+                    'for' => 'password_confirmation',
+                ],
+            ])
+            ->add(
+                'profile',
+                ChoiceType::class,
+                [
+                    'choices' => ProfileQuery::getProfileList(),
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                    'label' => $this->translator->trans('Profile'),
+                    'label_attr' => [
+                        'for' => 'profile',
+                    ],
+                ],
+            )
+            ->add(
+                'locale',
+                ChoiceType::class,
+                [
+                    'choices' => $this->getLocaleList(),
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                    'label' => $this->translator->trans('Preferred locale'),
+                    'label_attr' => [
+                        'for' => 'locale',
+                    ],
+                ],
+            );
+    }
+
+    /**
+     * @return mixed[]
+     */
+    protected function getLocaleList(): array
+    {
+        $locales = [];
+
+        $list = LangQuery::create()->find();
+
+        foreach ($list as $item) {
+            $locales[$item->getLocale()] = $item->getLocale();
+        }
+
+        return $locales;
+    }
+
+    public function verifyPasswordField($value, ExecutionContextInterface $context): void
+    {
+        $data = $context->getRoot()->getData();
+
+        if ('' === $data['password'] && '' === $data['password_confirm']) {
+            $context->addViolation("password can't be empty");
+        }
+
+        if ($data['password'] !== $data['password_confirm']) {
+            $context->addViolation('password confirmation is not the same as password field');
+        }
+
+        $minLength = ConfigQuery::getMinimuAdminPasswordLength();
+
+        if (\strlen((string) $data['password']) < $minLength) {
+            $context->addViolation(\sprintf('password must be composed of at least %s characters', $minLength));
+        }
+    }
+
+    public function verifyExistingLogin($value, ExecutionContextInterface $context): void
+    {
+        if (null !== $administrator = AdminQuery::create()->findOneByLogin($value)) {
+            $context->addViolation($this->translator->trans('This administrator login already exists'));
+        }
+    }
+
+    public function verifyExistingEmail($value, ExecutionContextInterface $context): void
+    {
+        if (null !== $administrator = AdminQuery::create()->findOneByEmail($value)) {
+            $context->addViolation($this->translator->trans('An administrator with thie email address already exists'));
+        }
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_admin_administrator_creation';
+    }
+}

--- a/Form/AdministratorModificationForm.php
+++ b/Form/AdministratorModificationForm.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\AdminQuery;
+
+class AdministratorModificationForm extends AdministratorCreationForm
+{
+    protected function buildForm(): void
+    {
+        parent::buildForm();
+
+        $this->formBuilder
+            ->add('id', HiddenType::class, [
+                'required' => true,
+                'constraints' => [
+                    new NotBlank(),
+                    new Callback(
+                        $this->verifyAdministratorId(...),
+                    ),
+                ],
+                'attr' => [
+                    'id' => 'administrator_update_id',
+                ],
+            ]);
+
+        $this->formBuilder->get('password')->setRequired(false);
+        $this->formBuilder->get('password_confirm')->setRequired(false);
+    }
+
+    /**
+     * @return string the name of you form. This name must be unique
+     */
+    public static function getName(): string
+    {
+        return 'thelia_admin_administrator_modification';
+    }
+
+    public function verifyAdministratorId($value, ExecutionContextInterface $context): void
+    {
+        $administrator = AdminQuery::create()
+            ->findPk($value);
+
+        if (null === $administrator) {
+            $context->addViolation(Translator::getInstance()->trans('Administrator ID not found'));
+        }
+    }
+
+    public function verifyExistingLogin($value, ExecutionContextInterface $context): void
+    {
+        $data = $context->getRoot()->getData();
+
+        $administrator = AdminQuery::create()->findOneByLogin($value);
+
+        if (null !== $administrator && $administrator->getId() !== (int) $data['id']) {
+            $context->addViolation($this->translator->trans('This administrator login already exists'));
+        }
+    }
+
+    public function verifyExistingEmail($value, ExecutionContextInterface $context): void
+    {
+        $data = $context->getRoot()->getData();
+
+        $administrator = AdminQuery::create()->findOneByEmail($value);
+
+        if (null !== $administrator && $administrator->getId() !== (int) $data['id']) {
+            $context->addViolation($this->translator->trans('An administrator with this email address already exists'));
+        }
+    }
+
+    public function verifyPasswordField($value, ExecutionContextInterface $context): void
+    {
+        $data = $context->getRoot()->getData();
+
+        if (!empty($data['password'])) {
+            if ($data['password'] !== $data['password_confirm']) {
+                $context->addViolation(Translator::getInstance()->trans('password confirmation is not the same as password field'));
+            }
+
+            if ('' !== $data['password'] && \strlen((string) $data['password']) < 4) {
+                $context->addViolation(Translator::getInstance()->trans('password must be composed of at least 4 characters'));
+            }
+        }
+    }
+}

--- a/Form/Area/AreaCountryForm.php
+++ b/Form/Area/AreaCountryForm.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\Area;
+
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+use Thelia\Form\BaseForm;
+
+/**
+ * Class AreaCountryForm.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class AreaCountryForm extends BaseForm
+{
+    use CountryListValidationTrait;
+
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add(
+                'area_id',
+                HiddenType::class,
+                [
+                    'constraints' => [
+                        new GreaterThan(['value' => 0]),
+                        new NotBlank(),
+                    ],
+                ],
+            )
+            ->add(
+                'country_id',
+                CollectionType::class,
+                [
+                    'entry_type' => TextType::class,
+                    'required' => true,
+                    'constraints' => [
+                        new NotBlank(),
+                        new Callback($this->verifyCountryList(...)),
+                    ],
+                    'allow_add' => true,
+                    'allow_delete' => true,
+                    'label' => Translator::getInstance()->trans('Countries'),
+                    'label_attr' => [
+                        'for' => 'countries-add',
+                        'help' => Translator::getInstance()
+                            ->trans('Select the countries to include in this shipping zone'),
+                    ],
+                    'attr' => [
+                        'size' => 10,
+                        'multiple' => true,
+                    ],
+                ],
+            );
+    }
+
+    /**
+     * @return string the name of you form. This name must be unique
+     */
+    public static function getName(): string
+    {
+        return 'thelia_area_country';
+    }
+}

--- a/Form/Area/AreaCreateForm.php
+++ b/Form/Area/AreaCreateForm.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\Area;
+
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+use Thelia\Form\BaseForm;
+
+/**
+ * Class AreaCreateForm.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class AreaCreateForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add(
+                'name',
+                TextType::class,
+                [
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                    'label' => Translator::getInstance()->trans('Shipping zone name'),
+                    'label_attr' => [
+                        'for' => 'shipping_name',
+                    ],
+                    'attr' => [
+                        'placeholder' => Translator::getInstance()->trans('A name such as Europe or Overseas'),
+                    ],
+                ],
+            );
+    }
+
+    /**
+     * @return string the name of you form. This name must be unique
+     */
+    public static function getName(): string
+    {
+        return 'thelia_area_creation';
+    }
+}

--- a/Form/Area/AreaDeleteCountryForm.php
+++ b/Form/Area/AreaDeleteCountryForm.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\Area;
+
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+use Thelia\Form\BaseForm;
+
+/**
+ * Class AreaDeleteCountryForm.
+ *
+ * @author  Franck Allimant <franck@cqfdev.fr>
+ */
+class AreaDeleteCountryForm extends BaseForm
+{
+    use CountryListValidationTrait;
+
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add(
+                'area_id',
+                HiddenType::class,
+                [
+                    'required' => true,
+
+                    'constraints' => [
+                        new GreaterThan(['value' => 0]),
+                        new NotBlank(),
+                    ],
+                ],
+            )
+            ->add(
+                'country_id',
+                CollectionType::class,
+                [
+                    'entry_type' => TextType::class,
+                    'constraints' => [
+                        new NotBlank(),
+                        new Callback($this->verifyCountryList(...)),
+                    ],
+                    'allow_add' => true,
+                    'allow_delete' => true,
+                    'label' => Translator::getInstance()->trans('Countries'),
+                    'label_attr' => [
+                        'for' => 'country_delete_id',
+                        'help' => Translator::getInstance()->trans(
+                            'Select the countries to delete from this shipping zone',
+                        ),
+                    ],
+                ],
+            );
+    }
+
+    /**
+     * @return string the name of you form. This name must be unique
+     */
+    public static function getName(): string
+    {
+        return 'thelia_area_delete_country';
+    }
+}

--- a/Form/Area/AreaModificationForm.php
+++ b/Form/Area/AreaModificationForm.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\Area;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+
+/**
+ * Class AreaModificationForm.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class AreaModificationForm extends AreaCreateForm
+{
+    protected function buildForm(): void
+    {
+        parent::buildForm();
+
+        $this->formBuilder
+            ->add(
+                'area_id',
+                HiddenType::class,
+                [
+                    'constraints' => [
+                        new GreaterThan(['value' => 0]),
+                    ],
+                ],
+            );
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_area_modification';
+    }
+}

--- a/Form/Area/AreaPostageForm.php
+++ b/Form/Area/AreaPostageForm.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\Area;
+
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+use Thelia\Form\BaseForm;
+
+/**
+ * Class AreaPostageForm.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class AreaPostageForm extends BaseForm
+{
+    /**
+     * in this function you add all the fields you need for your Form.
+     * Form this you have to call add method on $this->formBuilder attribute :.
+     *
+     * $this->formBuilder->add("name", TextType::class)
+     *   ->add("email", EmailType::class, array(
+     *           "attr" => array(
+     *               "class" => "field"
+     *           ),
+     *           "label" => "email",
+     *           "constraints" => array(
+     *               new \Symfony\Component\Validator\Constraints\NotBlank()
+     *           )
+     *       )
+     *   )
+     *   ->add('age', IntegerType::class);
+     */
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('area_id', IntegerType::class, [
+                'constraints' => [
+                    new GreaterThan(['value' => 0]),
+                    new NotBlank(),
+                ],
+            ])
+            ->add('postage', NumberType::class, [
+                'constraints' => [
+                    new GreaterThanOrEqual(['value' => 0]),
+                    new NotBlank(),
+                ],
+                'label_attr' => ['for' => 'area_postage'],
+                'label' => Translator::getInstance()->trans('Postage'),
+            ]);
+    }
+
+    /**
+     * @return string the name of you form. This name must be unique
+     */
+    public static function getName(): string
+    {
+        return 'thelia_area_postage';
+    }
+}

--- a/Form/Area/CountryListValidationTrait.php
+++ b/Form/Area/CountryListValidationTrait.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\Area;
+
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\CountryQuery;
+use Thelia\Model\StateQuery;
+
+/**
+ * Class CountryListValidationTrait.
+ *
+ * @author Julien Chanséaume <julien@thelia.net>
+ */
+trait CountryListValidationTrait
+{
+    public function verifyCountryList($value, ExecutionContextInterface $context): void
+    {
+        $countryList = \is_array($value) ? $value : [$value];
+
+        foreach ($countryList as $countryItem) {
+            $item = explode('-', (string) $countryItem);
+
+            if (2 === \count($item)) {
+                $country = CountryQuery::create()->findPk($item[0]);
+
+                if (null === $country) {
+                    $context->addViolation(
+                        Translator::getInstance()->trans(
+                            'Country ID %id not found',
+                            ['%id' => $item[0]],
+                        ),
+                    );
+                }
+
+                if ('0' === $item[1]) {
+                    continue;
+                }
+
+                $state = StateQuery::create()->findPk($item[1]);
+
+                if (null === $state) {
+                    $context->addViolation(
+                        Translator::getInstance()->trans(
+                            'State ID %id not found',
+                            ['%id' => $item[1]],
+                        ),
+                    );
+                }
+            } else {
+                $context->addViolation(Translator::getInstance()->trans('Wrong country definition'));
+            }
+        }
+    }
+}

--- a/Form/AttributeAvCreationForm.php
+++ b/Form/AttributeAvCreationForm.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+
+class AttributeAvCreationForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('title', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('Title *'),
+                'label_attr' => [
+                    'for' => 'title',
+                ],
+            ])
+            ->add('locale', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+            ])
+            ->add('attribute_id', HiddenType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+            ]);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_attributeav_creation';
+    }
+}

--- a/Form/AttributeCreationForm.php
+++ b/Form/AttributeCreationForm.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+
+class AttributeCreationForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('title', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('Title *'),
+                'label_attr' => [
+                    'for' => 'title',
+                ],
+            ])
+            ->add('locale', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+            ])
+            ->add('add_to_all', CheckboxType::class, [
+                'label' => Translator::getInstance()->trans('Add to all product templates'),
+                'label_attr' => [
+                    'for' => 'add_to_all',
+                ],
+            ]);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_attribute_creation';
+    }
+}

--- a/Form/AttributeModificationForm.php
+++ b/Form/AttributeModificationForm.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+
+class AttributeModificationForm extends AttributeCreationForm
+{
+    use StandardDescriptionFieldsTrait;
+
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('id', HiddenType::class, [
+                'constraints' => [
+                    new GreaterThan(
+                        ['value' => 0],
+                    ),
+                ],
+            ]);
+
+        // Add standard description fields
+        $this->addStandardDescFields();
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_attribute_modification';
+    }
+}

--- a/Form/Brand/BrandCreationForm.php
+++ b/Form/Brand/BrandCreationForm.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\Brand;
+
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+use Thelia\Form\BaseForm;
+use Thelia\Model\Lang;
+
+/**
+ * Class BrandCreationForm.
+ *
+ * @author  Franck Allimant <franck@cqfdev.fr>
+ */
+class BrandCreationForm extends BaseForm
+{
+    protected function doBuilForm($titleFieldHelpLabel): void
+    {
+        $this->formBuilder->add(
+            'title',
+            TextType::class,
+            [
+                'constraints' => [new NotBlank()],
+                'required' => true,
+                'label' => Translator::getInstance()->trans('Brand name'),
+                'label_attr' => [
+                    'for' => 'title',
+                    'help' => $titleFieldHelpLabel,
+                ],
+                'attr' => [
+                    'placeholder' => Translator::getInstance()->trans('The brand name or title'),
+                ],
+            ],
+        )
+            ->add(
+                'locale',
+                HiddenType::class,
+                [
+                    'constraints' => [new NotBlank()],
+                    'required' => true,
+                ],
+            )
+        // Is this brand online ?
+            ->add(
+                'visible',
+                CheckboxType::class,
+                [
+                    'required' => false,
+                    'label' => Translator::getInstance()->trans('This brand is online'),
+                    'label_attr' => [
+                        'for' => 'visible_create',
+                    ],
+                ],
+            );
+    }
+
+    protected function buildForm(): void
+    {
+        $this->doBuilForm(
+            Translator::getInstance()->trans(
+                'Enter here the brand name in the default language (%title%)',
+                ['%title%' => Lang::getDefaultLanguage()->getTitle()],
+            ),
+        );
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_brand_creation';
+    }
+}

--- a/Form/Brand/BrandDocumentModification.php
+++ b/Form/Brand/BrandDocumentModification.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\Brand;
+
+use Thelia\Form\Image\DocumentModification;
+
+/**
+ * @author  Franck Allimant <franck@cqfdev.fr>
+ */
+class BrandDocumentModification extends DocumentModification
+{
+    public static function getName(): string
+    {
+        return 'thelia_brand_document_modification';
+    }
+}

--- a/Form/Brand/BrandImageModification.php
+++ b/Form/Brand/BrandImageModification.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\Brand;
+
+use Thelia\Form\Image\ImageModification;
+
+/**
+ * @author  Franck Allimant <franck@cqfdev.fr>
+ */
+class BrandImageModification extends ImageModification
+{
+    public static function getName(): string
+    {
+        return 'thelia_brand_image_modification';
+    }
+}

--- a/Form/Brand/BrandModificationForm.php
+++ b/Form/Brand/BrandModificationForm.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\Brand;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+use Thelia\Core\Translation\Translator;
+use Thelia\Form\StandardDescriptionFieldsTrait;
+
+/**
+ * Class BrandModificationForm.
+ *
+ * @author  Franck Allimant <franck@cqfdev.fr>
+ */
+class BrandModificationForm extends BrandCreationForm
+{
+    use StandardDescriptionFieldsTrait;
+
+    protected function buildForm(): void
+    {
+        $this->doBuilForm(
+            Translator::getInstance()->trans('The brand name or title'),
+        );
+
+        $this->formBuilder->add(
+            'id',
+            HiddenType::class,
+            [
+                'constraints' => [new GreaterThan(['value' => 0])],
+                'required' => true,
+            ],
+        )
+            ->add('logo_image_id', IntegerType::class, [
+                'constraints' => [],
+                'required' => false,
+                'label' => Translator::getInstance()->trans('Select the brand logo'),
+                'label_attr' => [
+                    'for' => 'logo_image_id',
+                    'help' => Translator::getInstance()->trans('Select the brand logo amongst the brand images'),
+                ],
+            ]);
+
+        // Add standard description fields, excluding title and locale, which are already defined
+        $this->addStandardDescFields(['title', 'locale']);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_brand_modification';
+    }
+}

--- a/Form/Cache/AssetsFlushForm.php
+++ b/Form/Cache/AssetsFlushForm.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\Cache;
+
+use Thelia\Form\BaseForm;
+
+/**
+ * Class CacheFlushForm.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class AssetsFlushForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        // Nothing, we just want CSRF protection
+    }
+
+    public static function getName(): string
+    {
+        return 'assets_flush';
+    }
+}

--- a/Form/Cache/CacheFlushForm.php
+++ b/Form/Cache/CacheFlushForm.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\Cache;
+
+use Thelia\Form\BaseForm;
+
+/**
+ * Class CacheFlushForm.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class CacheFlushForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        // Nothing, we just want CSRF protection
+    }
+
+    public static function getName(): string
+    {
+        return 'cache_flush';
+    }
+}

--- a/Form/Cache/ImagesAndDocumentsCacheFlushForm.php
+++ b/Form/Cache/ImagesAndDocumentsCacheFlushForm.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\Cache;
+
+use Thelia\Form\BaseForm;
+
+/**
+ * Class CacheFlushForm.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class ImagesAndDocumentsCacheFlushForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        // Nothing, we just want CSRF protection
+    }
+
+    public static function getName(): string
+    {
+        return 'images_and_documents_cache_flush';
+    }
+}

--- a/Form/CategoryCreationForm.php
+++ b/Form/CategoryCreationForm.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Model\Lang;
+
+class CategoryCreationForm extends BaseForm
+{
+    protected function doBuilForm($titleHelpText): void
+    {
+        $this->formBuilder
+            ->add(
+                'title',
+                TextType::class,
+                [
+                    'constraints' => [new NotBlank()],
+                    'label' => $this->translator->trans('Category title'),
+                    'label_attr' => [
+                        'help' => $titleHelpText,
+                    ],
+                ],
+            )
+            ->add(
+                'parent',
+                IntegerType::class,
+                [
+                    'label' => $this->translator->trans('Parent category'),
+                    'constraints' => [new NotBlank()],
+                    'label_attr' => [
+                        'help' => $this->translator->trans('Select the parent category of this category.'),
+                    ],
+                ],
+            )
+            ->add(
+                'locale',
+                HiddenType::class,
+                [
+                    'constraints' => [new NotBlank()],
+                ],
+            )
+            ->add(
+                'visible',
+                IntegerType::class, // Should be checkbox, but this is not API compatible, see #1199
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans('This category is online'),
+                ],
+            );
+    }
+
+    protected function buildForm(): void
+    {
+        $this->doBuilForm(
+            $this->translator->trans(
+                'Enter here the category title in the default language (%title%)',
+                ['%title%' => Lang::getDefaultLanguage()->getTitle()],
+            ),
+        );
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_category_creation';
+    }
+}

--- a/Form/CategoryDocumentModification.php
+++ b/Form/CategoryDocumentModification.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Thelia\Form\Image\DocumentModification;
+
+/**
+ * Created by JetBrains PhpStorm.
+ * Date: 9/18/13
+ * Time: 3:56 PM.
+ *
+ * Form allowing to process an document collection
+ *
+ * @author  Guillaume MOREL <gmorel@openstudio.fr>
+ */
+class CategoryDocumentModification extends DocumentModification
+{
+    /**
+     * Get form name
+     * This name must be unique.
+     */
+    public static function getName(): string
+    {
+        return 'thelia_category_document_modification';
+    }
+}

--- a/Form/CategoryImageModification.php
+++ b/Form/CategoryImageModification.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Thelia\Form\Image\ImageModification;
+
+/**
+ * Created by JetBrains PhpStorm.
+ * Date: 9/18/13
+ * Time: 3:56 PM.
+ *
+ * Form allowing to process an image collection
+ *
+ * @author  Guillaume MOREL <gmorel@openstudio.fr>
+ */
+class CategoryImageModification extends ImageModification
+{
+    /**
+     * Get form name
+     * This name must be unique.
+     */
+    public static function getName(): string
+    {
+        return 'thelia_category_image_modification';
+    }
+}

--- a/Form/CategoryModificationForm.php
+++ b/Form/CategoryModificationForm.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+use Thelia\Model\Template;
+use Thelia\Model\TemplateQuery;
+
+class CategoryModificationForm extends CategoryCreationForm
+{
+    use StandardDescriptionFieldsTrait;
+
+    protected function buildForm(): void
+    {
+        $this->doBuilForm(
+            $this->translator->trans('The category title'),
+        );
+
+        // Create countries and shipping modules list
+        $templateList = [$this->translator->trans('None') => 0];
+
+        $list = TemplateQuery::create()->find();
+
+        // Get the current edition locale
+        $locale = $this->getRequest()->getSession()->getAdminEditionLang()->getLocale();
+
+        /** @var Template $item */
+        foreach ($list as $item) {
+            $templateList[$item->setLocale($locale)->getName()] = $item->getId();
+        }
+
+        asort($templateList);
+
+        $this->formBuilder
+            ->add(
+                'id',
+                HiddenType::class,
+                [
+                    'constraints' => [new GreaterThan(['value' => 0])],
+                ],
+            )
+            ->add(
+                'default_template_id',
+                ChoiceType::class,
+                [
+                    'choices' => $templateList,
+                    'label' => $this->translator->trans('Default product template'),
+                    'label_attr' => [
+                        'for' => 'price_offset_type',
+                        'help' => $this->translator->trans(
+                            'Select a default template for new products created in this category',
+                        ),
+                    ],
+                    'attr' => [
+                    ],
+                ],
+            );
+
+        // Add standard description fields, excluding title which is defined in parent class
+        $this->addStandardDescFields(['title']);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_category_modification';
+    }
+}

--- a/Form/ConfigCreationForm.php
+++ b/Form/ConfigCreationForm.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\ConfigQuery;
+
+class ConfigCreationForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('name', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new Callback($this->checkDuplicateName(...)),
+                ],
+                'label' => Translator::getInstance()->trans('Name *'),
+                'label_attr' => [
+                    'for' => 'name',
+                ],
+            ])
+            ->add('title', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('Purpose *'),
+                'label_attr' => [
+                    'for' => 'purpose',
+                ],
+            ])
+            ->add('locale', HiddenType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+            ])
+            ->add('value', TextType::class, [
+                'label' => Translator::getInstance()->trans('Value *'),
+                'label_attr' => [
+                    'for' => 'value',
+                ],
+            ])
+            ->add('hidden', HiddenType::class, [])
+            ->add('secured', HiddenType::class, [
+                'label' => Translator::getInstance()->trans('Prevent variable modification or deletion, except for super-admin'),
+            ]);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_config_creation';
+    }
+
+    public function checkDuplicateName($value, ExecutionContextInterface $context): void
+    {
+        $config = ConfigQuery::create()->findOneByName($value);
+
+        if ($config) {
+            $context->addViolation(Translator::getInstance()->trans('A variable with name "%name" already exists.', ['%name' => $value]));
+        }
+    }
+}

--- a/Form/ConfigModificationForm.php
+++ b/Form/ConfigModificationForm.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+
+class ConfigModificationForm extends BaseForm
+{
+    use StandardDescriptionFieldsTrait;
+
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('id', HiddenType::class, [
+                'constraints' => [
+                    new GreaterThan(
+                        ['value' => 0],
+                    ),
+                ],
+            ])
+            ->add('name', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('Name'),
+                'label_attr' => [
+                    'for' => 'name',
+                ],
+            ])
+            ->add('value', TextType::class, [
+                'label' => Translator::getInstance()->trans('Value'),
+                'label_attr' => [
+                    'for' => 'value',
+                ],
+            ])
+            ->add('hidden', HiddenType::class, [])
+            ->add('secured', HiddenType::class, [
+                'label' => Translator::getInstance()->trans('Prevent variable modification or deletion, except for super-admin'),
+            ]);
+
+        // Add standard description fields
+        $this->addStandardDescFields();
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_config_modification';
+    }
+}

--- a/Form/ConfigStoreForm.php
+++ b/Form/ConfigStoreForm.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\Image;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\ConfigQuery;
+
+class ConfigStoreForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $tr = Translator::getInstance();
+
+        $this->formBuilder
+            ->add(
+                'store_name',
+                TextType::class,
+                [
+                    'data' => ConfigQuery::getStoreName(),
+                    'constraints' => [new NotBlank()],
+                    'label' => $tr->trans('Store name'),
+                    'attr' => [
+                        'placeholder' => $tr->trans('Used in your store front'),
+                    ],
+                ],
+            )
+            ->add(
+                'store_description',
+                TextType::class,
+                [
+                    'data' => ConfigQuery::getStoreDescription(),
+                    'required' => false,
+                    'label' => $tr->trans('Store description'),
+                    'attr' => [
+                        'placeholder' => $tr->trans('Used in your store front'),
+                    ],
+                ],
+            )
+            ->add(
+                'store_email',
+                TextType::class,
+                [
+                    'data' => ConfigQuery::getStoreEmail(),
+                    'constraints' => [
+                        new NotBlank(),
+                        new Email(),
+                    ],
+                    'label' => $tr->trans('Store email address'),
+                    'attr' => [
+                        'placeholder' => $tr->trans('Contact and sender email address'),
+                    ],
+                    'label_attr' => [
+                        'help' => $tr->trans('This is the contact email address, and the sender email of all e-mails sent by your store.'),
+                    ],
+                ],
+            )
+            ->add(
+                'store_notification_emails',
+                TextType::class,
+                [
+                    'data' => ConfigQuery::read('store_notification_emails'),
+                    'constraints' => [
+                        new NotBlank(),
+                        new Callback(
+                            $this->checkEmailList(...),
+                        ),
+                    ],
+                    'label' => $tr->trans('Email addresses of notification recipients'),
+                    'attr' => [
+                        'placeholder' => $tr->trans('A comma separated list of email addresses'),
+                    ],
+                    'label_attr' => [
+                        'help' => $tr->trans('This is a comma separated list of email addresses where store notifications (such as order placed) are sent.'),
+                    ],
+                ],
+            )
+            ->add(
+                'store_business_id',
+                TextType::class,
+                [
+                    'data' => ConfigQuery::read('store_business_id'),
+                    'label' => $tr->trans('Business ID'),
+                    'required' => false,
+                    'attr' => [
+                        'placeholder' => $tr->trans('Store Business Identification Number (SIRET, etc).'),
+                    ],
+                ],
+            )
+            ->add(
+                'store_phone',
+                TextType::class,
+                [
+                    'data' => ConfigQuery::read('store_phone'),
+                    'label' => $tr->trans('Phone'),
+                    'required' => false,
+                    'attr' => [
+                        'placeholder' => $tr->trans('The store phone number.'),
+                    ],
+                ],
+            )
+            ->add(
+                'store_fax',
+                TextType::class,
+                [
+                    'data' => ConfigQuery::read('store_fax'),
+                    'label' => $tr->trans('Fax'),
+                    'required' => false,
+                    'attr' => [
+                        'placeholder' => $tr->trans('The store fax number.'),
+                    ],
+                ],
+            )
+            ->add(
+                'store_address1',
+                TextType::class,
+                [
+                    'data' => ConfigQuery::read('store_address1'),
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                    'label' => $tr->trans('Street Address'),
+                    'attr' => [
+                        'placeholder' => $tr->trans('Address.'),
+                    ],
+                ],
+            )
+            ->add(
+                'store_address2',
+                TextType::class,
+                [
+                    'data' => ConfigQuery::read('store_address2'),
+                    'required' => false,
+                    'attr' => [
+                        'placeholder' => $tr->trans('Additional address information'),
+                    ],
+                ],
+            )
+            ->add(
+                'store_address3',
+                TextType::class,
+                [
+                    'data' => ConfigQuery::read('store_address3'),
+                    'required' => false,
+                    'attr' => [
+                        'placeholder' => $tr->trans('Additional address information'),
+                    ],
+                ],
+            )
+            ->add(
+                'store_zipcode',
+                TextType::class,
+                [
+                    'data' => ConfigQuery::read('store_zipcode'),
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                    'label' => $tr->trans('Zip code'),
+                    'attr' => [
+                        'placeholder' => $tr->trans('Zip code'),
+                    ],
+                ],
+            )
+            ->add(
+                'store_city',
+                TextType::class,
+                [
+                    'data' => ConfigQuery::read('store_city'),
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                    'label' => $tr->trans('City'),
+                    'attr' => [
+                        'placeholder' => $tr->trans('City'),
+                    ],
+                ],
+            )
+            ->add(
+                'store_country',
+                IntegerType::class,
+                [
+                    'data' => ConfigQuery::read('store_country'),
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                    'label' => $tr->trans('Country'),
+                    'attr' => [
+                        'placeholder' => $tr->trans('Country'),
+                    ],
+                ],
+            )
+            ->add(
+                'favicon_file',
+                FileType::class,
+                [
+                    'required' => false,
+                    'constraints' => [
+                        new Image([
+                            'mimeTypes' => ['image/png', 'image/x-icon'],
+                        ]),
+                    ],
+                    'label' => $tr->trans('Favicon image'),
+                    'label_attr' => [
+                        'for' => 'favicon_file',
+                        'help' => $tr->trans('Icon of the website. Only PNG and ICO files are allowed.'),
+                    ],
+                ],
+            )
+            ->add(
+                'logo_file',
+                FileType::class,
+                [
+                    'required' => false,
+                    'constraints' => [
+                        new Image(),
+                    ],
+                    'label' => $tr->trans('Store logo'),
+                    'label_attr' => [
+                        'for' => 'logo_file',
+                    ],
+                ],
+            )
+            ->add(
+                'banner_file',
+                FileType::class,
+                [
+                    'required' => false,
+                    'constraints' => [
+                        new Image(),
+                    ],
+                    'label' => $tr->trans('Banner'),
+                    'label_attr' => [
+                        'for' => 'banner_file',
+                        'help' => $tr->trans('Banner of the website. Used in the e-mails send to the customers.'),
+                    ],
+                ],
+            );
+    }
+
+    public function checkEmailList($value, ExecutionContextInterface $context): void
+    {
+        $list = preg_split('/[,;]/', (string) $value);
+
+        $emailValidator = new Email();
+
+        foreach ($list as $email) {
+            $email = trim($email);
+
+            $context->getValidator()->validate($email, $emailValidator);
+        }
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_configuration_store';
+    }
+}

--- a/Form/ContentCreationForm.php
+++ b/Form/ContentCreationForm.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+
+class ContentCreationForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('title', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('Content title *'),
+                'label_attr' => [
+                    'for' => 'title',
+                ],
+            ])
+            ->add('default_folder', IntegerType::class, [
+                'label' => Translator::getInstance()->trans('Default folder *'),
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label_attr' => ['for' => 'default_folder'],
+            ])
+            ->add('locale', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+            ])
+            ->add('visible', IntegerType::class, [
+                'label' => Translator::getInstance()->trans('This content is online.'),
+                'label_attr' => ['for' => 'visible_create'],
+            ]);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_content_creation';
+    }
+}

--- a/Form/ContentDocumentModification.php
+++ b/Form/ContentDocumentModification.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Thelia\Form\Image\DocumentModification;
+
+/**
+ * Created by JetBrains PhpStorm.
+ * Date: 9/18/13
+ * Time: 3:56 PM.
+ *
+ * Form allowing to process a file
+ *
+ * @author  Guillaume MOREL <gmorel@openstudio.fr>
+ */
+class ContentDocumentModification extends DocumentModification
+{
+    /**
+     * Get form name
+     * This name must be unique.
+     */
+    public static function getName(): string
+    {
+        return 'thelia_content_document_modification';
+    }
+}

--- a/Form/ContentImageModification.php
+++ b/Form/ContentImageModification.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Thelia\Form\Image\ImageModification;
+
+/**
+ * Created by JetBrains PhpStorm.
+ * Date: 9/18/13
+ * Time: 3:56 PM.
+ *
+ * Form allowing to process an image collection
+ *
+ * @author  Guillaume MOREL <gmorel@openstudio.fr>
+ */
+class ContentImageModification extends ImageModification
+{
+    /**
+     * Get form name
+     * This name must be unique.
+     */
+    public static function getName(): string
+    {
+        return 'thelia_content_image_modification';
+    }
+}

--- a/Form/ContentModificationForm.php
+++ b/Form/ContentModificationForm.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+
+/**
+ * Class ContentModificationForm.
+ *
+ * @author manuel raynaud <manu@raynaud.io>
+ */
+class ContentModificationForm extends ContentCreationForm
+{
+    use StandardDescriptionFieldsTrait;
+
+    protected function buildForm(): void
+    {
+        parent::buildForm();
+
+        $this->formBuilder
+            ->add('id', HiddenType::class, ['constraints' => [new GreaterThan(['value' => 0])]]);
+
+        // Add standard description fields, excluding title and locale, which a re defined in parent class
+        $this->addStandardDescFields(['title', 'locale']);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_content_modification';
+    }
+}

--- a/Form/CountryCreationForm.php
+++ b/Form/CountryCreationForm.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class CountryCreationForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add(
+                'title',
+                TextType::class,
+                [
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                    'label' => $this->translator->trans('Country title'),
+                ],
+            )
+            ->add(
+                'locale',
+                HiddenType::class,
+                [
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                ],
+            )
+            ->add(
+                'visible',
+                CheckboxType::class,
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans('This country is online'),
+                    'label_attr' => [
+                        'for' => 'visible_create',
+                    ],
+                ],
+            )
+            ->add(
+                'isocode',
+                TextType::class,
+                [
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                    'label' => $this->translator->trans('Numerical ISO Code'),
+                    'label_attr' => [
+                        'help' => $this->translator->trans('Check country iso codes <a href="http://en.wikipedia.org/wiki/ISO_3166-1#Current_codes" target="_blank">here</a>.'),
+                    ],
+                ],
+            )
+            ->add(
+                'isoalpha2',
+                TextType::class,
+                [
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                    'label' => $this->translator->trans('ISO Alpha-2 code'),
+                    'label_attr' => [
+                        'help' => $this->translator->trans('Check country iso codes <a href="http://en.wikipedia.org/wiki/ISO_3166-1#Current_codes" target="_blank">here</a>.'),
+                    ],
+                ],
+            )
+            ->add(
+                'isoalpha3',
+                TextType::class,
+                [
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                    'label' => $this->translator->trans('ISO Alpha-3 code'),
+                    'label_attr' => [
+                        'help' => $this->translator->trans('Check country iso codes <a href="http://en.wikipedia.org/wiki/ISO_3166-1#Current_codes" target="_blank">here</a>.'),
+                    ],
+                ],
+            )
+            ->add(
+                'has_states',
+                CheckboxType::class,
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans('This country has states / provinces'),
+                    'label_attr' => [
+                        'for' => 'has_states_create',
+                    ],
+                ],
+            );
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_country_creation';
+    }
+}

--- a/Form/CountryModificationForm.php
+++ b/Form/CountryModificationForm.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+
+class CountryModificationForm extends CountryCreationForm
+{
+    use StandardDescriptionFieldsTrait;
+
+    protected function buildForm(): void
+    {
+        parent::buildForm();
+
+        $this->formBuilder
+            ->add('id', HiddenType::class, ['constraints' => [new GreaterThan(['value' => 0])]])
+            ->add(
+                'need_zip_code',
+                CheckboxType::class,
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans('Addresses for this country need a zip code'),
+                    'label_attr' => [
+                        'for' => 'need_zip_code',
+                    ],
+                ],
+            )
+            ->add(
+                'zip_code_format',
+                TextType::class,
+                [
+                    'required' => false,
+                    'constraints' => [],
+                    'label' => $this->translator->trans('The zip code format'),
+                    'label_attr' => [
+                        'help' => $this->translator->trans(
+                            'Use a N for a number, L for Letter, C for an iso code for the state.',
+                        ),
+                    ],
+                ],
+            );
+
+        // Add standard description fields, excluding title and locale, which a re defined in parent class
+        $this->addStandardDescFields(['title', 'locale']);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_country_modification';
+    }
+}

--- a/Form/CouponCreationForm.php
+++ b/Form/CouponCreationForm.php
@@ -1,0 +1,321 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\NotEqualTo;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\Country;
+use Thelia\Model\CountryQuery;
+use Thelia\Model\CouponQuery;
+use Thelia\Model\LangQuery;
+use Thelia\Model\Module;
+use Thelia\Model\ModuleQuery;
+use Thelia\Module\BaseModule;
+
+/**
+ * Allow to build a form Coupon.
+ *
+ * @author  Guillaume MOREL <gmorel@openstudio.fr>
+ */
+class CouponCreationForm extends BaseForm
+{
+    public const COUPON_CREATION_FORM_NAME = 'thelia_coupon_creation';
+
+    /**
+     * Build Coupon form.
+     */
+    protected function buildForm(): void
+    {
+        // Create countries and shipping modules list
+        $countries = [Translator::getInstance()->trans('All countries') => 0];
+
+        $list = CountryQuery::create()->find();
+
+        /** @var Country $item */
+        foreach ($list as $item) {
+            $countries[$item->getTitle()] = $item->getId();
+        }
+
+        asort($countries);
+
+        $modules = [Translator::getInstance()->trans('All shipping methods') => 0];
+
+        $list = ModuleQuery::create()->filterByActivate(BaseModule::IS_ACTIVATED)->filterByType(BaseModule::DELIVERY_MODULE_TYPE)->find();
+
+        /** @var Module $item */
+        foreach ($list as $item) {
+            $modules[$item->getTitle()] = $item->getId();
+        }
+
+        asort($modules);
+
+        $this->formBuilder
+            ->add(
+                'code',
+                TextType::class,
+                [
+                    'constraints' => [
+                        new NotBlank(),
+                        new Callback(
+                            [
+                                'callback' => $this->checkDuplicateCouponCode(...),
+                                'groups' => 'creation',
+                            ],
+                        ),
+                        new Callback(
+                            [
+                                'callback' => $this->checkCouponCodeChangedAndDoesntExists(...),
+                                'groups' => 'update',
+                            ],
+                        ),
+                    ],
+                ],
+            )
+            ->add(
+                'title',
+                TextType::class,
+                [
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                ],
+            )
+            ->add(
+                'shortDescription',
+                TextType::class,
+            )
+            ->add(
+                'description',
+                TextareaType::class,
+            )
+            ->add(
+                'type',
+                TextType::class,
+                [
+                    'constraints' => [
+                        new NotBlank(),
+                        new NotEqualTo(
+                            [
+                                'value' => -1,
+                            ],
+                        ),
+                    ],
+                ],
+            )
+            ->add(
+                'isEnabled',
+                TextType::class,
+                [],
+            )
+            ->add(
+                'startDate',
+                TextType::class,
+                [
+                    'constraints' => [
+                        new Callback(
+                            $this->checkLocalizedDate(...),
+                        ),
+                    ],
+                ],
+            )
+            ->add(
+                'expirationDate',
+                TextType::class,
+                [
+                    'constraints' => [
+                        new NotBlank(),
+                        new Callback($this->checkLocalizedDate(...)),
+                        new Callback($this->checkConsistencyDates(...)),
+                    ],
+                ],
+            )
+            ->add(
+                'isCumulative',
+                TextType::class,
+                [],
+            )
+            ->add(
+                'isRemovingPostage',
+                TextType::class,
+                [],
+            )
+            ->add(
+                'freeShippingForCountries',
+                ChoiceType::class,
+                [
+                    'multiple' => true,
+                    'choices' => $countries,
+                ],
+            )
+            ->add(
+                'freeShippingForModules',
+                ChoiceType::class,
+                [
+                    'multiple' => true,
+                    'choices' => $modules,
+                ],
+            )
+            ->add(
+                'isAvailableOnSpecialOffers',
+                TextType::class,
+                [],
+            )
+            ->add(
+                'maxUsage',
+                TextType::class,
+                [
+                    'constraints' => [
+                        new NotBlank(),
+                        new GreaterThanOrEqual(['value' => -1]),
+                    ],
+                ],
+            )
+            ->add(
+                'perCustomerUsageCount',
+                ChoiceType::class,
+                [
+                    'multiple' => false,
+                    'required' => true,
+                    'choices' => [
+                        Translator::getInstance()->trans('Per customer') => 1,
+                        Translator::getInstance()->trans('Overall') => 0,
+                    ],
+                ],
+            )
+            ->add(
+                'locale',
+                HiddenType::class,
+                [
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                ],
+            )
+            ->add(
+                'coupon_specific',
+                // Data will be json encoded on pre-submit because it can contains array or string...
+                TextType::class,
+                [
+                    // Value can be array or string so no validation possible here...
+                    'validation_groups' => false,
+                ],
+            );
+
+        $this->formBuilder->addEventListener(FormEvents::PRE_SUBMIT, static function (FormEvent $event): void {
+            $data = $event->getData();
+
+            if (isset($data['coupon_specific'])) {
+                $data['coupon_specific'] = json_encode($data['coupon_specific']);
+            }
+
+            $event->setData($data);
+        }, 256);
+    }
+
+    /**
+     * Check coupon code unicity.
+     */
+    public function checkDuplicateCouponCode(string $value, ExecutionContextInterface $context): void
+    {
+        $exists = CouponQuery::create()->filterByCode($value)->count() > 0;
+
+        if ($exists) {
+            $context->addViolation(
+                Translator::getInstance()->trans(
+                    "The coupon code '%code' already exists. Please choose another coupon code",
+                    ['%code' => $value],
+                ),
+            );
+        }
+    }
+
+    public function checkCouponCodeChangedAndDoesntExists($value, ExecutionContextInterface $context): void
+    {
+        $data = $context->getRoot()->getData();
+
+        $changed = isset($data['code']) && $data['code'] !== $value;
+        $exists = CouponQuery::create()->filterByCode($value)->count() > 0;
+
+        if ($changed && $exists) {
+            $context->addViolation(
+                Translator::getInstance()->trans(
+                    "The coupon code '%code' already exist. Please choose another coupon code",
+                    ['%code' => $value],
+                ),
+            );
+        }
+    }
+
+    /**
+     * Validate a date entered with the default Language date format.
+     */
+    public function checkLocalizedDate(?string $value, ExecutionContextInterface $context): void
+    {
+        if (null === $value || '' === $value) {
+            return;
+        }
+        $format = LangQuery::create()->findOneByByDefault(true)->getDatetimeFormat();
+
+        if (false === \DateTime::createFromFormat($format, $value)) {
+            $context->addViolation(
+                Translator::getInstance()->trans(
+                    "Date '%date' is invalid, please enter a valid date using %fmt format",
+                    [
+                        '%fmt' => $format,
+                        '%date' => $value,
+                    ],
+                ),
+            );
+        }
+    }
+
+    public function checkConsistencyDates($value, ExecutionContextInterface $context): void
+    {
+        if (null === $startDate = $this->getForm()->get('startDate')->getData()) {
+            return;
+        }
+
+        $format = LangQuery::create()->findOneByByDefault(true)->getDatetimeFormat();
+
+        $startDate = \DateTime::createFromFormat($format, $startDate);
+        $expirationDate = \DateTime::createFromFormat($format, $value);
+
+        if ($startDate <= $expirationDate) {
+            return;
+        }
+
+        $context->addViolation(
+            Translator::getInstance()->trans('Start date and expiration date are inconsistent'),
+        );
+    }
+
+    /**
+     * Get form name.
+     */
+    public static function getName(): string
+    {
+        return self::COUPON_CREATION_FORM_NAME;
+    }
+}

--- a/Form/CurrencyCreationForm.php
+++ b/Form/CurrencyCreationForm.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\CurrencyQuery;
+
+class CurrencyCreationForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $defaultCurrency = CurrencyQuery::create()->findOneByByDefault(true);
+
+        $this->formBuilder
+            ->add('name', TextType::class, [
+                'required' => true,
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => $this->translator->trans('Name'),
+                'label_attr' => [
+                    'for' => 'name',
+                    'help' => '&nbsp;',
+                ],
+                'attr' => [
+                    'placeholder' => $this->translator->trans('Currency name'),
+                ],
+            ])
+            ->add('locale', TextType::class, [
+                'required' => true,
+                'constraints' => [
+                    new NotBlank(),
+                ],
+            ])
+            ->add('symbol', TextType::class, [
+                'required' => true,
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => $this->translator->trans('Symbol'),
+                'label_attr' => [
+                    'for' => 'symbol',
+                    'help' => $this->translator->trans('The symbol, such as &#36;, £, &euro;...'),
+                ],
+                'attr' => [
+                    'placeholder' => $this->translator->trans('Symbol'),
+                ],
+            ])
+            ->add('format', TextType::class, [
+                'required' => true,
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => $this->translator->trans('Format'),
+                'label_attr' => [
+                    'for' => 'format',
+                    'help' => $this->translator->trans('%n for number, %c for the currency code, %s for the currency symbol'),
+                ],
+                'attr' => [
+                    'placeholder' => '%n',
+                ],
+            ])
+            ->add('rate', TextType::class, [
+                'required' => true,
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => $this->translator->trans(
+                    'Rate from %currencyCode',
+                    ['%currencyCode' => $defaultCurrency->getCode()],
+                ),
+                'label_attr' => [
+                    'for' => 'rate',
+                    'help' => $this->translator->trans(
+                        'The rate from %currencyCode: Price in %currencyCode x rate = Price in this currency',
+                        ['%currencyCode' => $defaultCurrency->getCode()],
+                    ),
+                ],
+                'attr' => [
+                    'placeholder' => $this->translator->trans('Rate'),
+                ],
+            ])
+            ->add('code', TextType::class, [
+                'required' => true,
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => $this->translator->trans('ISO 4217 code'),
+                'label_attr' => [
+                    'for' => 'iso_4217_code',
+                    'help' => $this->translator->trans('More information about ISO 4217'),
+                ],
+                'attr' => [
+                    'placeholder' => $this->translator->trans('Code'),
+                ],
+            ]);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_currency_creation';
+    }
+
+    public function checkDuplicateCode($value, ExecutionContextInterface $context): void
+    {
+        $currency = CurrencyQuery::create()->findOneByCode($value);
+
+        if ($currency) {
+            $context->addViolation(
+                Translator::getInstance()->trans(
+                    'A currency with code "%name" already exists.',
+                    ['%name' => $value],
+                ),
+            );
+        }
+    }
+}

--- a/Form/CurrencyModificationForm.php
+++ b/Form/CurrencyModificationForm.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+
+class CurrencyModificationForm extends CurrencyCreationForm
+{
+    protected function buildForm(): void
+    {
+        parent::buildForm();
+
+        $this->formBuilder
+            ->add('id', HiddenType::class, ['constraints' => [new GreaterThan(['value' => 0])]]);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_currency_modification';
+    }
+}

--- a/Form/ExportForm.php
+++ b/Form/ExportForm.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Model\LangQuery;
+
+/**
+ * Class ExportForm.
+ *
+ * @author Benjamin Perche <bperche@openstudio.fr>
+ */
+class ExportForm extends BaseForm
+{
+    public static function getName(): string
+    {
+        return 'thelia_export';
+    }
+
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            // Todo: use list
+            ->add(
+                'serializer',
+                TextType::class,
+                [
+                    'required' => true,
+                    'label' => $this->translator->trans('File format'),
+                    'label_attr' => [
+                        'for' => 'serializer',
+                    ],
+                ],
+            )
+            // Todo: use list
+            ->add(
+                'language',
+                IntegerType::class,
+                [
+                    'required' => true,
+                    'label' => $this->translator->trans('Language'),
+                    'label_attr' => [
+                        'for' => 'language',
+                    ],
+                    'constraints' => [
+                        new Callback(
+                            $this->checkLanguage(...),
+                        ),
+                    ],
+                ],
+            )
+            ->add('do_compress', CheckboxType::class, [
+                'label' => $this->translator->trans('Do compress'),
+                'label_attr' => ['for' => 'do_compress'],
+                'required' => false,
+            ])
+            // Todo: use list
+            ->add(
+                'archiver',
+                TextType::class,
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans('Archive Format'),
+                    'label_attr' => [
+                        'for' => 'archiver',
+                    ],
+                ],
+            )
+            ->add('images', CheckboxType::class, [
+                'label' => $this->translator->trans('Include images'),
+                'label_attr' => ['for' => 'with_images'],
+                'required' => false,
+            ])
+            ->add('documents', CheckboxType::class, [
+                'label' => $this->translator->trans('Include documents'),
+                'label_attr' => ['for' => 'with_documents'],
+                'required' => false,
+            ])
+            ->add('range_date_start', DateType::class, [
+                'label' => $this->translator->trans('Range date Start'),
+                'label_attr' => ['for' => 'for_range_date_start'],
+                'required' => false,
+                'years' => range(date('Y'), date('Y') - 5),
+                'input' => 'array',
+                'widget' => 'choice',
+                'format' => 'yyyy-MM-d',
+            ])
+            ->add('range_date_end', DateType::class, [
+                'label' => $this->translator->trans('Range date End'),
+                'label_attr' => ['for' => 'for_range_date_end'],
+                'required' => false,
+                'years' => range(date('Y'), date('Y') - 5),
+                'input' => 'array',
+                'widget' => 'choice',
+                'format' => 'yyyy-MM-d',
+            ]);
+    }
+
+    public function checkLanguage($value, ExecutionContextInterface $context): void
+    {
+        if (null === LangQuery::create()->findPk($value)) {
+            $context->addViolation(
+                $this->translator->trans(
+                    "The language \"%id\" doesn't exist",
+                    [
+                        '%id' => $value,
+                    ],
+                ),
+            );
+        }
+    }
+}

--- a/Form/FeatureAvCreationForm.php
+++ b/Form/FeatureAvCreationForm.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+
+class FeatureAvCreationForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('title', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('Title *'),
+                'label_attr' => [
+                    'for' => 'title',
+                ],
+            ])
+            ->add('locale', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+            ])
+            ->add('feature_id', HiddenType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+            ]);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_featureav_creation';
+    }
+}

--- a/Form/FeatureCreationForm.php
+++ b/Form/FeatureCreationForm.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+
+class FeatureCreationForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add(
+                'title',
+                TextType::class,
+                [
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                    'label' => Translator::getInstance()->trans('Title *'),
+                    'label_attr' => [
+                        'for' => 'title',
+                    ], ],
+            )
+            ->add(
+                'locale',
+                TextType::class,
+                [
+                    'constraints' => [
+                        new NotBlank(),
+                    ], ],
+            )
+            ->add(
+                'add_to_all',
+                CheckboxType::class,
+                [
+                    'label' => Translator::getInstance()->trans('Add to all product templates'),
+                    'label_attr' => [
+                        'for' => 'add_to_all',
+                    ], ],
+            );
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_feature_creation';
+    }
+}

--- a/Form/FeatureModificationForm.php
+++ b/Form/FeatureModificationForm.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+
+class FeatureModificationForm extends FeatureCreationForm
+{
+    use StandardDescriptionFieldsTrait;
+
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('id', HiddenType::class, [
+                'constraints' => [
+                    new GreaterThan(
+                        ['value' => 0],
+                    ),
+                ],
+            ]);
+
+        // Add standard description fields
+        $this->addStandardDescFields();
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_feature_modification';
+    }
+}

--- a/Form/FolderCreationForm.php
+++ b/Form/FolderCreationForm.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+
+class FolderCreationForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('title', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('Folder title *'),
+                'label_attr' => [
+                    'for' => 'title',
+                ],
+            ])
+            ->add('parent', TextType::class, [
+                'label' => Translator::getInstance()->trans('Parent folder *'),
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label_attr' => ['for' => 'parent_create'],
+            ])
+            ->add('locale', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label_attr' => ['for' => 'locale_create'],
+            ])
+            ->add('visible', IntegerType::class, [
+                'label' => Translator::getInstance()->trans('This folder is online.'),
+                'label_attr' => ['for' => 'visible_create'],
+            ]);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_folder_creation';
+    }
+}

--- a/Form/FolderDocumentModification.php
+++ b/Form/FolderDocumentModification.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Thelia\Form\Image\DocumentModification;
+
+/**
+ * Created by JetBrains PhpStorm.
+ * Date: 9/18/13
+ * Time: 3:56 PM.
+ *
+ * Form allowing to process a file
+ *
+ * @author  Guillaume MOREL <gmorel@openstudio.fr>
+ */
+class FolderDocumentModification extends DocumentModification
+{
+    /**
+     * Get form name
+     * This name must be unique.
+     */
+    public static function getName(): string
+    {
+        return 'thelia_folder_document_modification';
+    }
+}

--- a/Form/FolderImageModification.php
+++ b/Form/FolderImageModification.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Thelia\Form\Image\ImageModification;
+
+/**
+ * Created by JetBrains PhpStorm.
+ * Date: 9/18/13
+ * Time: 3:56 PM.
+ *
+ * Form allowing to process an image collection
+ *
+ * @author  Guillaume MOREL <gmorel@openstudio.fr>
+ */
+class FolderImageModification extends ImageModification
+{
+    /**
+     * Get form name
+     * This name must be unique.
+     */
+    public static function getName(): string
+    {
+        return 'thelia_folder_image_modification';
+    }
+}

--- a/Form/FolderModificationForm.php
+++ b/Form/FolderModificationForm.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+
+class FolderModificationForm extends FolderCreationForm
+{
+    use StandardDescriptionFieldsTrait;
+
+    protected function buildForm(): void
+    {
+        parent::buildForm();
+
+        $this->formBuilder
+            ->add('id', HiddenType::class, ['constraints' => [new GreaterThan(['value' => 0])]]);
+
+        // Add standard description fields, excluding title and locale, which a re defined in parent class
+        $this->addStandardDescFields(['title', 'locale']);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_folder_modification';
+    }
+}

--- a/Form/HookCreationForm.php
+++ b/Form/HookCreationForm.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Template\TemplateDefinition;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\HookQuery;
+
+/**
+ * Class HookCreationForm.
+ *
+ * @author Julien Chanséaume <jchanseaume@openstudio.fr>
+ */
+class HookCreationForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('code', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new Callback($this->checkCodeUnicity(...)),
+                ],
+                'label' => Translator::getInstance()->trans('Hook code'),
+                'label_attr' => [
+                    'for' => 'code',
+                ],
+            ])
+            ->add('locale', HiddenType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+            ])
+            ->add('type', ChoiceType::class, [
+                'choices' => [
+                    Translator::getInstance()->trans('Front Office') => TemplateDefinition::FRONT_OFFICE,
+                    Translator::getInstance()->trans('Back Office') => TemplateDefinition::BACK_OFFICE,
+                    Translator::getInstance()->trans('email') => TemplateDefinition::EMAIL,
+                    Translator::getInstance()->trans('pdf') => TemplateDefinition::PDF,
+                ],
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('Type'),
+                'label_attr' => [
+                    'for' => 'type',
+                ],
+            ])
+            ->add('native', HiddenType::class, [
+                'label' => Translator::getInstance()->trans('Native'),
+                'label_attr' => [
+                    'for' => 'native',
+                    'help' => Translator::getInstance()->trans('Core hook of Thelia.'),
+                ],
+            ])
+            ->add('active', CheckboxType::class, [
+                'label' => Translator::getInstance()->trans('Active'),
+                'required' => false,
+                'label_attr' => [
+                    'for' => 'active',
+                ],
+            ])
+            ->add('title', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('Hook title'),
+                'label_attr' => [
+                    'for' => 'title',
+                ],
+            ]);
+    }
+
+    public function checkCodeUnicity($code, ExecutionContextInterface $context): void
+    {
+        $type = $context->getRoot()->getData()['type'];
+
+        $query = HookQuery::create()->filterByCode($code)->filterByType($type);
+
+        if ($this->form->has('id')) {
+            $query->filterById($this->form->getRoot()->getData()['id'], Criteria::NOT_EQUAL);
+        }
+
+        if ($query->count() > 0) {
+            $context->addViolation(
+                Translator::getInstance()->trans(
+                    'A Hook with code %name already exists. Please choose another code.',
+                    ['%name' => $code],
+                ),
+            );
+        }
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_hook_creation';
+    }
+}

--- a/Form/HookModificationForm.php
+++ b/Form/HookModificationForm.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+use Thelia\Core\Translation\Translator;
+
+/**
+ * Class HookModificationForm.
+ *
+ * @author Julien Chanséaume <jchanseaume@openstudio.fr>
+ */
+class HookModificationForm extends HookCreationForm
+{
+    use StandardDescriptionFieldsTrait;
+
+    protected function buildForm(): void
+    {
+        parent::buildForm();
+
+        $this->formBuilder
+            ->add('id', HiddenType::class, ['constraints' => [new GreaterThan(['value' => 0])]])
+            ->add('by_module', CheckboxType::class, [
+                'label' => Translator::getInstance()->trans('By Module'),
+                'required' => false,
+                'label_attr' => [
+                    'for' => 'by_module',
+                    'help' => Translator::getInstance()->trans(
+                        'This hook is specific to a module (delivery/payment modules).',
+                    ),
+                ],
+            ])
+            ->add('block', CheckboxType::class, [
+                'label' => Translator::getInstance()->trans('Hook block'),
+                'required' => false,
+                'label_attr' => [
+                    'for' => 'block',
+                    'help' => Translator::getInstance()->trans(
+                        'If checked, this hook will be used by a hook block. If not, by hook function.',
+                    ),
+                ],
+            ]);
+
+        // Add standard description fields, excluding title and locale, which a re defined in parent class
+        $this->addStandardDescFields(['title', 'postscriptum', 'locale']);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_hook_modification';
+    }
+}

--- a/Form/ImportForm.php
+++ b/Form/ImportForm.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Model\LangQuery;
+
+/**
+ * Class ImportForm.
+ *
+ * @author Benjamin Perche <bperche@openstudio.fr>
+ */
+class ImportForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('file_upload', FileType::class, [
+                'label' => $this->translator->trans('File to upload'),
+                'label_attr' => ['for' => 'file_to_upload'],
+                'required' => true,
+                'constraints' => [
+                    new Assert\NotNull(),
+                ],
+            ])
+            ->add('language', IntegerType::class, [
+                'label' => $this->translator->trans('Language'),
+                'label_attr' => ['for' => 'language'],
+                'required' => true,
+                'constraints' => [
+                    new Assert\Callback(
+                        $this->checkLanguage(...),
+                    ),
+                ],
+            ]);
+    }
+
+    /**
+     * @return string the name of you form. This name must be unique
+     */
+    public static function getName(): string
+    {
+        return 'thelia_import';
+    }
+
+    public function checkLanguage($value, ExecutionContextInterface $context): void
+    {
+        if (null === LangQuery::create()->findPk($value)) {
+            $context->addViolation(
+                $this->translator->trans(
+                    "The language \"%id\" doesn't exist",
+                    [
+                        '%id' => $value,
+                    ],
+                ),
+            );
+        }
+    }
+}

--- a/Form/Lang/LangCreateForm.php
+++ b/Form/Lang/LangCreateForm.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\Lang;
+
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+use Thelia\Form\BaseForm;
+
+/**
+ * Class LangCreateForm.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class LangCreateForm extends BaseForm
+{
+    /**
+     * in this function you add all the fields you need for your Form.
+     * Form this you have to call add method on $this->formBuilder attribute :.
+     *
+     * $this->formBuilder->add("name", TextType::class)
+     *   ->add("email", EmailType::class, array(
+     *           "attr" => array(
+     *               "class" => "field"
+     *           ),
+     *           "label" => "email",
+     *           "constraints" => array(
+     *               new \Symfony\Component\Validator\Constraints\NotBlank()
+     *           )
+     *       )
+     *   )
+     *   ->add('age', IntegerType::class);
+     */
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('title', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('Language name'),
+                'label_attr' => [
+                    'for' => 'title_lang',
+                ],
+            ])
+            ->add('code', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('ISO 639-1 Code'),
+                'label_attr' => [
+                    'for' => 'code_lang',
+                ],
+            ])
+            ->add('locale', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('language locale'),
+                'label_attr' => [
+                    'for' => 'locale_lang',
+                ],
+            ])
+            ->add('date_time_format', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('date/time format'),
+                'label_attr' => [
+                    'for' => 'date_time_format',
+                ],
+            ])
+            ->add('date_format', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('date format'),
+                'label_attr' => [
+                    'for' => 'date_lang',
+                ],
+            ])
+            ->add('time_format', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('time format'),
+                'label_attr' => [
+                    'for' => 'time_lang',
+                ],
+            ])
+            ->add('decimal_separator', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('decimal separator'),
+                'label_attr' => [
+                    'for' => 'decimal_separator',
+                ],
+            ])
+            ->add('thousands_separator', TextType::class, [
+                'trim' => false,
+                'label' => Translator::getInstance()->trans('thousands separator'),
+                'label_attr' => [
+                    'for' => 'thousands_separator',
+                ],
+            ])
+            ->add('decimals', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('Decimal places'),
+                'label_attr' => [
+                    'for' => 'decimals',
+                ],
+            ]);
+    }
+
+    /**
+     * @return string the name of you form. This name must be unique
+     */
+    public static function getName(): string
+    {
+        return 'thelia_language_create';
+    }
+}

--- a/Form/Lang/LangDefaultBehaviorForm.php
+++ b/Form/Lang/LangDefaultBehaviorForm.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\Lang;
+
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+use Thelia\Form\BaseForm;
+
+/**
+ * Class LangDefaultBehaviorForm.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class LangDefaultBehaviorForm extends BaseForm
+{
+    /**
+     * in this function you add all the fields you need for your Form.
+     * Form this you have to call add method on $this->formBuilder attribute :.
+     *
+     * $this->formBuilder->add("name", TextType::class)
+     *   ->add("email", EmailType::class, array(
+     *           "attr" => array(
+     *               "class" => "field"
+     *           ),
+     *           "label" => "email",
+     *           "constraints" => array(
+     *               new \Symfony\Component\Validator\Constraints\NotBlank()
+     *           )
+     *       )
+     *   )
+     *   ->add('age', IntegerType::class);
+     */
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('behavior', ChoiceType::class, [
+                'choices' => [
+                    Translator::getInstance()->trans('Strictly use the requested language') => 0,
+                    Translator::getInstance()->trans('Replace by the default language') => 1,
+                ],
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('If a translation is missing or incomplete :'),
+                'label_attr' => [
+                    'for' => 'defaultBehavior-form',
+                ],
+            ]);
+    }
+
+    /**
+     * @return string the name of you form. This name must be unique
+     */
+    public static function getName(): string
+    {
+        return 'thelia_lang_defaultBehavior';
+    }
+}

--- a/Form/Lang/LangUpdateForm.php
+++ b/Form/Lang/LangUpdateForm.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\Lang;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+/**
+ * Class LangUpdateForm.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class LangUpdateForm extends LangCreateForm
+{
+    protected function buildForm(): void
+    {
+        parent::buildForm();
+
+        $this->formBuilder
+            ->add('id', HiddenType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new GreaterThan(['value' => 0]),
+                ],
+            ]);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_lang_update';
+    }
+}

--- a/Form/Lang/LangUrlEvent.php
+++ b/Form/Lang/LangUrlEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\Lang;
+
+use Thelia\Core\Event\ActionEvent;
+
+/**
+ * Class LangUrlEvent.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class LangUrlEvent extends ActionEvent
+{
+    protected $url = [];
+
+    public function addUrl($id, $url): void
+    {
+        $this->url[$id] = $url;
+    }
+
+    public function getUrl()
+    {
+        return $this->url;
+    }
+}

--- a/Form/Lang/LangUrlForm.php
+++ b/Form/Lang/LangUrlForm.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\Lang;
+
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Form\BaseForm;
+use Thelia\Model\LangQuery;
+
+/**
+ * Class LangUrlForm.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class LangUrlForm extends BaseForm
+{
+    public const LANG_PREFIX = 'url_';
+
+    /**
+     * in this function you add all the fields you need for your Form.
+     * Form this you have to call add method on $this->formBuilder attribute :.
+     *
+     * $this->formBuilder->add("name", TextType::class)
+     *   ->add("email", EmailType::class, array(
+     *           "attr" => array(
+     *               "class" => "field"
+     *           ),
+     *           "label" => "email",
+     *           "constraints" => array(
+     *               new \Symfony\Component\Validator\Constraints\NotBlank()
+     *           )
+     *       )
+     *   )
+     *   ->add('age', IntegerType::class);
+     */
+    protected function buildForm(): void
+    {
+        foreach (LangQuery::create()->find() as $lang) {
+            $this->formBuilder->add(
+                self::LANG_PREFIX.$lang->getId(),
+                TextType::class,
+                [
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                    'attr' => [
+                        'tag' => 'url',
+                        'url_id' => $lang->getId(),
+                        'url_title' => $lang->getTitle(),
+                    ],
+                ],
+            );
+        }
+    }
+
+    /**
+     * @return string the name of you form. This name must be unique
+     */
+    public static function getName(): string
+    {
+        return 'thelia_language_url';
+    }
+}

--- a/Form/MailingSystemModificationForm.php
+++ b/Form/MailingSystemModificationForm.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\ConfigQuery;
+
+/**
+ * Class MailingSystemModificationForm.
+ *
+ * @author Etienne Roudeix <eroudeix@openstudio.fr>
+ */
+class MailingSystemModificationForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $disabled = ConfigQuery::isSmtpInEnv();
+        $this->formBuilder
+            ->add('enabled', CheckboxType::class, [
+                'disabled' => $disabled,
+                'required' => false,
+                'label' => Translator::getInstance()->trans('Enable remote SMTP use'),
+                'label_attr' => ['for' => 'enabled_field'],
+            ])
+            ->add('host', TextType::class, [
+                'disabled' => $disabled,
+                'required' => false,
+                'label' => Translator::getInstance()->trans('Host'),
+                'label_attr' => ['for' => 'host_field'],
+            ])
+            ->add('port', TextType::class, [
+                'disabled' => $disabled,
+                'required' => false,
+                'label' => Translator::getInstance()->trans('Port'),
+                'label_attr' => ['for' => 'port_field'],
+            ])
+            ->add('encryption', TextType::class, [
+                'disabled' => $disabled,
+                'required' => false,
+                'label' => Translator::getInstance()->trans('Encryption'),
+                'label_attr' => [
+                    'for' => 'encryption_field',
+                    'help' => Translator::getInstance()->trans('ssl, tls or empty'),
+                ],
+            ])
+            ->add('username', TextType::class, [
+                'disabled' => $disabled,
+                'required' => false,
+                'label' => Translator::getInstance()->trans('Username'),
+                'label_attr' => ['for' => 'username_field'],
+            ])
+            ->add('password', PasswordType::class, [
+                'disabled' => $disabled,
+                'required' => false,
+                'label' => Translator::getInstance()->trans('Password'),
+                'label_attr' => ['for' => 'password_field'],
+            ])
+            ->add('authmode', TextType::class, [
+                'disabled' => $disabled,
+                'required' => false,
+                'label' => Translator::getInstance()->trans('Auth mode'),
+                'label_attr' => [
+                    'for' => 'authmode_field',
+                    'help' => Translator::getInstance()->trans('plain, login, cram-md5 or empty'),
+                ],
+            ])
+            ->add('timeout', TextType::class, [
+                'disabled' => $disabled,
+                'required' => false,
+                'label' => Translator::getInstance()->trans('Timeout'),
+                'label_attr' => ['for' => 'timeout_field'],
+            ])
+            ->add('sourceip', TextType::class, [
+                'disabled' => $disabled,
+                'required' => false,
+                'label' => Translator::getInstance()->trans('Source IP'),
+                'label_attr' => ['for' => 'sourceip_field'],
+            ]);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_mailing_system_modification';
+    }
+
+    /*public function verifyCode($value, ExecutionContextInterface $context)
+    {
+        $profile = ProfileQuery::create()
+            ->findOneByCode($value);
+
+        if (null !== $profile) {
+            $context->addViolation("Profile `code` already exists");
+        }
+    }*/
+}

--- a/Form/MessageCreationForm.php
+++ b/Form/MessageCreationForm.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\Lang;
+use Thelia\Model\MessageQuery;
+
+class MessageCreationForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('name', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new Callback($this->checkDuplicateName(...)),
+                ],
+                'label' => Translator::getInstance()->trans('Name'),
+                'label_attr' => [
+                    'for' => 'name',
+                    'help' => Translator::getInstance()->trans('This is an identifier that will be used in the code to get this message'),
+                ],
+                'attr' => [
+                    'placeholder' => Translator::getInstance()->trans('Mail template name'),
+                ],
+            ])
+            ->add('title', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('Purpose'),
+                'label_attr' => [
+                    'for' => 'purpose',
+                    'help' => Translator::getInstance()->trans(
+                        'Enter here the mail template purpose in the default language (%title%)',
+                        ['%title%' => Lang::getDefaultLanguage()->getTitle()],
+                    ),
+                ],
+                'attr' => [
+                    'placeholder' => Translator::getInstance()->trans('Mail template purpose'),
+                ],
+            ])
+            ->add('locale', HiddenType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+            ])
+            ->add('secured', HiddenType::class, []);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_message_creation';
+    }
+
+    public function checkDuplicateName($value, ExecutionContextInterface $context): void
+    {
+        $message = MessageQuery::create()->findOneByName($value);
+
+        if ($message) {
+            $context->addViolation(Translator::getInstance()->trans('A message with name "%name" already exists.', ['%name' => $value]));
+        }
+    }
+}

--- a/Form/MessageModificationForm.php
+++ b/Form/MessageModificationForm.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Type;
+use Thelia\Core\Translation\Translator;
+
+class MessageModificationForm extends BaseForm
+{
+    public static function getName(): string
+    {
+        return 'thelia_message_modification';
+    }
+
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('id', HiddenType::class, [
+                'constraints' => [
+                    new GreaterThan(['value' => 0]),
+                ],
+            ])
+
+            ->add('name', TextType::class, [
+                'constraints' => [new NotBlank()],
+                'label' => Translator::getInstance()->trans('Name'),
+                'label_attr' => [
+                    'for' => 'name',
+                    'help' => Translator::getInstance()->trans('This the unique name of this message. Do not change this value unless you understand what you do.'),
+                ],
+                'attr' => [
+                    'placeholder' => Translator::getInstance()->trans('Message name'),
+                ],
+            ])
+            // Define all messages as not secured.
+            ->add('secured', HiddenType::class, [
+                'constraints' => [new Type(['type' => 'bool'])],
+                'required' => false,
+                'data' => false,
+            ])
+            ->add('locale', HiddenType::class, [])
+            ->add('title', TextType::class, [
+                'constraints' => [new NotBlank()],
+                'label' => Translator::getInstance()->trans('Title'),
+                'label_attr' => [
+                    'for' => 'title',
+                    'help' => Translator::getInstance()->trans("This is the message purpose, such as 'Order confirmation'."),
+                ],
+                'attr' => [
+                    'placeholder' => Translator::getInstance()->trans('Title'),
+                ],
+            ])
+            ->add('subject', TextType::class, [
+                'constraints' => [new NotBlank()],
+                'label' => Translator::getInstance()->trans('Message subject'),
+                'label_attr' => [
+                    'for' => 'subject',
+                    'help' => Translator::getInstance()->trans("This is the subject of the e-mail, such as 'Your order is confirmed'."),
+                ],
+                'attr' => [
+                    'placeholder' => Translator::getInstance()->trans('Message subject'),
+                ],
+            ])
+
+            ->add('html_message', TextType::class, [
+                'label' => Translator::getInstance()->trans('HTML Message'),
+                'label_attr' => [
+                    'for' => 'html_message',
+                    'help' => Translator::getInstance()->trans('The mailing template in HTML format.'),
+                ],
+                'required' => false,
+            ])
+
+            ->add('text_message', TextareaType::class, [
+                'label' => Translator::getInstance()->trans('Text Message'),
+                'label_attr' => [
+                    'for' => 'text_message',
+                    'help' => Translator::getInstance()->trans('The mailing template in text-only format.'),
+                ],
+                'required' => false,
+            ])
+
+            ->add('html_layout_file_name', TextType::class, [
+                'label' => Translator::getInstance()->trans('Name of the HTML layout file'),
+                'label_attr' => [
+                    'for' => 'html_layout_file_name',
+                ],
+                'required' => false,
+            ])
+
+            ->add('html_template_file_name', TextType::class, [
+                'label' => Translator::getInstance()->trans('Name of the HTML template file'),
+                'label_attr' => [
+                    'for' => 'html_template_file_name',
+                ],
+                'required' => false,
+            ])
+
+            ->add('text_layout_file_name', TextType::class, [
+                'label' => Translator::getInstance()->trans('Name of the text layout file'),
+                'label_attr' => [
+                    'for' => 'text_layout_file_name',
+                ],
+                'required' => false,
+            ])
+
+            ->add('text_template_file_name', TextType::class, [
+                'label' => Translator::getInstance()->trans('Name of the text template file'),
+                'label_attr' => [
+                    'for' => 'text_template_file_name',
+                ],
+                'required' => false,
+            ]);
+    }
+}

--- a/Form/MessageSendSampleForm.php
+++ b/Form/MessageSendSampleForm.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+
+class MessageSendSampleForm extends BaseForm
+{
+    public static function getName(): string
+    {
+        return 'thelia_message_send_sample';
+    }
+
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add(
+                'recipient_email',
+                EmailType::class,
+                [
+                    'constraints' => [new NotBlank()],
+                    'label' => Translator::getInstance()->trans('Send test e-mail to:'),
+                    'attr' => [
+                        'placeholder' => Translator::getInstance()->trans('Recipient e-mail address'),
+                    ],
+                ],
+            );
+    }
+}

--- a/Form/ModuleHookCreationForm.php
+++ b/Form/ModuleHookCreationForm.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Thelia\Core\Hook\BaseHook;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\Base\ModuleHookQuery;
+use Thelia\Model\Hook;
+use Thelia\Model\HookQuery;
+use Thelia\Model\IgnoredModuleHookQuery;
+use Thelia\Model\Module;
+use Thelia\Model\ModuleQuery;
+
+/**
+ * Class HookCreationForm.
+ *
+ * @author Julien Chanséaume <jchanseaume@openstudio.fr>
+ */
+class ModuleHookCreationForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add(
+                'module_id',
+                ChoiceType::class,
+                [
+                    'choices' => $this->getModuleChoices(),
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                    'label' => $this->trans('Module'),
+                    'label_attr' => [
+                        'for' => 'module_id',
+                        'help' => $this->trans(
+                            'Only hookable modules are displayed in this menu.',
+                        ),
+                    ],
+                ],
+            )
+            ->add(
+                'hook_id',
+                ChoiceType::class,
+                [
+                    'choices' => $this->getHookChoices(),
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                    'label' => $this->trans('Hook'),
+                    'label_attr' => ['for' => 'hook_id'],
+                ],
+            )
+            ->add(
+                'classname',
+                TextType::class,
+                [
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                    'label' => $this->trans('Service ID'),
+                    'label_attr' => [
+                        'for' => 'classname',
+                        'help' => $this->trans(
+                            'The service id that will handle the hook (defined in the config.xml file of the module).',
+                        ),
+                    ],
+                ],
+            )
+            ->add(
+                'method',
+                TextType::class,
+                [
+                    'label' => $this->trans('Method Name'),
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                    'label_attr' => [
+                        'for' => 'method',
+                        'help' => $this->trans(
+                            'The method name that will handle the hook event.',
+                        ),
+                    ],
+                ],
+            )
+            ->add(
+                'templates',
+                TextType::class,
+                [
+                    'label' => $this->trans('Automatic rendered templates'),
+                    'constraints' => [
+                        new Callback(
+                            $this->verifyTemplates(...),
+                        ),
+                    ],
+                    'label_attr' => [
+                        'for' => 'templates',
+                        'help' => $this->trans(
+                            'When using the %method% method you can automatically render or dump templates or add CSS and JS files (e.g.: render:mytemplate.html;js:assets/js/myjs.js)',
+                            ['%method%' => BaseHook::INJECT_TEMPLATE_METHOD_NAME],
+                        ),
+                    ],
+                    'required' => false,
+                ],
+            );
+    }
+
+    protected function trans(?string $id, array $parameters = []): string
+    {
+        if (!$this->translator instanceof TranslatorInterface) {
+            $this->translator = Translator::getInstance();
+        }
+
+        return $this->translator->trans($id, $parameters);
+    }
+
+    /**
+     * @return mixed[]
+     */
+    protected function getModuleChoices(): array
+    {
+        $choices = [];
+        $modules = ModuleQuery::getActivated();
+
+        /** @var Module $module */
+        foreach ($modules as $module) {
+            // Check if module defines a hook ID
+            if (ModuleHookQuery::create()->filterByModuleId($module->getId())->count() > 0
+                || IgnoredModuleHookQuery::create()->filterByModuleId($module->getId())->count() > 0
+            ) {
+                $choices[$module->getTitle()] = $module->getId();
+            }
+        }
+
+        asort($choices);
+
+        return $choices;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    protected function getHookChoices(): array
+    {
+        $choices = [];
+        $hooks = HookQuery::create()
+            ->filterByActivate(true, Criteria::EQUAL)
+            ->joinWithI18n($this->translator->getLocale())
+            ->orderBy('HookI18n.title', Criteria::ASC)
+            ->find();
+
+        /** @var Hook $hook */
+        foreach ($hooks as $hook) {
+            $choices[$hook->getTitle().' (code '.$hook->getCode().')'] = $hook->getId();
+        }
+
+        return $choices;
+    }
+
+    /**
+     * Check if method is the right one if we want to use automatic inserted templates .
+     */
+    public function verifyTemplates($value, ExecutionContextInterface $context): void
+    {
+        $data = $context->getRoot()->getData();
+
+        if (!empty($data['templates']) && BaseHook::INJECT_TEMPLATE_METHOD_NAME !== $data['method']) {
+            $context->addViolation(
+                $this->trans(
+                    'If you use automatic insert templates, you should use the method %method%',
+                    [
+                        '%method%' => BaseHook::INJECT_TEMPLATE_METHOD_NAME,
+                    ],
+                ),
+            );
+        }
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_module_hook_creation';
+    }
+}

--- a/Form/ModuleHookModificationForm.php
+++ b/Form/ModuleHookModificationForm.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+use Thelia\Core\Translation\Translator;
+
+/**
+ * Class HookModificationForm.
+ *
+ * @author Julien Chanséaume <jchanseaume@openstudio.fr>
+ */
+class ModuleHookModificationForm extends ModuleHookCreationForm
+{
+    protected function buildForm(): void
+    {
+        parent::buildForm();
+
+        $this->formBuilder
+            ->add('id', HiddenType::class, ['constraints' => [new GreaterThan(['value' => 0])]])
+            ->add('active', CheckboxType::class, [
+                'label' => Translator::getInstance()->trans('Active'),
+                'required' => false,
+                'label_attr' => [
+                    'for' => 'active',
+                ],
+            ]);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_module_hook_modification';
+    }
+}

--- a/Form/ModuleImageModification.php
+++ b/Form/ModuleImageModification.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Thelia\Form\Image\ImageModification;
+
+class ModuleImageModification extends ImageModification
+{
+    /**
+     * Get form name
+     * This name must be unique.
+     */
+    public static function getName(): string
+    {
+        return 'thelia_module_image_modification';
+    }
+}

--- a/Form/ModuleInstallForm.php
+++ b/Form/ModuleInstallForm.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\File;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Archiver\Archiver\ZipArchiver;
+use Thelia\Core\Translation\Translator;
+use Thelia\Module\Validator\ModuleDefinition;
+use Thelia\Module\Validator\ModuleValidator;
+
+/**
+ * Class ProductCreationForm.
+ *
+ * @author  Julien Chanséaume <jchanseaume@openstudio.fr>
+ */
+class ModuleInstallForm extends BaseForm
+{
+    protected ModuleDefinition $moduleDefinition;
+    protected $modulePath;
+
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add(
+                'module',
+                FileType::class,
+                [
+                    'required' => true,
+                    'constraints' => [
+                        new File(
+                            [
+                                'mimeTypes' => [
+                                    'application/zip',
+                                ],
+                                'mimeTypesMessage' => Translator::getInstance()->trans('Please upload a valid Zip file'),
+                            ],
+                        ),
+                        new Callback(
+                            $this->checkModuleValidity(...),
+                        ),
+                    ],
+                    'label' => Translator::getInstance()->trans('The module zip file'),
+                    'label_attr' => [
+                        'for' => 'module',
+                    ],
+                ],
+            );
+    }
+
+    /**
+     * Check module validity.
+     */
+    public function checkModuleValidity(UploadedFile $file, ExecutionContextInterface $context): void
+    {
+        $modulePath = $this->unzipModule($file);
+
+        if (false !== $modulePath) {
+            try {
+                // get the first directory
+                $moduleFiles = $this->getDirContents($modulePath);
+
+                if (1 !== \count($moduleFiles['directories'])) {
+                    throw new \Exception(Translator::getInstance()->trans('Your zip must contain 1 root directory which is the root folder directory of your module'));
+                }
+
+                $moduleDirectory = $moduleFiles['directories'][0];
+
+                $this->modulePath = \sprintf('%s/%s', $modulePath, $moduleDirectory);
+
+                $moduleValidator = new ModuleValidator($this->modulePath);
+
+                $moduleValidator->validate();
+
+                $this->moduleDefinition = $moduleValidator->getModuleDefinition();
+            } catch (\Exception $ex) {
+                $context->addViolation(
+                    Translator::getInstance()->trans(
+                        'The module is not valid : %message',
+                        ['%message' => $ex->getMessage()],
+                    ),
+                );
+            }
+        }
+    }
+
+    public function getModuleDefinition(): ModuleDefinition
+    {
+        return $this->moduleDefinition;
+    }
+
+    public function getModulePath(): ?string
+    {
+        return $this->modulePath;
+    }
+
+    /**
+     * Unzip a module file.
+     *
+     * @return string|bool the path where the module has been extracted or false if an error has occured
+     */
+    protected function unzipModule(UploadedFile $file): string|bool
+    {
+        $extractPath = false;
+        $zip = new ZipArchiver(true);
+
+        if (!$zip->open($file->getRealPath())) {
+            throw new \Exception('unable to open zipfile');
+        }
+
+        $extractPath = $this->tempdir();
+
+        if (false !== $extractPath && false === $zip->extract($extractPath)) {
+            $extractPath = false;
+        }
+
+        $zip->close();
+
+        return $extractPath;
+    }
+
+    /**
+     * create a unique directory.
+     *
+     * @return bool|string the directory path or false if it fails
+     */
+    protected function tempdir(): bool|string
+    {
+        $tempfile = tempnam(sys_get_temp_dir(), '');
+
+        if (file_exists($tempfile)) {
+            unlink($tempfile);
+        }
+
+        mkdir($tempfile);
+
+        if (is_dir($tempfile)) {
+            return $tempfile;
+        }
+
+        return false;
+    }
+
+    protected function getDirContents(string $dir): array
+    {
+        $paths = array_diff(scandir($dir), ['..', '.']);
+
+        $out = [
+            'directories' => [],
+            'files' => [],
+        ];
+
+        foreach ($paths as $path) {
+            if (is_dir($dir.DS.$path)) {
+                $out['directories'][] = $path;
+            } else {
+                $out['files'][] = $path;
+            }
+        }
+
+        return $out;
+    }
+
+    public static function getName(): string
+    {
+        return 'module_install';
+    }
+}

--- a/Form/ModuleModificationForm.php
+++ b/Form/ModuleModificationForm.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\ModuleQuery;
+
+class ModuleModificationForm extends BaseForm
+{
+    use StandardDescriptionFieldsTrait;
+
+    protected function buildForm(): void
+    {
+        $this->addStandardDescFields();
+
+        $this->formBuilder
+            ->add('id', HiddenType::class, [
+                'required' => true,
+                'constraints' => [
+                    new NotBlank(),
+                    new Callback(
+                        $this->verifyModuleId(...),
+                    ),
+                ],
+                'attr' => [
+                    'id' => 'module_update_id',
+                ],
+            ]);
+        $this->formBuilder->get('id')->addEventListener(
+            FormEvents::SUBMIT,
+            static function (FormEvent $event): void {
+                $value = $event->getData();
+                $event->setData($value === null || $value === '' ? null : (int) $value);
+            }
+        );
+    }
+
+    /**
+     * @return string the name of you form. This name must be unique
+     */
+    public static function getName(): string
+    {
+        return 'thelia_admin_module_modification';
+    }
+
+    public function verifyModuleId($value, ExecutionContextInterface $context): void
+    {
+        $module = ModuleQuery::create()
+            ->findPk($value);
+
+        if (null === $module) {
+            $context->addViolation(Translator::getInstance()->trans('Module ID not found'));
+        }
+    }
+}

--- a/Form/OrderStatus/OrderStatusCreationForm.php
+++ b/Form/OrderStatus/OrderStatusCreationForm.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\OrderStatus;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Translation\Translator;
+use Thelia\Form\BaseForm;
+use Thelia\Form\StandardDescriptionFieldsTrait;
+use Thelia\Model\Lang;
+use Thelia\Model\OrderStatusQuery;
+
+/**
+ * Class OrderStatusCreationForm.
+ *
+ * @author  Gilles Bourgeat <gbourgeat@openstudio.fr>
+ */
+class OrderStatusCreationForm extends BaseForm
+{
+    use StandardDescriptionFieldsTrait;
+
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add(
+                'title',
+                TextType::class,
+                [
+                    'constraints' => [new NotBlank()],
+                    'required' => true,
+                    'label' => Translator::getInstance()->trans('Order status name'),
+                    'label_attr' => [
+                        'for' => 'title',
+                        'help' => Translator::getInstance()->trans(
+                            'Enter here the order status name in the default language (%title%)',
+                            ['%title%' => Lang::getDefaultLanguage()->getTitle()],
+                        ),
+                    ],
+                    'attr' => [
+                        'placeholder' => Translator::getInstance()->trans('The order status name or title'),
+                    ],
+                ],
+            )
+            ->add(
+                'code',
+                TextType::class,
+                [
+                    'constraints' => [
+                        new Callback($this->checkUniqueCode(...)),
+                        new Callback($this->checkFormatCode(...)),
+                        new Callback($this->checkIsRequiredCode(...)),
+                    ],
+                    'required' => true,
+                    'label' => Translator::getInstance()->trans('Order status code'),
+                    'label_attr' => [
+                        'for' => 'title',
+                        'help' => Translator::getInstance()->trans('Enter here the order status code'),
+                    ],
+                    'attr' => [
+                        'placeholder' => Translator::getInstance()->trans('The order status code'),
+                    ],
+                ],
+            )
+            ->add(
+                'color',
+                TextType::class,
+                [
+                    'constraints' => [
+                        new NotBlank(),
+                        new Callback($this->checkColor(...)),
+                    ],
+                    'required' => false,
+                    'label' => Translator::getInstance()->trans('Order status color'),
+                    'label_attr' => [
+                        'for' => 'title',
+                        'help' => Translator::getInstance()->trans('Choice a color for this order status code'),
+                    ],
+                    'attr' => [
+                        'placeholder' => Translator::getInstance()->trans('#000000'),
+                    ],
+                ],
+            );
+
+        $this->addStandardDescFields(['title', 'description', 'chapo', 'postscriptum']);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_order_status_creation';
+    }
+
+    public function checkColor($value, ExecutionContextInterface $context): void
+    {
+        if (!preg_match('/^#[0-9a-fA-F]{6}$/', (string) $value)) {
+            $context->addViolation(
+                Translator::getInstance()->trans('This is not a hexadecimal color.'),
+            );
+        }
+    }
+
+    public function checkUniqueCode($value, ExecutionContextInterface $context): void
+    {
+        $query = OrderStatusQuery::create()
+            ->filterByCode($value);
+
+        if ($this->form->has('id')) {
+            $query->filterById($this->form->get('id')->getData(), Criteria::NOT_EQUAL);
+        }
+
+        if ($query->findOne()) {
+            $context->addViolation(
+                Translator::getInstance()->trans('This code is already used.'),
+            );
+        }
+    }
+
+    public function checkFormatCode($value, ExecutionContextInterface $context): void
+    {
+        if (!empty($value) && !preg_match('/^\w+$/', (string) $value)) {
+            $context->addViolation(
+                Translator::getInstance()->trans('This is not a valid code.'),
+            );
+        }
+    }
+
+    public function checkIsRequiredCode($value, ExecutionContextInterface $context): void
+    {
+        if ($this->form->has('id') && null !== ($orderStatus = OrderStatusQuery::create()->findOneById($this->form->get('id')->getData())) && (!$orderStatus->getProtectedStatus() && empty($this->form->get('code')->getData()))) {
+            $context->addViolation(
+                Translator::getInstance()->trans('This value should not be blank.'),
+            );
+        }
+    }
+}

--- a/Form/OrderStatus/OrderStatusModificationForm.php
+++ b/Form/OrderStatus/OrderStatusModificationForm.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\OrderStatus;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+
+/**
+ * Class OrderStatusModificationForm.
+ *
+ * @author  Gilles Bourgeat <gbourgeat@openstudio.fr>
+ */
+class OrderStatusModificationForm extends OrderStatusCreationForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder->add('id', HiddenType::class, [
+            'required' => true,
+            'constraints' => [
+                new GreaterThan(['value' => 0]),
+            ],
+        ]);
+
+        parent::buildForm();
+
+        $this->addStandardDescFields();
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_order_status_modification';
+    }
+}

--- a/Form/OrderUpdateAddress.php
+++ b/Form/OrderUpdateAddress.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\CountryQuery;
+use Thelia\Model\CustomerTitleQuery;
+use Thelia\Model\OrderAddressQuery;
+
+/**
+ * Class AddressUpdateForm.
+ *
+ * @author Etienne Roudeix <eroudeix@openstudio.fr>
+ */
+class OrderUpdateAddress extends BaseForm
+{
+    use AddressCountryValidationTrait;
+
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('id', IntegerType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new Callback(
+                        $this->verifyId(...),
+                    ),
+                ],
+                'required' => true,
+            ])
+            ->add('title', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new Callback(
+                        $this->verifyTitle(...),
+                    ),
+                ],
+                'label' => Translator::getInstance()->trans('Title'),
+                'label_attr' => [
+                    'for' => 'title_update',
+                ],
+            ])
+            ->add('firstname', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('Firstname'),
+                'label_attr' => [
+                    'for' => 'firstname_update',
+                ],
+            ])
+            ->add('lastname', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('Lastname'),
+                'label_attr' => [
+                    'for' => 'lastname_update',
+                ],
+            ])
+            ->add('address1', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('Street Address'),
+                'label_attr' => [
+                    'for' => 'address1_update',
+                ],
+            ])
+            ->add('address2', TextType::class, [
+                'required' => false,
+                'label' => Translator::getInstance()->trans('Additional address'),
+                'label_attr' => [
+                    'for' => 'address2_update',
+                ],
+            ])
+            ->add('address3', TextType::class, [
+                'required' => false,
+                'label' => Translator::getInstance()->trans('Additional address'),
+                'label_attr' => [
+                    'for' => 'address3_update',
+                ],
+            ])
+            ->add('zipcode', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new Callback(
+                        $this->verifyZipCode(...),
+                    ),
+                ],
+                'label' => Translator::getInstance()->trans('Zip code'),
+                'label_attr' => [
+                    'for' => 'zipcode_update',
+                ],
+            ])
+            ->add('city', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => Translator::getInstance()->trans('City'),
+                'label_attr' => [
+                    'for' => 'city_update',
+                ],
+            ])
+            ->add('country', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new Callback(
+                        $this->verifyCountry(...),
+                    ),
+                ],
+                'label' => Translator::getInstance()->trans('Country'),
+                'label_attr' => [
+                    'for' => 'country_update',
+                ],
+            ])
+            ->add('state', TextType::class, [
+                'required' => false,
+                'constraints' => [
+                    new Callback(
+                        $this->verifyState(...),
+                    ),
+                ],
+                'label' => Translator::getInstance()->trans('State *'),
+                'label_attr' => [
+                    'for' => 'state',
+                ],
+            ])
+            ->add('phone', TextType::class, [
+                'required' => false,
+                'label' => Translator::getInstance()->trans('Phone'),
+                'label_attr' => [
+                    'for' => 'phone_update',
+                ],
+            ])
+            ->add('cellphone', TextType::class, [
+                'required' => false,
+                'label' => Translator::getInstance()->trans('Cellphone'),
+                'label_attr' => [
+                    'for' => 'cellphone_update',
+                ],
+            ])
+            ->add('company', TextType::class, [
+                'required' => false,
+                'label' => Translator::getInstance()->trans('Compagny'),
+                'label_attr' => [
+                    'for' => 'company_update',
+                ],
+            ]);
+    }
+
+    /**
+     * @return string the name of you form. This name must be unique
+     */
+    public static function getName(): string
+    {
+        return 'thelia_order_address_update';
+    }
+
+    public function verifyId($value, ExecutionContextInterface $context): void
+    {
+        $address = OrderAddressQuery::create()
+            ->findPk($value);
+
+        if (null === $address) {
+            $context->addViolation(Translator::getInstance()->trans('Order address ID not found'));
+        }
+    }
+
+    public function verifyTitle($value, ExecutionContextInterface $context): void
+    {
+        $address = CustomerTitleQuery::create()
+            ->findPk($value);
+
+        if (null === $address) {
+            $context->addViolation(Translator::getInstance()->trans('Title ID not found'));
+        }
+    }
+
+    public function verifyCountry($value, ExecutionContextInterface $context): void
+    {
+        $address = CountryQuery::create()
+            ->findPk($value);
+
+        if (null === $address) {
+            $context->addViolation(Translator::getInstance()->trans('Country ID not found'));
+        }
+    }
+}

--- a/Form/ProductCloneForm.php
+++ b/Form/ProductCloneForm.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Model\ProductQuery;
+
+class ProductCloneForm extends BaseForm
+{
+    public static function getName(): string
+    {
+        return 'thelia_product_clone';
+    }
+
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('productId', IntegerType::class, [
+                'constraints' => [new NotBlank()],
+            ])
+            ->add('newRef', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new Callback($this->checkRefDifferent(...)),
+                ],
+                'label' => $this->translator->trans('Product reference (must be unique)'),
+                'label_attr' => ['for' => 'newRef'],
+            ]);
+    }
+
+    public function checkRefDifferent($value, ExecutionContextInterface $context): void
+    {
+        $originalRef = ProductQuery::create()
+            ->filterByRef($value, Criteria::EQUAL)
+            ->count();
+
+        if (0 !== $originalRef) {
+            $context->addViolation($this->translator->trans('This product reference is already assigned to another product.'));
+        }
+    }
+}

--- a/Form/ProductCombinationGenerationForm.php
+++ b/Form/ProductCombinationGenerationForm.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Translation\Translator;
+
+class ProductCombinationGenerationForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('product_id', IntegerType::class, [
+                'label' => Translator::getInstance()->trans('Product ID'),
+                'label_attr' => ['for' => 'combination_builder_id_field'],
+                'constraints' => [new GreaterThan(['value' => 0])],
+            ])
+            ->add('currency', IntegerType::class, [
+                'label' => Translator::getInstance()->trans('Price currency *'),
+                'label_attr' => ['for' => 'combination_builder_currency_field'],
+                'constraints' => [new GreaterThan(['value' => 0])],
+            ])
+            ->add('reference', TextType::class, [
+                'label' => Translator::getInstance()->trans('Reference'),
+                'label_attr' => ['for' => 'combination_builder_reference_field'],
+            ])
+            ->add('price', NumberType::class, [
+                'label' => Translator::getInstance()->trans('Product price excluding taxes'),
+                'label_attr' => ['for' => 'combination_builder_price_field'],
+            ])
+            ->add('weight', NumberType::class, [
+                'label' => Translator::getInstance()->trans('Weight'),
+                'label_attr' => ['for' => 'combination_builder_weight_field'],
+            ])
+            ->add('quantity', NumberType::class, [
+                'label' => Translator::getInstance()->trans('Available quantity'),
+                'label_attr' => ['for' => 'combination_builder_quantity_field'],
+            ])
+            ->add('sale_price', NumberType::class, [
+                'label' => Translator::getInstance()->trans('Sale price excluding taxes'),
+                'label_attr' => ['for' => 'combination_builder_price_with_tax_field'],
+            ])
+            ->add('onsale', IntegerType::class, [
+                'label' => Translator::getInstance()->trans('This product is on sale'),
+                'label_attr' => ['for' => 'combination_builder_onsale_field'],
+            ])
+            ->add('isnew', IntegerType::class, [
+                'label' => Translator::getInstance()->trans('Advertise this product as new'),
+                'label_attr' => ['for' => 'combination_builder_isnew_field'],
+            ])
+            ->add('ean_code', TextType::class, [
+                'label' => Translator::getInstance()->trans('EAN Code'),
+                'label_attr' => ['for' => 'combination_builder_ean_code_field'],
+            ])
+            ->add('attribute_av', CollectionType::class, [
+                'entry_type' => TextType::class,
+                'label' => Translator::getInstance()->trans('Attribute ID:Attribute AV ID'),
+                'label_attr' => ['for' => 'combination_builder_attribute_av_id'],
+                'allow_add' => true,
+                'allow_delete' => true,
+                'constraints' => [
+                    new Callback($this->checkAttributeAv(...)),
+                ],
+            ]);
+    }
+
+    public function checkAttributeAv($value, ExecutionContextInterface $context): void
+    {
+        if (empty($value)) {
+            $context->addViolation(
+                Translator::getInstance()->trans(
+                    'You must select at least one attribute.',
+                ),
+            );
+        }
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_product_combination_generation_form';
+    }
+}

--- a/Form/ProductCreationForm.php
+++ b/Form/ProductCreationForm.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\ProductQuery;
+
+class ProductCreationForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $this->doBuildForm(false);
+    }
+
+    protected function doBuildForm($change_mode): void
+    {
+        $this->formBuilder
+            ->add('ref', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new Callback($this->checkDuplicateRef(...)),
+                ],
+                'label' => Translator::getInstance()->trans('Product reference *'),
+                'label_attr' => ['for' => 'ref'],
+            ])
+            ->add('title', TextType::class, [
+                'constraints' => [new NotBlank()],
+                'label' => Translator::getInstance()->trans('Product title'),
+                'label_attr' => ['for' => 'title'],
+            ])
+            ->add('default_category', IntegerType::class, [
+                'constraints' => [new NotBlank()],
+                'label' => Translator::getInstance()->trans('Default product category *'),
+                'label_attr' => ['for' => 'default_category_field'],
+            ])
+            ->add('locale', TextType::class, [
+                'constraints' => [new NotBlank()],
+            ])
+            ->add('visible', IntegerType::class, [
+                'label' => Translator::getInstance()->trans('This product is online'),
+                'label_attr' => ['for' => 'visible_field'],
+            ])
+            ->add('virtual', IntegerType::class, [
+                'label' => Translator::getInstance()->trans('This product does not have a physical presence'),
+                'label_attr' => ['for' => 'virtual_field'],
+            ]);
+
+        if (!$change_mode) {
+            $this->formBuilder
+                ->add('price', NumberType::class, [
+                    'constraints' => [new NotBlank()],
+                    'label' => Translator::getInstance()->trans('Product base price excluding taxes *'),
+                    'label_attr' => ['for' => 'price_without_tax'],
+                ])
+                ->add('tax_price', NumberType::class, [
+                    'label' => Translator::getInstance()->trans('Product base price with taxes'),
+                    'label_attr' => ['for' => 'price_with_tax'],
+                ])
+                ->add('currency', IntegerType::class, [
+                    'constraints' => [new NotBlank()],
+                    'label' => Translator::getInstance()->trans('Price currency *'),
+                    'label_attr' => ['for' => 'currency_field'],
+                ])
+                ->add('tax_rule', IntegerType::class, [
+                    'constraints' => [new NotBlank()],
+                    'label' => Translator::getInstance()->trans('Tax rule for this product *'),
+                    'label_attr' => ['for' => 'tax_rule_field'],
+                ])
+                ->add('weight', NumberType::class, [
+                    'label' => Translator::getInstance()->trans('Weight'),
+                    'label_attr' => ['for' => 'weight_field'],
+                ])
+                ->add('quantity', NumberType::class, [
+                    'label' => Translator::getInstance()->trans('Stock'),
+                    'label_attr' => ['for' => 'quantity_field'],
+                    'required' => false,
+                ])
+                ->add('template_id', IntegerType::class, [
+                    'label' => Translator::getInstance()->trans('Template'),
+                    'label_attr' => ['for' => 'template_field'],
+                    'required' => false,
+                ]);
+        }
+    }
+
+    public function checkDuplicateRef($value, ExecutionContextInterface $context): void
+    {
+        $count = ProductQuery::create()->filterByRef($value)->count();
+
+        if ($count > 0) {
+            $context->addViolation(
+                Translator::getInstance()->trans(
+                    'A product with reference %ref already exists. Please choose another reference.',
+                    ['%ref' => $value],
+                ),
+            );
+        }
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_product_creation';
+    }
+}

--- a/Form/ProductDefaultSaleElementUpdateForm.php
+++ b/Form/ProductDefaultSaleElementUpdateForm.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\Currency;
+
+class ProductDefaultSaleElementUpdateForm extends ProductSaleElementUpdateForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('product_id', IntegerType::class, [
+                'label' => Translator::getInstance()->trans('Product ID *'),
+                'label_attr' => ['for' => 'product_id_field'],
+                'constraints' => [new GreaterThan(['value' => 0])],
+            ])
+            ->add('product_sale_element_id', IntegerType::class, [
+                'label' => Translator::getInstance()->trans('Product sale element ID *'),
+                'label_attr' => ['for' => 'product_sale_element_id_field'],
+            ])
+            ->add('reference', TextType::class, [
+                'label' => Translator::getInstance()->trans('Reference *'),
+                'label_attr' => ['for' => 'reference_field'],
+            ])
+            ->add('price', NumberType::class, [
+                'constraints' => [new NotBlank()],
+                'label' => Translator::getInstance()->trans('Product price excluding taxes *'),
+                'label_attr' => ['for' => 'price_field'],
+            ])
+            ->add('price_with_tax', NumberType::class, [
+                'label' => Translator::getInstance()->trans('Product price including taxes'),
+                'label_attr' => ['for' => 'price_with_tax_field'],
+            ])
+            ->add('currency', IntegerType::class, [
+                'constraints' => [new NotBlank()],
+                'label' => Translator::getInstance()->trans('Price currency *'),
+                'label_attr' => ['for' => 'currency_field'],
+            ])
+            ->add('tax_rule', IntegerType::class, [
+                'constraints' => [new NotBlank()],
+                'label' => Translator::getInstance()->trans('Tax rule for this product *'),
+                'label_attr' => ['for' => 'tax_rule_field'],
+            ])
+            ->add('weight', NumberType::class, [
+                'label' => Translator::getInstance()->trans('Weight'),
+                'label_attr' => ['for' => 'weight_field'],
+            ])
+            ->add('quantity', NumberType::class, [
+                'constraints' => [new NotBlank()],
+                'label' => Translator::getInstance()->trans('Available quantity *'),
+                'label_attr' => ['for' => 'quantity_field'],
+            ])
+            ->add('sale_price', NumberType::class, [
+                'label' => Translator::getInstance()->trans('Sale price excluding taxes'),
+                'label_attr' => ['for' => 'price_with_tax_field'],
+            ])
+            ->add('sale_price_with_tax', NumberType::class, [
+                'label' => Translator::getInstance()->trans('Sale price including taxes'),
+                'label_attr' => ['for' => 'sale_price_with_tax_field'],
+            ])
+            ->add('onsale', IntegerType::class, [
+                'label' => Translator::getInstance()->trans('This product is on sale'),
+                'label_attr' => ['for' => 'onsale_field'],
+            ])
+            ->add('isnew', IntegerType::class, [
+                'label' => Translator::getInstance()->trans('Advertise this product as new'),
+                'label_attr' => ['for' => 'isnew_field'],
+            ])
+            ->add('isdefault', IntegerType::class, [
+                'label' => Translator::getInstance()->trans('Is it the default product sale element ?'),
+                'label_attr' => ['for' => 'isdefault_field'],
+            ])
+            ->add('ean_code', TextType::class, [
+                'label' => Translator::getInstance()->trans('EAN Code'),
+                'label_attr' => ['for' => 'ean_code_field'],
+            ])
+            ->add('use_exchange_rate', IntegerType::class, [
+                'label' => Translator::getInstance()->trans('Apply exchange rates on price in %sym', ['%sym' => Currency::getDefaultCurrency()->getSymbol()]),
+                'label_attr' => ['for' => 'use_exchange_rate_field'],
+            ]);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_product_default_sale_element_update_form';
+    }
+}

--- a/Form/ProductDocumentModification.php
+++ b/Form/ProductDocumentModification.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Thelia\Form\Image\DocumentModification;
+
+/**
+ * Created by JetBrains PhpStorm.
+ * Date: 9/18/13
+ * Time: 3:56 PM.
+ *
+ * Form allowing to process a file
+ *
+ * @author  Guillaume MOREL <gmorel@openstudio.fr>
+ */
+class ProductDocumentModification extends DocumentModification
+{
+    /**
+     * Get form name
+     * This name must be unique.
+     */
+    public static function getName(): string
+    {
+        return 'thelia_product_document_modification';
+    }
+}

--- a/Form/ProductImageModification.php
+++ b/Form/ProductImageModification.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Thelia\Form\Image\ImageModification;
+
+/**
+ * Created by JetBrains PhpStorm.
+ * Date: 9/18/13
+ * Time: 3:56 PM.
+ *
+ * Form allowing to process an image collection
+ *
+ * @author  Guillaume MOREL <gmorel@openstudio.fr>
+ */
+class ProductImageModification extends ImageModification
+{
+    /**
+     * Get form name
+     * This name must be unique.
+     */
+    public static function getName(): string
+    {
+        return 'thelia_product_image_modification';
+    }
+}

--- a/Form/ProductModificationForm.php
+++ b/Form/ProductModificationForm.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\ProductQuery;
+
+class ProductModificationForm extends ProductCreationForm
+{
+    use StandardDescriptionFieldsTrait;
+
+    protected function buildForm(): void
+    {
+        parent::doBuildForm(true);
+
+        $this->formBuilder
+            ->add('id', IntegerType::class, [
+                'label' => Translator::getInstance()->trans('Prodcut ID *'),
+                'label_attr' => ['for' => 'product_id_field'],
+                'constraints' => [new GreaterThan(['value' => 0])],
+            ])
+            ->add('template_id', IntegerType::class, [
+                'label' => Translator::getInstance()->trans('Product template'),
+                'label_attr' => ['for' => 'product_template_field'],
+            ])
+            ->add('brand_id', IntegerType::class, [
+                'constraints' => [new NotBlank()],
+                'required' => true,
+                'label' => Translator::getInstance()->trans('Brand / Supplier'),
+                'label_attr' => [
+                    'for' => 'mode',
+                    'help' => Translator::getInstance()->trans('Select the product brand, or supplier.'),
+                ],
+            ])
+            ->add('virtual_document_id', IntegerType::class, [
+                'label' => Translator::getInstance()->trans('Virtual document'),
+                'label_attr' => ['for' => 'virtual_document_id_field'],
+            ]);
+
+        // Add standard description fields, excluding title and locale, which a re defined in parent class
+        $this->addStandardDescFields(['title', 'locale']);
+    }
+
+    public function checkDuplicateRef($value, ExecutionContextInterface $context): void
+    {
+        $data = $context->getRoot()->getData();
+
+        $count = ProductQuery::create()
+            ->filterById($data['id'], Criteria::NOT_EQUAL)
+            ->filterByRef($value)->count();
+
+        if ($count > 0) {
+            $context->addViolation(
+                Translator::getInstance()->trans(
+                    'A product with reference %ref already exists. Please choose another reference.',
+                    ['%ref' => $value],
+                ),
+            );
+        }
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_product_modification';
+    }
+}

--- a/Form/ProductSaleElementUpdateForm.php
+++ b/Form/ProductSaleElementUpdateForm.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\Currency;
+
+class ProductSaleElementUpdateForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('tax_rule', IntegerType::class, [
+                'constraints' => [new NotBlank()],
+                'label' => Translator::getInstance()->trans('Tax rule for this product *'),
+                'label_attr' => ['for' => 'tax_rule_field'],
+            ])
+            ->add('product_id', IntegerType::class, [
+                'label' => Translator::getInstance()->trans('Product ID *'),
+                'label_attr' => ['for' => 'product_id_field'],
+                'constraints' => [new GreaterThan(['value' => 0])],
+            ])
+            ->add('default_pse', IntegerType::class, [
+                'label' => Translator::getInstance()->trans('Default product sale element'),
+                'label_attr' => ['for' => 'default_pse_field'],
+            ])
+            ->add('currency', IntegerType::class, [
+                'constraints' => [new NotBlank()],
+                'label' => Translator::getInstance()->trans('Price currency *'),
+                'label_attr' => ['for' => 'currency_field'],
+            ])
+            ->add('use_exchange_rate', IntegerType::class, [
+                'label' => Translator::getInstance()->trans('Apply exchange rates on price in %sym', ['%sym' => Currency::getDefaultCurrency()->getSymbol()]),
+                'label_attr' => ['for' => 'use_exchange_rate_field'],
+            ])
+
+            // -- Collections
+
+            ->add('product_sale_element_id', CollectionType::class, [
+                'entry_type' => IntegerType::class,
+                'label' => Translator::getInstance()->trans('Product sale element ID *'),
+                'label_attr' => ['for' => 'product_sale_element_id_field'],
+                'allow_add' => true,
+                'allow_delete' => true,
+            ])
+            ->add('reference', CollectionType::class, [
+                'entry_type' => TextType::class,
+                'label' => Translator::getInstance()->trans('Reference *'),
+                'label_attr' => ['for' => 'reference_field'],
+                'allow_add' => true,
+                'allow_delete' => true,
+            ])
+            ->add('price', CollectionType::class, [
+                'entry_type' => NumberType::class,
+                'label' => Translator::getInstance()->trans('Product price excluding taxes *'),
+                'label_attr' => ['for' => 'price_field'],
+                'allow_add' => true,
+                'allow_delete' => true,
+                'entry_options' => [
+                    'constraints' => [new NotBlank()],
+                ],
+            ])
+            ->add('price_with_tax', CollectionType::class, [
+                'entry_type' => NumberType::class,
+                'label' => Translator::getInstance()->trans('Product price including taxes'),
+                'label_attr' => ['for' => 'price_with_tax_field'],
+                'allow_add' => true,
+                'allow_delete' => true,
+            ])
+            ->add('weight', CollectionType::class, [
+                'entry_type' => NumberType::class,
+                'label' => Translator::getInstance()->trans('Weight'),
+                'label_attr' => ['for' => 'weight_field'],
+                'allow_add' => true,
+                'allow_delete' => true,
+            ])
+            ->add('quantity', CollectionType::class, [
+                'entry_type' => NumberType::class,
+                'label' => Translator::getInstance()->trans('Available quantity *'),
+                'label_attr' => ['for' => 'quantity_field'],
+                'allow_add' => true,
+                'allow_delete' => true,
+                'entry_options' => [
+                    'constraints' => [new NotBlank()],
+                ],
+            ])
+            ->add(
+                'visible',
+                CheckboxType::class,
+                [
+                    'constraints' => [],
+                    'required' => false,
+                ],
+            )
+            ->add('sale_price', CollectionType::class, [
+                'label' => Translator::getInstance()->trans('Sale price excluding taxes'),
+                'label_attr' => ['for' => 'price_with_tax_field'],
+                'allow_add' => true,
+                'allow_delete' => true,
+            ])
+            ->add('sale_price_with_tax', CollectionType::class, [
+                'entry_type' => NumberType::class,
+                'label' => Translator::getInstance()->trans('Sale price including taxes'),
+                'label_attr' => ['for' => 'sale_price_with_tax_field'],
+                'allow_add' => true,
+                'allow_delete' => true,
+            ])
+            ->add('onsale', CollectionType::class, [
+                'entry_type' => IntegerType::class,
+                'label' => Translator::getInstance()->trans('This product is on sale'),
+                'label_attr' => ['for' => 'onsale_field'],
+                'allow_add' => true,
+                'allow_delete' => true,
+            ])
+            ->add('isnew', CollectionType::class, [
+                'entry_type' => IntegerType::class,
+                'label' => Translator::getInstance()->trans('Advertise this product as new'),
+                'label_attr' => ['for' => 'isnew_field'],
+                'allow_add' => true,
+                'allow_delete' => true,
+            ])
+            ->add('isdefault', CollectionType::class, [
+                'entry_type' => IntegerType::class,
+                'label' => Translator::getInstance()->trans('Is it the default product sale element ?'),
+                'label_attr' => ['for' => 'isdefault_field'],
+                'allow_add' => true,
+                'allow_delete' => true,
+            ])
+            ->add('ean_code', CollectionType::class, [
+                'entry_type' => TextType::class,
+                'label' => Translator::getInstance()->trans('EAN Code'),
+                'label_attr' => ['for' => 'ean_code_field'],
+                'allow_add' => true,
+                'allow_delete' => true,
+            ]);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_product_sale_element_update_form';
+    }
+}

--- a/Form/ProfileCreationForm.php
+++ b/Form/ProfileCreationForm.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\ProfileQuery;
+
+/**
+ * Class ProfileCreationForm.
+ *
+ * @author Etienne Roudeix <eroudeix@openstudio.fr>
+ */
+class ProfileCreationForm extends BaseForm
+{
+    use StandardDescriptionFieldsTrait;
+
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('locale', TextType::class, [
+                'constraints' => [new NotBlank()],
+            ])
+            ->add('code', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new Callback(
+                        $this->verifyCode(...),
+                    ),
+                ],
+                'label' => Translator::getInstance()->trans('Profile Code'),
+                'label_attr' => ['for' => 'profile_code_fiels'],
+            ]);
+
+        $this->addStandardDescFields(['locale']);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_profile_creation';
+    }
+
+    public function verifyCode($value, ExecutionContextInterface $context): void
+    {
+        /* check unicity */
+        $profile = ProfileQuery::create()
+            ->findOneByCode($value);
+
+        if (null !== $profile) {
+            $context->addViolation(Translator::getInstance()->trans('Profile `code` already exists'));
+        }
+    }
+}

--- a/Form/ProfileModificationForm.php
+++ b/Form/ProfileModificationForm.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\ProfileQuery;
+
+/**
+ * Class ProfileModificationForm.
+ *
+ * @author Etienne Roudeix <eroudeix@openstudio.fr>
+ */
+class ProfileModificationForm extends ProfileCreationForm
+{
+    protected function buildForm(): void
+    {
+        parent::buildForm();
+
+        $this->formBuilder
+            ->add('id', HiddenType::class, [
+                'required' => true,
+                'constraints' => [
+                    new NotBlank(),
+                    new Callback($this->verifyProfileId(...)),
+                ],
+            ]);
+
+        $this->formBuilder->remove('code');
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_profile_modification';
+    }
+
+    public function verifyProfileId($value, ExecutionContextInterface $context): void
+    {
+        $profile = ProfileQuery::create()
+            ->findPk($value);
+
+        if (null === $profile) {
+            $context->addViolation(Translator::getInstance()->trans('Profile ID not found'));
+        }
+    }
+}

--- a/Form/ProfileUpdateModuleAccessForm.php
+++ b/Form/ProfileUpdateModuleAccessForm.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\ModuleQuery;
+use Thelia\Model\ProfileQuery;
+
+/**
+ * Class ProfileUpdateModuleAccessForm.
+ *
+ * @author Etienne Roudeix <eroudeix@openstudio.fr>
+ */
+class ProfileUpdateModuleAccessForm extends BaseForm
+{
+    public const MODULE_ACCESS_FIELD_PREFIX = 'module';
+
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('id', HiddenType::class, [
+                'required' => true,
+                'constraints' => [
+                    new NotBlank(),
+                    new Callback(
+                        $this->verifyProfileId(...),
+                    ),
+                ],
+            ]);
+
+        foreach (ModuleQuery::create()->find() as $module) {
+            $this->formBuilder->add(
+                self::MODULE_ACCESS_FIELD_PREFIX.':'.str_replace('.', ':', $module->getCode()),
+                ChoiceType::class,
+                [
+                    'choices' => [
+                        AccessManager::VIEW => AccessManager::VIEW,
+                        AccessManager::CREATE => AccessManager::CREATE,
+                        AccessManager::UPDATE => AccessManager::UPDATE,
+                        AccessManager::DELETE => AccessManager::DELETE,
+                    ],
+                    'attr' => [
+                        'tag' => 'modules',
+                        'module_code' => $module->getCode(),
+                    ],
+                    'multiple' => true,
+                    'constraints' => [
+                    ],
+                ],
+            );
+        }
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_profile_module_access_modification';
+    }
+
+    public function verifyProfileId($value, ExecutionContextInterface $context): void
+    {
+        $profile = ProfileQuery::create()
+            ->findPk($value);
+
+        if (null === $profile) {
+            $context->addViolation(Translator::getInstance()->trans('Profile ID not found'));
+        }
+    }
+}

--- a/Form/ProfileUpdateResourceAccessForm.php
+++ b/Form/ProfileUpdateResourceAccessForm.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\ProfileQuery;
+use Thelia\Model\ResourceQuery;
+
+/**
+ * Class ProfileUpdateResourceAccessForm.
+ *
+ * @author Etienne Roudeix <eroudeix@openstudio.fr>
+ */
+class ProfileUpdateResourceAccessForm extends BaseForm
+{
+    public const RESOURCE_ACCESS_FIELD_PREFIX = 'resource';
+
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('id', HiddenType::class, [
+                'required' => true,
+                'constraints' => [
+                    new NotBlank(),
+                    new Callback(
+                        $this->verifyProfileId(...),
+                    ),
+                ],
+            ]);
+
+        foreach (ResourceQuery::create()->find() as $resource) {
+            $this->formBuilder->add(
+                self::RESOURCE_ACCESS_FIELD_PREFIX.':'.str_replace('.', ':', $resource->getCode()),
+                ChoiceType::class,
+                [
+                    'choices' => [
+                        AccessManager::VIEW => AccessManager::VIEW,
+                        AccessManager::CREATE => AccessManager::CREATE,
+                        AccessManager::UPDATE => AccessManager::UPDATE,
+                        AccessManager::DELETE => AccessManager::DELETE,
+                    ],
+                    'attr' => [
+                        'tag' => 'resources',
+                        'resource_code' => $resource->getCode(),
+                    ],
+                    'multiple' => true,
+                    'constraints' => [
+                    ],
+                ],
+            );
+        }
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_profile_resource_access_modification';
+    }
+
+    public function verifyProfileId($value, ExecutionContextInterface $context): void
+    {
+        $profile = ProfileQuery::create()
+            ->findPk($value);
+
+        if (null === $profile) {
+            $context->addViolation(Translator::getInstance()->trans('Profile ID not found'));
+        }
+    }
+}

--- a/Form/Sale/SaleCreationForm.php
+++ b/Form/Sale/SaleCreationForm.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\Sale;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+use Thelia\Form\BaseForm;
+use Thelia\Model\Lang;
+
+/**
+ * Class SaleCreationForm.
+ *
+ * @author  Franck Allimant <franck@cqfdev.fr>
+ */
+class SaleCreationForm extends BaseForm
+{
+    protected function doBuildForm($titleFieldHelpLabel): void
+    {
+        $this->formBuilder->add(
+            'title',
+            TextType::class,
+            [
+                'constraints' => [new NotBlank()],
+                'required' => true,
+                'label' => Translator::getInstance()->trans('Sale title'),
+                'label_attr' => [
+                    'for' => 'title',
+                    'help' => $titleFieldHelpLabel,
+                ],
+                'attr' => [
+                    'placeholder' => Translator::getInstance()->trans('The sale name or descriptive title'),
+                ],
+            ],
+        )
+            ->add(
+                'label',
+                TextType::class,
+                [
+                    'constraints' => [new NotBlank()],
+                    'required' => true,
+                    'label' => Translator::getInstance()->trans('Sale announce label'),
+                    'label_attr' => [
+                        'for' => 'label',
+                        'help' => Translator::getInstance()->trans('The sale announce label, such as Sales ! or Flash Sales !'),
+                    ],
+                    'attr' => [
+                        'placeholder' => Translator::getInstance()->trans('Sale announce label'),
+                    ],
+                ],
+            )
+            ->add(
+                'locale',
+                HiddenType::class,
+                [
+                    'constraints' => [new NotBlank()],
+                    'required' => true,
+                ],
+            );
+    }
+
+    protected function buildForm(): void
+    {
+        $this->doBuildForm(
+            Translator::getInstance()->trans(
+                'Enter here the sale name in the default language (%title%)',
+                ['%title%' => Lang::getDefaultLanguage()->getTitle()],
+            ),
+        );
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_sale_creation';
+    }
+}

--- a/Form/Sale/SaleModificationForm.php
+++ b/Form/Sale/SaleModificationForm.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\Sale;
+
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Type;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Translation\Translator;
+use Thelia\Form\StandardDescriptionFieldsTrait;
+use Thelia\Model\CategoryQuery;
+use Thelia\Model\Sale;
+
+/**
+ * Class SaleModificationForm.phpModificationForm.
+ *
+ * @author  Franck Allimant <franck@cqfdev.fr>
+ */
+class SaleModificationForm extends SaleCreationForm
+{
+    use StandardDescriptionFieldsTrait;
+
+    // The date format for the start and end date
+    public const PHP_DATE_FORMAT = 'Y-m-d H:i:s';
+    public const MOMENT_JS_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
+
+    protected function buildForm(): void
+    {
+        $this->doBuildForm(
+            Translator::getInstance()->trans('The sale name or title'),
+        );
+
+        $this->formBuilder->add(
+            'id',
+            HiddenType::class,
+            [
+                'constraints' => [new GreaterThan(['value' => 0])],
+                'required' => true,
+            ],
+        )
+            ->add(
+                'active',
+                CheckboxType::class,
+                [
+                    'constraints' => [new Type(['type' => 'bool'])],
+                    'required' => false,
+                    'label' => Translator::getInstance()->trans('Activate this sale'),
+                    'label_attr' => [
+                        'for' => 'active',
+                    ],
+                    'attr' => [
+                    ],
+                ],
+            )
+            ->add(
+                'display_initial_price',
+                CheckboxType::class,
+                [
+                    'constraints' => [new Type(['type' => 'bool'])],
+                    'required' => false,
+                    'label' => Translator::getInstance()->trans('Display initial product prices on front-office'),
+                    'label_attr' => [
+                        'for' => 'display_initial_price',
+                    ],
+                    'attr' => [
+                    ],
+                ],
+            )
+            ->add(
+                'start_date',
+                TextType::class,
+                [
+                    'constraints' => [
+                        new Callback([$this, 'checkDate']),
+                    ],
+                    'required' => false,
+                    'label' => Translator::getInstance()->trans('Start date of sales'),
+                    'label_attr' => [
+                        'for' => 'start_date',
+                        'help' => Translator::getInstance()->trans('The date from which sales are active. Please use %fmt format.', ['%fmt' => self::MOMENT_JS_DATE_FORMAT]),
+                    ],
+                    'attr' => [
+                        'data-date-format' => self::MOMENT_JS_DATE_FORMAT,
+                    ],
+                ],
+            )
+            ->add(
+                'end_date',
+                TextType::class,
+                [
+                    'constraints' => [
+                        new Callback([$this, 'checkDate']),
+                    ],
+                    'required' => false,
+                    'label' => Translator::getInstance()->trans('End date of sales'),
+                    'label_attr' => [
+                        'for' => 'end_date',
+                        'help' => Translator::getInstance()->trans('The date after which sales are de-activated. Please use %fmt format.', ['%fmt' => self::MOMENT_JS_DATE_FORMAT]),
+                    ],
+                    'attr' => [
+                        'data-date-format' => self::MOMENT_JS_DATE_FORMAT,
+                    ],
+                ],
+            )
+            ->add(
+                'price_offset_type',
+                ChoiceType::class,
+                [
+                    'constraints' => [new NotBlank()],
+                    'choices' => [
+                        Translator::getInstance()->trans('Constant amount') => Sale::OFFSET_TYPE_AMOUNT,
+                        Translator::getInstance()->trans('Percentage') => Sale::OFFSET_TYPE_PERCENTAGE,
+                    ],
+                    'required' => true,
+                    'label' => Translator::getInstance()->trans('Discount type'),
+                    'label_attr' => [
+                        'for' => 'price_offset_type',
+                        'help' => Translator::getInstance()->trans('Select the discount type that will be applied to original product prices'),
+                    ],
+                    'attr' => [
+                    ],
+                ],
+            )
+            ->add(
+                'price_offset',
+                CollectionType::class,
+                [
+                    'entry_type' => NumberType::class,
+                    'required' => true,
+                    'allow_add' => true,
+                    'allow_delete' => true,
+                    'entry_options' => [
+                        'constraints' => [new NotBlank()],
+                    ],
+
+                    'label' => Translator::getInstance()->trans('Product price offset for each currency'),
+                    'label_attr' => [
+                        'for' => 'price_offset',
+                    ],
+                ],
+            )
+            ->add(
+                'categories',
+                ChoiceType::class,
+                [
+                    'required' => true,
+                    'multiple' => true,
+                    'choices' => $this->getCategoriesIdArray(),
+                    'label' => Translator::getInstance()->trans('Product categories'),
+                    'label_attr' => [
+                        'for' => 'categories',
+                        'help' => Translator::getInstance()->trans('Select the categories of the products covered by this operation'),
+                    ],
+                    'attr' => [
+                        'size' => 10,
+                    ],
+                ],
+            )
+            ->add(
+                'products',
+                CollectionType::class,
+                [
+                    'entry_type' => IntegerType::class,
+                    'required' => false,
+                    'allow_add' => true,
+                    'allow_delete' => true,
+                    'label' => Translator::getInstance()->trans('Products'),
+                    'label_attr' => [
+                        'for' => 'products',
+                        'help' => Translator::getInstance()->trans('Select the products covered by this operation'),
+                    ],
+                    'attr' => [
+                    ],
+                ],
+            )
+            ->add(
+                'product_attributes',
+                CollectionType::class,
+                [
+                    'entry_type' => TextType::class,
+                    'required' => false,
+                    'allow_add' => true,
+                    'allow_delete' => true,
+                    'label' => Translator::getInstance()->trans('Product attributes'),
+                    'label_attr' => [
+                        'for' => 'product_attributes',
+                        'help' => Translator::getInstance()->trans('Select the product attributes included in this operation'),
+                    ],
+                    'attr' => [
+                    ],
+                ],
+            );
+        // Add standard description fields, excluding title and locale, which are already defined
+        $this->addStandardDescFields(['title', 'locale']);
+    }
+
+    /**
+     * Validate a date entered with the current edition Language date format.
+     */
+    public function checkDate(?string $value, ExecutionContextInterface $context): void
+    {
+        if (null === $value) {
+            return;
+        }
+        $format = self::PHP_DATE_FORMAT;
+
+        if (!empty($value) && false === \DateTime::createFromFormat($format, $value)) {
+            $context->addViolation(Translator::getInstance()->trans("Date '%date' is invalid, please enter a valid date using %fmt format", [
+                '%fmt' => self::MOMENT_JS_DATE_FORMAT,
+                '%date' => $value,
+            ]));
+        }
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_sale_modification';
+    }
+
+    private function getCategoriesIdArray()
+    {
+        $categories = CategoryQuery::create()
+            ->select('id')
+            ->find()
+            ->toArray();
+
+        $ids = [];
+
+        foreach ($categories as $category) {
+            $ids[$category] = $category;
+        }
+
+        return $ids;
+    }
+}

--- a/Form/ShippingZone/ShippingZoneAddArea.php
+++ b/Form/ShippingZone/ShippingZoneAddArea.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\ShippingZone;
+
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+use Thelia\Form\BaseForm;
+
+/**
+ * Class ShippingZoneAddArea.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class ShippingZoneAddArea extends BaseForm
+{
+    /**
+     * in this function you add all the fields you need for your Form.
+     * Form this you have to call add method on $this->formBuilder attribute :.
+     *
+     * $this->formBuilder->add("name", TextType::class)
+     *   ->add("email", EmailType::class, array(
+     *           "attr" => array(
+     *               "class" => "field"
+     *           ),
+     *           "label" => "email",
+     *           "constraints" => array(
+     *               new \Symfony\Component\Validator\Constraints\NotBlank()
+     *           )
+     *       )
+     *   )
+     *   ->add('age', IntegerType::class);
+     */
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('area_id', IntegerType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new GreaterThan(['value' => 0]),
+                ],
+                'label_attr' => ['for' => 'shipping_area'],
+                'label' => Translator::getInstance()->trans('Available shipping zones'),
+            ])
+            ->add('shipping_zone_id', IntegerType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new GreaterThan(['value' => 0]),
+                ],
+            ]);
+    }
+
+    /**
+     * @return string the name of you form. This name must be unique
+     */
+    public static function getName(): string
+    {
+        return 'thelia_shippingzone_area';
+    }
+}

--- a/Form/ShippingZone/ShippingZoneRemoveArea.php
+++ b/Form/ShippingZone/ShippingZoneRemoveArea.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\ShippingZone;
+
+/**
+ * Class ShippingZoneRemoveArea.
+ *
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class ShippingZoneRemoveArea extends ShippingZoneAddArea
+{
+    /**
+     * @return string the name of you form. This name must be unique
+     */
+    public static function getName(): string
+    {
+        return 'thelia_shippingzone_remove_area';
+    }
+}

--- a/Form/State/StateCreationForm.php
+++ b/Form/State/StateCreationForm.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\State;
+
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Form\Type\Field\CountryIdType;
+use Thelia\Form\BaseForm;
+
+/**
+ * Class StateCreationForm.
+ *
+ * @author Julien Chanséaume <julien@thelia.net>
+ */
+class StateCreationForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add(
+                'title',
+                TextType::class,
+                [
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                    'label' => $this->translator->trans('State title'),
+                ],
+            )
+            ->add('country_id', CountryIdType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'label' => $this->translator->trans('Country'),
+                'label_attr' => [
+                    'for' => 'country',
+                ],
+            ])
+            ->add(
+                'locale',
+                HiddenType::class,
+                [
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                ],
+            )
+            ->add(
+                'visible',
+                CheckboxType::class,
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans('This state is online'),
+                    'label_attr' => [
+                        'for' => 'visible_create',
+                    ],
+                ],
+            )
+            ->add(
+                'isocode',
+                TextType::class,
+                [
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                    'label' => $this->translator->trans('ISO Code'),
+                    'label_attr' => [
+                        'help' => $this->translator->trans('Iso code for states. It depends of the country.'),
+                    ],
+                ],
+            );
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_state_creation';
+    }
+}

--- a/Form/State/StateModificationForm.php
+++ b/Form/State/StateModificationForm.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form\State;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+use Thelia\Form\StandardDescriptionFieldsTrait;
+
+/**
+ * Class StateModificationForm.
+ *
+ * @author Julien Chanséaume <julien@thelia.net>
+ */
+class StateModificationForm extends StateCreationForm
+{
+    use StandardDescriptionFieldsTrait;
+
+    protected function buildForm(): void
+    {
+        parent::buildForm();
+
+        $this->formBuilder
+            ->add('id', HiddenType::class, ['constraints' => [new GreaterThan(['value' => 0])]]);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_state_modification';
+    }
+}

--- a/Form/SystemLogConfigurationForm.php
+++ b/Form/SystemLogConfigurationForm.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+use Thelia\Log\Tlog;
+
+class SystemLogConfigurationForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('level', ChoiceType::class, [
+                'choices' => [
+                    Translator::getInstance()->trans('Disabled') => Tlog::MUET,
+                    Translator::getInstance()->trans('Debug') => Tlog::DEBUG,
+                    Translator::getInstance()->trans('Information') => Tlog::INFO,
+                    Translator::getInstance()->trans('Notices') => Tlog::NOTICE,
+                    Translator::getInstance()->trans('Warnings') => Tlog::WARNING,
+                    Translator::getInstance()->trans('Errors') => Tlog::ERROR,
+                    Translator::getInstance()->trans('Critical') => Tlog::CRITICAL,
+                    Translator::getInstance()->trans('Alerts') => Tlog::ALERT,
+                    Translator::getInstance()->trans('Emergency') => Tlog::EMERGENCY,
+                ],
+
+                'label' => Translator::getInstance()->trans('Log level *'),
+                'label_attr' => [
+                    'for' => 'level_field',
+                ],
+            ])
+            ->add('format', TextType::class, [
+                'label' => Translator::getInstance()->trans('Log format *'),
+                'label_attr' => [
+                    'for' => 'format_field',
+                ],
+            ])
+            ->add('show_redirections', ChoiceType::class, [
+                'choices' => [
+                    'Yes' => 1,
+                    'No' => 0,
+                ],
+                'constraints' => [new NotBlank()],
+                'label' => Translator::getInstance()->trans('Show redirections *'),
+                'label_attr' => [
+                    'for' => 'show_redirections_field',
+                ],
+            ])
+            ->add('files', TextType::class, [
+                'label' => Translator::getInstance()->trans('Activate logs only for these files'),
+                'label_attr' => [
+                    'for' => 'files_field',
+                ],
+            ])
+            ->add('ip_addresses', TextType::class, [
+                'label' => Translator::getInstance()->trans('Activate logs only for these IP Addresses'),
+                'label_attr' => [
+                    'for' => 'files_field',
+                ],
+            ]);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_system_log_configuration';
+    }
+}

--- a/Form/TaxCreationForm.php
+++ b/Form/TaxCreationForm.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Translation\Translator;
+use Thelia\Domain\Taxation\TaxEngine\TaxTypeRequirementDefinition;
+use Thelia\Model\Tax;
+use Thelia\Type\TypeInterface;
+
+/**
+ * Class TaxCreationForm.
+ *
+ * @author Etienne Roudeix <eroudeix@openstudio.fr>
+ */
+class TaxCreationForm extends BaseForm
+{
+    use StandardDescriptionFieldsTrait;
+
+    public function __construct(
+        #[AutowireIterator('thelia.taxType')]
+        private iterable $taxTypeIterator,
+    ) {
+    }
+
+    protected static $typeList = [];
+
+    protected function buildForm(): void
+    {
+        $typeList = [];
+        $requirementList = [];
+
+        foreach ($this->taxTypeIterator as $taxType) {
+            $typeList[$taxType->getTitle()] = Tax::escapeTypeName($taxType::class);
+            $requirementList[$taxType::class] = $taxType->getRequirementsDefinition();
+        }
+
+        $this->formBuilder
+            ->add(
+                'locale',
+                HiddenType::class,
+                [
+                    'constraints' => [new NotBlank()],
+                ],
+            )
+            ->add(
+                'type',
+                ChoiceType::class,
+                [
+                    'choices' => $typeList,
+                    'required' => true,
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                    'label' => Translator::getInstance()->trans('Type'),
+                    'label_attr' => ['for' => 'type_field'],
+                ],
+            );
+
+        foreach ($requirementList as $name => $requirements) {
+            /** @var TaxTypeRequirementDefinition $requirement */
+            foreach ($requirements as $requirement) {
+                if (!isset(self::$typeList[$requirement->getName()])) {
+                    self::$typeList[$requirement->getName()] = $requirement->getType();
+                }
+
+                $options = array_merge(
+                    [
+                        'constraints' => [
+                            new Callback($this->checkRequirementField(...)),
+                        ],
+                        'attr' => [
+                            'tag' => 'requirements',
+                            'tax_type' => Tax::escapeTypeName($name),
+                        ],
+                        'label_attr' => [
+                            'type' => $requirement->getName(),
+                        ],
+                        'label' => Translator::getInstance()->trans($requirement->getTitle()),
+                    ],
+                    $requirement->getType()->getFormOptions(),
+                );
+
+                $this->formBuilder
+                    // Replace the '\' in the class name by hyphens
+                    // See TaxController::getRequirements if some changes are made about this.
+                    ->add(
+                        Tax::escapeTypeName($name).':'.$requirement->getName(),
+                        $requirement->getType()->getFormType(),
+                        $options,
+                    );
+            }
+        }
+
+        $this->addStandardDescFields(['postscriptum', 'chapo', 'locale']);
+    }
+
+    public function checkRequirementField($value, ExecutionContextInterface $context): void
+    {
+        $data = $context->getRoot()->getData();
+        $type = $data['type'];
+
+        if (str_contains($context->getPropertyPath(), (string) $type)) {
+            // extract requirement type
+            if (preg_match('@\:(.+)\]@', $context->getPropertyPath(), $matches)) {
+                $requirementType = $matches[1];
+
+                if (isset(self::$typeList[$requirementType])) {
+                    /** @var TypeInterface $typeClass */
+                    $typeClass = self::$typeList[$requirementType];
+                    $typeClass->verifyForm($value, $context);
+
+                    return;
+                }
+            }
+
+            $context->addViolation(
+                Translator::getInstance()->trans(
+                    'Impossible to check value `%value` for `%type` type',
+                    [
+                        '%value' => $value,
+                        '%type' => $type,
+                    ],
+                ),
+            );
+        }
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_tax_creation';
+    }
+}

--- a/Form/TaxModificationForm.php
+++ b/Form/TaxModificationForm.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Model\TaxQuery;
+
+/**
+ * Class TaxModificationForm.
+ *
+ * @author Etienne Roudeix <eroudeix@openstudio.fr>
+ */
+class TaxModificationForm extends TaxCreationForm
+{
+    protected function buildForm(): void
+    {
+        parent::buildForm();
+
+        $this->formBuilder
+            ->add('id', HiddenType::class, [
+                'required' => true,
+                'constraints' => [
+                    new NotBlank(),
+                    new Callback(
+                        $this->verifyTaxId(...),
+                    ),
+                ],
+            ]);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_tax_modification';
+    }
+
+    public function verifyTaxId($value, ExecutionContextInterface $context): void
+    {
+        $tax = TaxQuery::create()
+            ->findPk($value);
+
+        if (null === $tax) {
+            $context->addViolation('Tax ID not found');
+        }
+    }
+}

--- a/Form/TaxRuleCreationForm.php
+++ b/Form/TaxRuleCreationForm.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class TaxRuleCreationForm extends BaseForm
+{
+    use StandardDescriptionFieldsTrait;
+
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add('locale', HiddenType::class, [
+                'constraints' => [new NotBlank()],
+            ]);
+
+        $this->addStandardDescFields(['postscriptum', 'chapo', 'locale']);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_tax_rule_creation';
+    }
+}

--- a/Form/TaxRuleModificationForm.php
+++ b/Form/TaxRuleModificationForm.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\TaxRuleQuery;
+
+class TaxRuleModificationForm extends TaxRuleCreationForm
+{
+    protected function buildForm(): void
+    {
+        parent::buildForm();
+
+        $this->formBuilder
+            ->add('id', HiddenType::class, [
+                'required' => true,
+                'constraints' => [
+                    new NotBlank(),
+                    new Callback(
+                        $this->verifyTaxRuleId(...),
+                    ),
+                ],
+            ]);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_tax_rule_modification';
+    }
+
+    public function verifyTaxRuleId($value, ExecutionContextInterface $context): void
+    {
+        $taxRule = TaxRuleQuery::create()
+            ->findPk($value);
+
+        if (null === $taxRule) {
+            $context->addViolation(Translator::getInstance()->trans('Tax rule ID not found'));
+        }
+    }
+}

--- a/Form/TaxRuleTaxListUpdateForm.php
+++ b/Form/TaxRuleTaxListUpdateForm.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\Base\CountryQuery;
+use Thelia\Model\StateQuery;
+use Thelia\Model\TaxQuery;
+use Thelia\Model\TaxRuleQuery;
+use Thelia\Type\JsonType;
+
+class TaxRuleTaxListUpdateForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add(
+                'id',
+                HiddenType::class,
+                [
+                    'required' => true,
+                    'constraints' => [
+                        new NotBlank(),
+                        new Callback(
+                            $this->verifyTaxRuleId(...),
+                        ),
+                    ],
+                ],
+            )
+            ->add(
+                'tax_list',
+                HiddenType::class,
+                [
+                    'required' => true,
+                    'attr' => [
+                        'id' => 'tax_list',
+                    ],
+                    'constraints' => [
+                        new Callback(
+                            $this->verifyTaxList(...),
+                        ),
+                    ],
+                ],
+            )
+            ->add(
+                'country_list',
+                HiddenType::class,
+                [
+                    'required' => true,
+                    'attr' => [
+                        'id' => 'country_list',
+                    ],
+                    'constraints' => [
+                        new Callback(
+                            $this->verifyCountryList(...),
+                        ),
+                    ],
+                ],
+            )
+            ->add(
+                'country_deleted_list',
+                HiddenType::class,
+                [
+                    'required' => true,
+                    'attr' => [
+                        'id' => 'country_deleted_list',
+                    ],
+                    'constraints' => [
+                        new Callback(
+                            $this->verifyCountryList(...),
+                        ),
+                    ],
+                ],
+            );
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_tax_rule_taxlistupdate';
+    }
+
+    public function verifyTaxRuleId($value, ExecutionContextInterface $context): void
+    {
+        $taxRule = TaxRuleQuery::create()
+            ->findPk($value);
+
+        if (null === $taxRule) {
+            $context->addViolation(Translator::getInstance()->trans('Tax rule ID not found'));
+        }
+    }
+
+    public function verifyTaxList($value, ExecutionContextInterface $context): void
+    {
+        $jsonType = new JsonType();
+
+        if (!$jsonType->isValid($value)) {
+            $context->addViolation(Translator::getInstance()->trans('Tax list is not valid JSON'));
+        }
+
+        $taxList = json_decode((string) $value, true);
+
+        /* check we have 2 level max */
+
+        foreach ($taxList as $taxLevel1) {
+            if (\is_array($taxLevel1)) {
+                foreach ($taxLevel1 as $taxLevel2) {
+                    if (\is_array($taxLevel2)) {
+                        $context->addViolation(Translator::getInstance()->trans('Bad tax list JSON'));
+                    } else {
+                        $taxModel = TaxQuery::create()->findPk($taxLevel2);
+
+                        if (null === $taxModel) {
+                            $context->addViolation(Translator::getInstance()
+                                ->trans('Tax ID not found in tax list JSON'));
+                        }
+                    }
+                }
+            } else {
+                $taxModel = TaxQuery::create()->findPk($taxLevel1);
+
+                if (null === $taxModel) {
+                    $context->addViolation(Translator::getInstance()->trans('Tax ID not found in tax list JSON'));
+                }
+            }
+        }
+    }
+
+    public function verifyCountryList($value, ExecutionContextInterface $context): void
+    {
+        $jsonType = new JsonType();
+
+        if (!$jsonType->isValid($value)) {
+            $context->addViolation(Translator::getInstance()->trans('Country list is not valid JSON'));
+        }
+
+        $countryList = json_decode((string) $value, true);
+
+        foreach ($countryList as $countryItem) {
+            if (\is_array($countryItem)) {
+                $country = CountryQuery::create()->findPk($countryItem[0]);
+
+                if (null === $country) {
+                    $context->addViolation(
+                        Translator::getInstance()->trans(
+                            'Country ID %id not found',
+                            ['%id' => $countryItem[0]],
+                        ),
+                    );
+                }
+
+                if ('0' === $countryItem[1]) {
+                    continue;
+                }
+
+                $state = StateQuery::create()->findPk($countryItem[1]);
+
+                if (null === $state) {
+                    $context->addViolation(
+                        Translator::getInstance()->trans(
+                            'State ID %id not found',
+                            ['%id' => $countryItem[1]],
+                        ),
+                    );
+                }
+            } else {
+                $context->addViolation(Translator::getInstance()->trans('Wrong country definition'));
+            }
+        }
+    }
+}

--- a/Form/TemplateCreationForm.php
+++ b/Form/TemplateCreationForm.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+
+class TemplateCreationForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder
+            ->add(
+                'name',
+                TextType::class,
+                [
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                    'label' => Translator::getInstance()->trans('Template Name *'),
+                    'label_attr' => [
+                        'for' => 'name',
+                    ], ],
+            )
+            ->add(
+                'locale',
+                TextType::class,
+                [
+                    'constraints' => [
+                        new NotBlank(),
+                    ], ],
+            );
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_template_creation';
+    }
+}

--- a/Form/TemplateModificationForm.php
+++ b/Form/TemplateModificationForm.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+
+class TemplateModificationForm extends TemplateCreationForm
+{
+    use StandardDescriptionFieldsTrait;
+
+    protected function buildForm(): void
+    {
+        parent::buildForm();
+
+        $this->formBuilder
+            ->add('id', HiddenType::class, [
+                'constraints' => [
+                    new GreaterThan(
+                        ['value' => 0],
+                    ),
+                ],
+            ]);
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_template_modification';
+    }
+}

--- a/Form/TranslationsCustomerTitleForm.php
+++ b/Form/TranslationsCustomerTitleForm.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\CustomerTitleQuery;
+
+class TranslationsCustomerTitleForm extends BaseForm
+{
+    protected function buildForm(): void
+    {
+        $this->formBuilder->add('locale', TextType::class, [
+            'required' => true,
+            'constraints' => [
+                new NotBlank(),
+            ],
+        ]);
+
+        $allTitle = CustomerTitleQuery::create()->find();
+
+        foreach ($allTitle as $aTitle) {
+            $id = $aTitle->getId();
+            $this->formBuilder
+                ->add('title_id_'.$id, HiddenType::class, [
+                    'required' => true,
+                    'constraints' => [
+                        new GreaterThan(['value' => 0]),
+                    ],
+                    'data' => $id,
+                ])
+                ->add('short_title_'.$id, TextType::class, [
+                    'label' => Translator::getInstance()->trans('Change short title for'),
+                    'required' => true,
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                ])
+                ->add('long_title_'.$id, TextType::class, [
+                    'label' => Translator::getInstance()->trans('Change long title for'),
+                    'required' => true,
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                ]);
+        }
+    }
+
+    public static function getName(): string
+    {
+        return 'thelia_translation_customer_title';
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,74 @@
+# thelia/backoffice-default-template
+
+Smarty-based back-office template for Thelia 3 — historically named "default".
+This package ships both the Smarty templates (`*.html`, `*.tpl`, hooks, assets) and
+the PHP back-office bundle that hosts the legacy admin controllers, forms, routing
+and form registry.
+
+## What this package provides
+
+```
+templates/backOffice/default/
+├── BackOfficeDefaultBundle.php           Symfony bundle entry point
+├── Routing/                              Custom route loader (#[Route] scanning)
+├── DependencyInjection/Compiler/         CompilerPass merging admin forms
+├── Controller/Admin/                     46 legacy admin controllers (Thelia\Controller\Admin\*)
+├── Form/                                 100+ admin forms (Thelia\Form\*)
+├── Config/Resources/
+│   ├── routing/admin.xml                 334 legacy /admin/* routes
+│   └── parameters/forms_admin.php        119 admin form registry entries
+├── *.html, *.tpl, admin-layout.tpl, …    Smarty templates
+├── assets/, components/, I18n/, …
+```
+
+## Why these PHP classes live here
+
+Before this extraction (cf. PLAN.md), the admin controllers and forms lived in
+`core/lib/Thelia/Controller/Admin/` and `core/lib/Thelia/Form/`. Moving them
+to the back-office template package decouples the core from the legacy Smarty
+admin layer while preserving full compatibility with third-party modules
+(the namespaces `Thelia\Controller\Admin\*` and `Thelia\Form\*` are kept
+intact via Composer PSR-4 path mapping; cf. `AUDIT_RESULTS.md` for the impact
+audit on the top-30 third-party modules).
+
+## Activation
+
+The bundle activates automatically when:
+
+1. The package is installed (`composer require thelia/backoffice-default-template`).
+2. The bundle is registered in `config/bundles.php` (handled by the Flex recipe
+   in `thelia/thelia-recipes`).
+3. The application's `config/routes.yaml` imports the bundle's attribute routes:
+   ```yaml
+   bo_default_admin_attributes:
+       resource: .
+       type: bo_default_attribute
+   ```
+   This entry is also installed by the Flex recipe.
+
+The admin form registry (`Thelia.parser.forms`) is merged with the bundle's
+admin entries **only when `active-admin-template` equals `default`** (DB config).
+This means third-party admin templates (e.g. `default-twig`) can coexist
+without registry collision.
+
+## Compatibility
+
+- The `Thelia\Form\BaseForm`, `FormInterface`, `EmptyForm`, `Exception\`,
+  `Definition\AdminForm`, `Definition\FrontForm`, `Image\` and all front forms
+  remain in the core, since 87 % of third-party modules inherit `BaseForm` and
+  the Selection module inherits `Form\Image\ImageModification`.
+- The `Thelia\Controller\Admin\BaseAdminController`, `AbstractCrudController`,
+  `AbstractSeoCrudController`, `AdminController` remain in the core for the
+  same reason (~80 % of modules inherit from one of them, and `AdminController`
+  is inherited by BetterSeo, ColissimoLabel, SEOne).
+
+## Maintenance
+
+- Adding or removing an admin form: update `Config/Resources/parameters/forms_admin.php`.
+- Adding or removing an admin route: update `Config/Resources/routing/admin.xml`
+  or use `#[Route]` on the controller and let
+  `BackOfficeDefaultAttributeLoader` pick it up.
+- Adding or removing an admin controller: drop the file in `Controller/Admin/`
+  (PSR-4 will pick it up via `Thelia\Controller\Admin\*` mapping).
+
+PHPStan and php-cs-fixer scan this directory like any other PHP source.

--- a/Routing/BackOfficeDefaultAttributeLoader.php
+++ b/Routing/BackOfficeDefaultAttributeLoader.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackOfficeDefaultBundle\Routing;
+
+use Symfony\Bundle\FrameworkBundle\Routing\AttributeRouteControllerLoader;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Loader\Loader;
+use Symfony\Component\Routing\Loader\AttributeDirectoryLoader;
+use Symfony\Component\Routing\RouteCollection;
+
+final class BackOfficeDefaultAttributeLoader extends Loader
+{
+    public const ROUTE_TYPE = 'bo_default_attribute';
+
+    private bool $isLoaded = false;
+
+    public function load(mixed $resource, ?string $type = null): RouteCollection
+    {
+        if ($this->isLoaded) {
+            throw new \RuntimeException(\sprintf('Do not add the "%s" loader twice.', self::ROUTE_TYPE));
+        }
+
+        $routes = new RouteCollection();
+        $controllerPath = \dirname(__DIR__).\DIRECTORY_SEPARATOR.'Controller';
+
+        if (is_dir($controllerPath)) {
+            $loader = new AttributeDirectoryLoader(new FileLocator(), new AttributeRouteControllerLoader($this->env));
+            $loaded = $loader->load($controllerPath, 'attribute');
+
+            if ($loaded instanceof RouteCollection) {
+                $routes->addCollection($loaded);
+            }
+        }
+
+        $this->isLoaded = true;
+
+        return $routes;
+    }
+
+    public function supports(mixed $resource, ?string $type = null): bool
+    {
+        return self::ROUTE_TYPE === $type;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,8 @@
     "name": "thelia/backoffice-default-template",
     "type": "thelia-backoffice-template",
     "require": {
+        "php": ">=8.3",
+        "symfony/framework-bundle": "^7.4",
         "thelia/smarty-module": "dev-twig",
         "thelia/hook-admin-home-module": "dev-twig",
         "thelia/tinymce-module": "dev-twig",
@@ -10,6 +12,13 @@
         "thelia/custom-delivery-module": "dev-twig",
         "thelia/cheque-module": "dev-twig",
         "thelia/free-order-module": "dev-twig"
+    },
+    "autoload": {
+        "psr-4": {
+            "BackOfficeDefaultBundle\\": "",
+            "Thelia\\Controller\\Admin\\": "Controller/Admin/",
+            "Thelia\\Form\\": "Form/"
+        }
     },
     "extra": {
         "installer-name": "default"


### PR DESCRIPTION
Receive the admin layer extracted from thelia/thelia core/lib/Thelia (cf. PLAN.md in thelia/thelia .claude/plans/bo-default-extraction/):

- BackOfficeDefaultBundle.php at root + composer.json autoload PSR-4 mappings for BackOfficeDefaultBundle\\, Thelia\\Controller\\Admin\\ and Thelia\\Form\\.
- 46 admin controllers under Thelia\\Controller\\Admin\\ namespace (kept intact for third-party module compatibility).
- 100+ admin forms under Thelia\\Form\\ namespace.
- Config/Resources/routing/admin.xml: 334 legacy admin routes.
- Config/Resources/parameters/forms_admin.php: 119 admin form registry entries merged into Thelia.parser.forms via a CompilerPass when the back-office template "default" is active.
- Routing/BackOfficeDefaultAttributeLoader: scans Controller/Admin for #[Route] attributes (exposed under type "bo_default_attribute" for config/routes.yaml).
- DependencyInjection/Compiler/RegisterAdminFormsPass: conditional merge of admin forms into the parser forms registry.

Requires PHP >= 8.3, symfony/framework-bundle ^7.4.