### PR TITLE
fix: check the import file against the formats the handlers declare

### DIFF
--- a/Controller/Admin/ImportController.php
+++ b/Controller/Admin/ImportController.php
@@ -18,13 +18,11 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
-use Thelia\Core\Archiver\AbstractArchiver;
 use Thelia\Core\Archiver\ArchiverManager;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Event\UpdatePositionEvent;
 use Thelia\Core\Security\AccessManager;
 use Thelia\Core\Security\Resource\AdminResources;
-use Thelia\Core\Serializer\AbstractSerializer;
 use Thelia\Core\Serializer\SerializerManager;
 use Thelia\Form\Definition\AdminForm;
 use Thelia\Form\Exception\FormValidationException;
@@ -147,20 +145,10 @@ class ImportController extends BaseAdminController
             return $this->pageNotFound();
         }
 
-        $extensions = [];
-        $mimeTypes = [];
-
-        /** @var AbstractSerializer $serializer */
-        foreach ($serializerManager->getSerializers() as $serializer) {
-            $extensions[] = $serializer->getExtension();
-            $mimeTypes[] = $serializer->getMimeType();
-        }
-
-        /** @var AbstractArchiver $archiver */
-        foreach ($archiverManager->getArchivers(true) as $archiver) {
-            $extensions[] = $archiver->getExtension();
-            $mimeTypes[] = $archiver->getMimeType();
-        }
+        // Advertise exactly what the import handlers accept, so that the page and the
+        // constraint enforced by ImportForm cannot drift apart.
+        $extensions = $importHandler->getAcceptedExtensions();
+        $mimeTypes = $importHandler->getAcceptedMimeTypes();
 
         // Render standard view or ajax one
         $templateName = 'import-page';

--- a/Form/ImportForm.php
+++ b/Form/ImportForm.php
@@ -16,8 +16,11 @@ namespace Thelia\Form;
 
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Domain\DataTransfer\ImportHandler;
+use Thelia\Form\Exception\FormValidationException;
 use Thelia\Model\LangQuery;
 
 /**
@@ -27,6 +30,11 @@ use Thelia\Model\LangQuery;
  */
 class ImportForm extends BaseForm
 {
+    public function __construct(
+        private readonly ImportHandler $importHandler,
+    ) {
+    }
+
     protected function buildForm(): void
     {
         $this->formBuilder
@@ -36,6 +44,9 @@ class ImportForm extends BaseForm
                 'required' => true,
                 'constraints' => [
                     new Assert\NotNull(),
+                    new Assert\Callback(
+                        $this->checkFileFormat(...),
+                    ),
                 ],
             ])
             ->add('language', IntegerType::class, [
@@ -56,6 +67,23 @@ class ImportForm extends BaseForm
     public static function getName(): string
     {
         return 'thelia_import';
+    }
+
+    /**
+     * The page advertises the formats the import handlers can read; only a NotNull
+     * used to stand between the request and the import cache directory.
+     */
+    public function checkFileFormat($value, ExecutionContextInterface $context): void
+    {
+        if (!$value instanceof UploadedFile) {
+            return;
+        }
+
+        try {
+            $this->importHandler->validateUpload($value->getClientOriginalName());
+        } catch (FormValidationException $exception) {
+            $context->addViolation($exception->getMessage());
+        }
     }
 
     public function checkLanguage($value, ExecutionContextInterface $context): void


### PR DESCRIPTION
Smarty back office half of https://github.com/thelia/thelia/issues/3592. Depends on the core change https://github.com/thelia/thelia/pull/3597 and must be merged after it.

## Symptom

The import page lists the formats it accepts and then accepts anything: a `.exe`, a shell script, a text file renamed `products.csv.php`. The file is written to `THELIA_CACHE_DIR/import/<date>/` under its original name before any check runs.

## Cause

`Form/ImportForm.php:33-40` carries a single `NotNull` on `file_upload`, so `Controller/Admin/ImportController.php:207-211` moves whatever came in. The extension and mime type lists built at `:150-163` were only used to fill the page (`includes/import-form-body.html:39-40`), so the interface promised a constraint that nothing enforced.

## Fix

`ImportHandler` now derives both the advertised list and the check from the registered serializers and archivers, so nothing here restates a policy of its own:

- `ImportForm` injects the handler and adds a callback constraint calling `validateUpload()`, next to the existing `NotNull`. A refused file produces a field violation and the upload never reaches disk.
- `ImportController::configureAction()` asks the handler for the two lists instead of rebuilding them, so the page and the constraint cannot drift apart.

## How to verify

Back office → Tools → Import → pick any import.

- Upload `payload.exe`: refused with "The extension "exe" is not allowed. Accepted formats: csv, json, xml, yaml, zip, tar, tgz, bz2", and `var/cache/<env>/import/` stays empty.
- Rename a CSV to `products.csv.php` and upload it: refused, where it used to be moved to disk and parsed as CSV.
- Upload a valid `.csv` or a `.zip` containing one: unchanged, the import runs.
